### PR TITLE
Stop emitting literal secret placeholders on sandbox egress (eumemic-ops#331)

### DIFF
--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -557,6 +557,38 @@ SESSION_LABEL_KEY = "aios.session_id"
 # accounting). ``FLATTENED_LABEL_KEY`` marks standalone export|import images
 # that share no layers with the base, so accounting charges them full size.
 ENV_KEYS_LABEL_KEY = "aios.env_keys"
+# ``VAULT_PLACEHOLDER_KEYS_LABEL_KEY`` carries the comma-separated NAMES (never
+# values, never credential ids) of the vault-credential placeholder env vars
+# injected at the provision that produced this container/image — the
+# ``secret_name`` of every active ``environment_variable`` credential bound at
+# that moment (eumemic/eumemic-ops#331).
+#
+# It exists because vault placeholder env vars are **start-time-derived state,
+# never snapshot-persisted state**. ``docker run --env`` overrides a key the
+# CURRENT provision still injects, so a rotated credential (same secret_name,
+# new credential id ⇒ new placeholder) self-heals on resume. The gap it closes
+# is the key that is no longer injected at all: when a credential is ARCHIVED,
+# its ``secret_name`` drops out of the current placeholder set, so no ``--env``
+# overrides it and the resumed container inherits whatever the snapshot baked —
+# a placeholder bound to a dead credential id, which the egress proxy's swap
+# set (built from ACTIVE creds only) can never exchange. Recording the names
+# lets the resume path explicitly neutralize exactly the stale keys, so a
+# resumed sandbox can never inherit a credential env var from its snapshot.
+VAULT_PLACEHOLDER_KEYS_LABEL_KEY = "aios.vault_placeholder_keys"
+
+
+def split_label_list(value: str | None) -> list[str]:
+    """Parse a comma-separated label value (e.g. ``aios.env_keys``) into names.
+
+    Shared by the Docker backend's commit-time env scrub and the registry's
+    resume-time stale-placeholder neutralization so both read the label
+    grammar the same way.
+    """
+    if not value:
+        return []
+    return [item for item in (part.strip() for part in value.split(",")) if item]
+
+
 BASE_IMAGE_LABEL_KEY = "aios.base_image"
 FLATTENED_LABEL_KEY = "aios.flattened"
 FLATTENED_LABEL_VALUE = "true"

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -48,6 +48,7 @@ from aios.sandbox.backends.base import (
     SandboxSnapshotTimeoutError,
     SandboxSpec,
     SnapshotOutcome,
+    split_label_list,
 )
 from aios.sandbox.network import SANDBOX_NETWORK_NAME
 
@@ -1072,11 +1073,9 @@ class DockerBackend:
         return max(0, size - await self._image_size_or_zero(base_ref))
 
 
-def _split_label_list(value: str | None) -> list[str]:
-    """Parse a comma-separated label value (e.g. ``aios.env_keys``) into names."""
-    if not value:
-        return []
-    return [item for item in (part.strip() for part in value.split(",")) if item]
+# Shared with the registry's resume-time placeholder neutralization so the
+# label grammar has exactly one reader.
+_split_label_list = split_label_list
 
 
 def _parse_json_labels(raw: str) -> dict[str, str]:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -49,6 +49,7 @@ from aios.sandbox.backends.base import (
     FLATTENED_LABEL_VALUE,
     PREWARM_LABEL_KEY,
     SESSION_LABEL_KEY,
+    VAULT_PLACEHOLDER_KEYS_LABEL_KEY,
     CommandResult,
     ManagedImage,
     SandboxBackend,
@@ -56,6 +57,7 @@ from aios.sandbox.backends.base import (
     SandboxHandle,
     SandboxSnapshotTimeoutError,
     SandboxSpec,
+    split_label_list,
 )
 from aios.sandbox.git_proxy import GitProxy
 from aios.sandbox.network import WORKER_NETWORK_ALIAS
@@ -1611,7 +1613,65 @@ class SandboxRegistry:
 
         # Valid resume: make the ref locally runnable (identity for v1).
         local_tag = await self._store.get(ref)
-        return dataclasses.replace(spec, snapshot_image=local_tag)
+        return self._neutralize_stale_placeholder_env(
+            dataclasses.replace(spec, snapshot_image=local_tag), snap_labels
+        )
+
+    @staticmethod
+    def _neutralize_stale_placeholder_env(
+        spec: SandboxSpec, snap_labels: dict[str, str]
+    ) -> SandboxSpec:
+        """Ensure a resumed container inherits NO vault placeholder from its snapshot.
+
+        The invariant (eumemic/eumemic-ops#331): a sandbox's vault-credential
+        placeholder env vars are **re-derived from the currently-active
+        credentials on every sandbox start — provision AND snapshot-resume —
+        and are never restored or reused from the snapshot.**
+
+        ``spec.environment`` is already re-derived: ``build_spec_from_session``
+        calls ``resolve_session_env_var_credentials`` against ACTIVE credentials
+        on every provision, and ``docker run --env`` overrides the image's baked
+        ENV. Placeholders are a deterministic function of (salt, owner,
+        credential id), so re-deriving is idempotent — a no-op when the
+        credentials are unchanged, and a self-heal when a credential was
+        RECREATED (same ``secret_name``, new credential id ⇒ new placeholder
+        overriding the old one).
+
+        The residual hole this closes is the credential that was ARCHIVED and
+        not replaced. Its ``secret_name`` is absent from the current
+        placeholder set, so no ``--env`` is emitted for that key and the
+        resumed container silently inherits the value baked into the snapshot
+        by the provision that minted it — a placeholder bound to a dead
+        credential id. The egress proxy builds its swap set from ACTIVE
+        credentials only, so that placeholder can never be exchanged: before
+        the fail-loud fence it rode out to the remote literally and drew a
+        misleading ``401``.
+
+        So: every key the snapshot recorded as a vault placeholder that the
+        CURRENT provision does not re-inject is explicitly set to the empty
+        string. Empty (not merely absent) is required — ``docker run --env
+        K=`` is what actually overrides a baked ``ENV K=<stale>``; omitting the
+        key would let the snapshot's value survive, which is the bug.
+        """
+        recorded = split_label_list(snap_labels.get(VAULT_PLACEHOLDER_KEYS_LABEL_KEY))
+        if not recorded:
+            # No recorded placeholder keys: either a pre-#331 snapshot or a
+            # session that never had credentials. Nothing to neutralize by
+            # name — the current provision's --env still overrides every key it
+            # does inject.
+            return spec
+        stale = sorted(key for key in recorded if key not in spec.environment)
+        if not stale:
+            return spec
+        log.info(
+            "sandbox.stale_placeholder_env_neutralized",
+            owner_id=spec.session_id,
+            # Names only — never a placeholder value or a credential id.
+            secret_names=stale,
+        )
+        return dataclasses.replace(
+            spec, environment={**spec.environment, **dict.fromkeys(stale, "")}
+        )
 
     async def _reset_snapshot(self, session_id: str, *, reason: str) -> None:
         """Clear the snapshot pointer and append a model-visible reset notice."""

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -1665,6 +1665,18 @@ class SandboxRegistry:
         K=`` is what actually overrides a baked ``ENV K=<stale>``; omitting the
         key would let the snapshot's value survive, which is the bug.
 
+        **A PRESENT but EMPTY label is not the same as an ABSENT one.** Every
+        post-#331 provision stamps ``aios.vault_placeholder_keys``, and it
+        stamps the empty string when the sandbox had no vault env credentials
+        to inject. That empty value is EVIDENCE — the snapshot positively
+        recorded that it baked no placeholder — so the correct action is to
+        scrub nothing and resume unchanged. Only an ABSENT label means "unknown
+        provenance" and takes the legacy path below. The branch is therefore on
+        label PRESENCE, not on the parsed list's truthiness: treating
+        present-empty as legacy costs a needless env scrub or, when the snapshot
+        also records no env keys, a COLD START that discards the session's
+        filesystem for a snapshot already proven clean.
+
         **The unlabeled (pre-#331) snapshot.** A snapshot committed before this
         fix carries no ``aios.vault_placeholder_keys`` label at all, so the
         stale-key diff has nothing to diff against. Treating that as "nothing
@@ -1688,9 +1700,29 @@ class SandboxRegistry:
         shipping an unexchangeable credential placeholder to a remote, which is
         neither.
         """
-        recorded = split_label_list(snap_labels.get(VAULT_PLACEHOLDER_KEYS_LABEL_KEY))
-        if not recorded:
+        # Branch on label PRESENCE, never on truthiness. ``split_label_list``
+        # maps BOTH a missing label and a present-but-empty one to ``[]``, but
+        # those are different states with different correct behaviours:
+        #
+        #   * PRESENT-AND-EMPTY — a post-#331 provision stamped the label and
+        #     recorded that it injected NO placeholder keys (a sandbox with no
+        #     active environment_variable credentials). That is a positive,
+        #     verified statement about the snapshot: there is no stale
+        #     placeholder to neutralize, so scrub NOTHING and resume as-is.
+        #   * ABSENT — a pre-#331 snapshot whose provenance is unknown. It may
+        #     have baked a placeholder for a since-archived credential, so it
+        #     takes the legacy handling below.
+        #
+        # Conflating them (``if not recorded``) sent every fully-verifiable
+        # empty-label snapshot down the legacy path: with a non-empty
+        # ``aios.env_keys`` it needlessly EMPTIES baked env the current
+        # provision does not re-inject, and with an empty one it COLD-STARTS —
+        # discarding a user's sandbox filesystem to defend against a stale
+        # placeholder the label already proved is not there. Avoidable
+        # filesystem loss is not a safe default; it is a bug.
+        if VAULT_PLACEHOLDER_KEYS_LABEL_KEY not in snap_labels:
             return SandboxRegistry._neutralize_unlabeled_placeholder_env(spec, snap_labels)
+        recorded = split_label_list(snap_labels[VAULT_PLACEHOLDER_KEYS_LABEL_KEY])
         stale = sorted(key for key in recorded if key not in spec.environment)
         if not stale:
             return spec

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -45,6 +45,7 @@ from aios.ids import is_run_owner_id
 from aios.logging import get_logger
 from aios.sandbox.backends.base import (
     BASE_IMAGE_LABEL_KEY,
+    ENV_KEYS_LABEL_KEY,
     FLATTENED_LABEL_KEY,
     FLATTENED_LABEL_VALUE,
     PREWARM_LABEL_KEY,
@@ -1613,15 +1614,26 @@ class SandboxRegistry:
 
         # Valid resume: make the ref locally runnable (identity for v1).
         local_tag = await self._store.get(ref)
-        return self._neutralize_stale_placeholder_env(
+        resumed = self._neutralize_stale_placeholder_env(
             dataclasses.replace(spec, snapshot_image=local_tag), snap_labels
         )
+        if resumed is None:
+            # Unlabeled snapshot whose stale placeholder keys cannot be
+            # determined: cold-start rather than resume an image that may bake
+            # an unexchangeable placeholder (see the method docstring).
+            await self._reset_snapshot(session_id, reason="unverifiable_placeholder_env")
+            return dataclasses.replace(spec, snapshot_image=None)
+        return resumed
 
     @staticmethod
     def _neutralize_stale_placeholder_env(
         spec: SandboxSpec, snap_labels: dict[str, str]
-    ) -> SandboxSpec:
+    ) -> SandboxSpec | None:
         """Ensure a resumed container inherits NO vault placeholder from its snapshot.
+
+        Returns the resume spec, or ``None`` meaning **do not resume this
+        snapshot** (the caller cold-starts) because its stale placeholder keys
+        cannot be determined.
 
         The invariant (eumemic/eumemic-ops#331): a sandbox's vault-credential
         placeholder env vars are **re-derived from the currently-active
@@ -1652,14 +1664,33 @@ class SandboxRegistry:
         string. Empty (not merely absent) is required — ``docker run --env
         K=`` is what actually overrides a baked ``ENV K=<stale>``; omitting the
         key would let the snapshot's value survive, which is the bug.
+
+        **The unlabeled (pre-#331) snapshot.** A snapshot committed before this
+        fix carries no ``aios.vault_placeholder_keys`` label at all, so the
+        stale-key diff has nothing to diff against. Treating that as "nothing
+        to neutralize" PRESERVES THE ORIGINAL VULNERABILITY for exactly the
+        population that has it: a pre-#331 snapshot is precisely the artifact
+        that could have baked a placeholder for a since-archived credential,
+        and resuming it unchanged re-injects that dead placeholder. Absence of
+        evidence is not evidence of absence, and this is a credential path, so
+        the unlabeled case must not fail open.
+
+        We resolve it WITHOUT needing the label, by scrubbing on SHAPE rather
+        than on name: the image's own baked ENV is inspected
+        (``snap_labels[aios.env_keys]`` records every env key the snapshot
+        carries) and any key whose value the current provision does not
+        re-inject is emptied when it could plausibly hold a placeholder. When
+        the snapshot records no env-key inventory either — nothing to inspect,
+        nothing to scrub, and no way to bound the risk — we return ``None`` and
+        the caller COLD-STARTS. Cold-start is the correct fallback: it costs
+        the session's filesystem state, which is recoverable and visible (an
+        ``fs_reset`` event the model sees), whereas the alternative is silently
+        shipping an unexchangeable credential placeholder to a remote, which is
+        neither.
         """
         recorded = split_label_list(snap_labels.get(VAULT_PLACEHOLDER_KEYS_LABEL_KEY))
         if not recorded:
-            # No recorded placeholder keys: either a pre-#331 snapshot or a
-            # session that never had credentials. Nothing to neutralize by
-            # name — the current provision's --env still overrides every key it
-            # does inject.
-            return spec
+            return SandboxRegistry._neutralize_unlabeled_placeholder_env(spec, snap_labels)
         stale = sorted(key for key in recorded if key not in spec.environment)
         if not stale:
             return spec
@@ -1668,6 +1699,56 @@ class SandboxRegistry:
             owner_id=spec.session_id,
             # Names only — never a placeholder value or a credential id.
             secret_names=stale,
+        )
+        return dataclasses.replace(
+            spec, environment={**spec.environment, **dict.fromkeys(stale, "")}
+        )
+
+    @staticmethod
+    def _neutralize_unlabeled_placeholder_env(
+        spec: SandboxSpec, snap_labels: dict[str, str]
+    ) -> SandboxSpec | None:
+        """Handle a snapshot with no ``aios.vault_placeholder_keys`` label.
+
+        Two sub-cases, both fail-safe:
+
+        * The snapshot DOES record its env-key inventory (``aios.env_keys``,
+          which predates #331 and is stamped by every provision that also bakes
+          ENV). Every recorded key the CURRENT provision does not re-inject is
+          emptied — a superset of the placeholder keys, which is exactly the
+          right side to err on: a baked env var the current provision no longer
+          sets is start-time-derived state the resume must not inherit, and the
+          only keys with a legitimate claim to survive are the ones the current
+          provision re-injects (which it does, by ``--env``). Ordinary
+          operator/session env is unaffected because the current provision
+          still sets it.
+        * The snapshot records NOTHING (a truly opaque pre-#331 artifact, or a
+          non-aios base). ``None`` ⇒ cold start. We cannot enumerate what it
+          baked, so we cannot prove it holds no stale placeholder, so we do not
+          resume it.
+
+        Either way the pre-#331 hole is closed rather than preserved, and the
+        first snapshot this session takes afterwards carries the label — so
+        this path is self-clearing, not a permanent tax.
+        """
+        baked = split_label_list(snap_labels.get(ENV_KEYS_LABEL_KEY))
+        if not baked:
+            log.warning(
+                "sandbox.unlabeled_snapshot_cold_start",
+                owner_id=spec.session_id,
+                # No names to report — the snapshot recorded no inventory. That
+                # IS the reason, and it is why this cold-starts.
+                reason="no_placeholder_or_env_key_label",
+            )
+            return None
+        stale = sorted(key for key in baked if key not in spec.environment)
+        if not stale:
+            return spec
+        log.info(
+            "sandbox.unlabeled_snapshot_env_scrubbed",
+            owner_id=spec.session_id,
+            # Names only — never a value.
+            env_keys=stale,
         )
         return dataclasses.replace(
             spec, environment={**spec.environment, **dict.fromkeys(stale, "")}

--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -238,6 +238,13 @@ _PLACEHOLDER_SUBSTITUTION_FAILED_BODY = (
     b"Note: a placeholder in the URL PATH or QUERY is never substituted (the\n"
     b"request-target is forwarded verbatim), so it is always refused. Send the\n"
     b"credential in a header or the request body instead.\n"
+    b"\n"
+    b"Note: this fence keys on the placeholder SHAPE, and a whole delimited\n"
+    b"placeholder is refused even when it is legitimate payload data (a log\n"
+    b"line, a diff, a config file being uploaded). That false positive is\n"
+    b"deliberate -- an unexchangeable placeholder is indistinguishable from\n"
+    b"one, and guessing wrong transmits a credential-shaped token. Encode or\n"
+    b"redact such content (base64, escaping, masking) to send it.\n"
 )
 
 # Matches the minted placeholder shape: the greppable prefix plus the 32 hex
@@ -254,6 +261,45 @@ _PLACEHOLDER_SUBSTITUTION_FAILED_BODY = (
 # ``[0-9A-Za-z_]`` is the boundary alphabet because the placeholder itself is
 # drawn from it (prefix has ``_``, body is hex); anything else — quote, colon,
 # space, comma, brace, ``/``, end-of-string — is a legitimate delimiter.
+#
+# THE REMAINING FALSE POSITIVE, AND WHY IT STAYS (the deliberate decision on
+# the MEDIUM finding). Boundary anchoring kills the *embedded-window* class (a
+# longer opaque token, prose that merely mentions the prefix). It does NOT and
+# CANNOT kill the *delimited* class: a request whose legitimate payload
+# contains a whole, delimited, placeholder-shaped token — a log line being
+# shipped to an observability API, a diff of a `.env` file, an issue comment
+# quoting one — is refused with 421 even though nothing is wrong with it.
+#
+# We keep that refusal, on purpose:
+#
+#   * The two cases are NOT DISTINGUISHABLE HERE. The scan runs POST-swap on a
+#     request whose provenance is gone: a placeholder that no rule exchanged
+#     and a placeholder-shaped literal the sandbox typed are the same bytes in
+#     the same position. There is no signal left to separate them — not the
+#     header, not the content type, not the position (a real miss can sit in a
+#     JSON body, and legitimate data can sit in ``Authorization``).
+#   * The two errors are NOT SYMMETRIC. Refusing legitimate content costs a
+#     421 with a body that names the cause and the workaround — loud, local,
+#     immediately actionable, and the caller can encode/redact the value.
+#     Forwarding a real miss puts a credential-shaped token on the wire and
+#     draws a 401 that is indistinguishable from a bad secret — the exact
+#     silent, weeks-long misdiagnosis eumemic/eumemic-ops#331 exists to end.
+#     A fence that fails open on ambiguity is not a fence.
+#   * Any narrowing we could write would be a GUESS about intent (allow it in
+#     bodies but not headers? only under some content types? only when it
+#     doesn't look like a credential?), and every such guess is a rule an
+#     attacker — or an unlucky legitimate miss — can land on. Cheap
+#     availability cost, uncapped confidentiality cost: take the availability
+#     cost.
+#   * The false positive is BOUNDED and RARE by construction: it needs a whole
+#     ``AIOS_SECRET_PLACEHOLDER_`` + exactly-32-hex token, delimited, in an
+#     outbound request. That string is minted by this system; it does not occur
+#     in the wild by accident.
+#
+# So this is a fail-closed-on-ambiguity trade, not an oversight, and
+# ``test_legitimate_delimited_placeholder_shaped_payload_is_refused_by_design``
+# pins it AS a trade — naming the cost, asserting the operator gets a
+# self-explaining refusal, and asserting the encoded workaround passes.
 _PLACEHOLDER_BODY = re.escape(SECRET_PLACEHOLDER_PREFIX) + r"[0-9a-f]{32}"
 _PLACEHOLDER_RE = re.compile(r"(?<![0-9A-Za-z_])" + _PLACEHOLDER_BODY + r"(?![0-9A-Za-z_])")
 _PLACEHOLDER_BODY_BYTES = re.escape(SECRET_PLACEHOLDER_PREFIX.encode()) + rb"[0-9a-f]{32}"

--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -76,7 +76,7 @@ from aios.logging import get_logger
 from aios.models.vaults import parse_allowed_host_entry
 from aios.pinned_transport import resolve_pinned_ip
 from aios.sandbox.egress_ca import EgressCA, get_egress_ca, mint_server_leaf
-from aios.services.vaults import ResolvedEnvVarCredential
+from aios.services.vaults import SECRET_PLACEHOLDER_PREFIX, ResolvedEnvVarCredential
 
 log = get_logger("aios.sandbox.secret_egress_proxy")
 
@@ -194,6 +194,80 @@ def _apply_swaps_bytes(data: bytes, swaps: list[tuple[str, str]]) -> bytes:
     for placeholder, secret in swaps:
         data = data.replace(placeholder.encode(), secret.encode())
     return data
+
+
+# ── unexchangeable-placeholder fence (eumemic/eumemic-ops#331) ───────────────
+#
+# A placeholder that survives the swap is a SUBSTITUTION MISS, not a credential
+# the upstream can evaluate: the sandbox holds an opaque stand-in whose real
+# secret this proxy could not supply (an archived/recreated credential id, a
+# snapshot-resumed env carrying a dead placeholder, a host/path gate that
+# excluded the only cred that could have swapped it). Forwarding it emits the
+# LITERAL ``AIOS_SECRET_PLACEHOLDER_…`` string to the remote, which answers
+# ``401 Bad credentials`` — indistinguishable from a genuinely bad secret, and
+# the single reason this class of bug reads as "random intermittent auth
+# failure" for weeks. So we refuse the request HERE with a distinguishable
+# status + machine-readable reason, and never open the upstream connection.
+#
+# 421 Misdirected Request is deliberate: it is not 401 (never conflatable with
+# an upstream credential verdict), not 5xx (this is not an upstream/plumbing
+# outage), and semantically apt — the request was routed to a proxy that
+# cannot serve the credential it carries.
+_PLACEHOLDER_SUBSTITUTION_FAILED_STATUS = 421
+_PLACEHOLDER_SUBSTITUTION_FAILED_HEADER = "x-aios-egress-error"
+_PLACEHOLDER_SUBSTITUTION_FAILED_CODE = "placeholder_substitution_failed"
+_PLACEHOLDER_SUBSTITUTION_FAILED_BODY = (
+    b"aios egress refused this request: placeholder substitution failed.\n"
+    b"\n"
+    b"An AIOS_SECRET_PLACEHOLDER_* token in this request could not be exchanged\n"
+    b"for its vaulted secret, so the request was NOT sent upstream (sending it\n"
+    b"would transmit the literal placeholder and draw a misleading 401).\n"
+    b"\n"
+    b"Cause: the placeholder is not bound to any ACTIVE environment_variable\n"
+    b"credential for this sandbox -- typically a credential that was rotated,\n"
+    b"archived or recreated after this sandbox's environment was materialized\n"
+    b"(placeholders are keyed on credential id), or a credential whose\n"
+    b"allowed_hosts / path prefix do not cover this request.\n"
+    b"\n"
+    b"Fix: re-provision the sandbox so the CURRENT credential's placeholder is\n"
+    b"injected, or widen the credential's allowed_hosts to cover this host.\n"
+)
+
+# Matches the minted placeholder shape: the greppable prefix plus the 32 hex
+# chars ``mint_secret_placeholder`` emits. Anchored on the exact shape (not a
+# bare prefix scan) so an unrelated string that merely mentions the prefix in
+# prose cannot trip the fence.
+_PLACEHOLDER_RE = re.compile(re.escape(SECRET_PLACEHOLDER_PREFIX) + r"[0-9a-f]{32}")
+_PLACEHOLDER_RE_BYTES = re.compile(re.escape(SECRET_PLACEHOLDER_PREFIX.encode()) + rb"[0-9a-f]{32}")
+
+
+def _residual_placeholder(headers: list[tuple[str, str]], body: bytes) -> str | None:
+    """The first unexchanged placeholder left in the post-swap request, if any.
+
+    Runs on the ALREADY-SWAPPED headers and body, so anything it finds is by
+    construction a placeholder no rule in this session's swap set could
+    exchange. ``Authorization: Basic`` values are decoded before the scan for
+    the same reason ``_swap_header_value`` decodes them: base64 shifts byte
+    boundaries, so a placeholder riding inside a Basic credential is not a
+    literal substring of the header and a raw scan would miss the exact case
+    (git-over-HTTPS, ``curl -u``) that motivated this fence.
+
+    Returns the matched placeholder token (safe to log — it IS the opaque
+    stand-in, never the secret) or ``None`` when the request is clean.
+    """
+    for name, value in headers:
+        scanned = value
+        if name.lower() == "authorization":
+            decoded = _decode_basic_credential(value)
+            if decoded is not None:
+                scanned = decoded
+        match = _PLACEHOLDER_RE.search(scanned)
+        if match is not None:
+            return match.group(0)
+    match_bytes = _PLACEHOLDER_RE_BYTES.search(body)
+    if match_bytes is not None:
+        return match_bytes.group(0).decode("ascii")
+    return None
 
 
 def _swap_header_value(name: str, value: str, swaps: list[tuple[str, str]]) -> str:
@@ -489,6 +563,32 @@ class SecretEgressProxy:
 
         fwd_headers = self._forward_headers(request.headers.raw_items(), host, swaps)
         swapped_body = _apply_swaps_bytes(body, swaps)
+
+        # FAIL LOUD on a substitution miss (eumemic/eumemic-ops#331). Anything
+        # still matching the placeholder shape after the swap is a placeholder
+        # this session's swap set could not exchange. Historically it rode out
+        # to the remote verbatim and came back as the upstream's ``401 Bad
+        # credentials`` — an upstream verdict on a credential the upstream
+        # never actually received, which is why a substitution miss was
+        # indistinguishable from a real auth failure. Refuse it here: no
+        # upstream connection is opened, so the literal placeholder is never
+        # transmitted, and the caller gets an error that NAMES the cause.
+        residual = _residual_placeholder(fwd_headers, swapped_body)
+        if residual is not None:
+            log.warning(
+                "secret_egress_proxy.placeholder_substitution_failed",
+                host=host,
+                path=path,
+                # The placeholder is the opaque stand-in, never the secret, so
+                # logging it is safe — and it is the ONLY handle an operator
+                # has to correlate the refusal with the credential id whose
+                # rotation orphaned it.
+                placeholder=residual,
+                swap_rule_count=len(swaps),
+            )
+            await self._send_substitution_failure(conn, writer)
+            return
+
         # The URL carries the request-target verbatim — the placeholder is
         # NEVER swapped in the path/query, only in headers and body.
         url = f"https://{_bracket(pinned)}:{_UPSTREAM_PORT}{target}"
@@ -619,6 +719,38 @@ class SecretEgressProxy:
         writer.write(_h11_send(conn, h11.EndOfMessage()))
         await writer.drain()
 
+    async def _send_substitution_failure(
+        self, conn: h11.Connection, writer: asyncio.StreamWriter
+    ) -> None:
+        """Refuse a request carrying an unexchangeable placeholder.
+
+        Distinguishable from every other outcome on this path by construction:
+        a dedicated status (``421``, never ``401``/``502``) AND a machine-
+        readable ``x-aios-egress-error: placeholder_substitution_failed``
+        header, so a caller can branch on the cause without parsing prose.
+        """
+        body = _PLACEHOLDER_SUBSTITUTION_FAILED_BODY
+        if conn.our_state is not h11.SEND_RESPONSE:
+            return
+        headers = [
+            (b"content-length", str(len(body)).encode()),
+            (b"content-type", b"text/plain; charset=utf-8"),
+            (
+                _PLACEHOLDER_SUBSTITUTION_FAILED_HEADER.encode(),
+                _PLACEHOLDER_SUBSTITUTION_FAILED_CODE.encode(),
+            ),
+            (b"connection", b"close"),
+        ]
+        writer.write(
+            _h11_send(
+                conn,
+                h11.Response(status_code=_PLACEHOLDER_SUBSTITUTION_FAILED_STATUS, headers=headers),
+            )
+        )
+        writer.write(_h11_send(conn, h11.Data(data=body)))
+        writer.write(_h11_send(conn, h11.EndOfMessage()))
+        await writer.drain()
+
     async def _send_simple(
         self, conn: h11.Connection, writer: asyncio.StreamWriter, status: int, body: bytes
     ) -> None:
@@ -631,4 +763,15 @@ class SecretEgressProxy:
         await writer.drain()
 
 
-__all__ = ["SecretEgressProxy"]
+__all__ = [
+    "PLACEHOLDER_SUBSTITUTION_FAILED_CODE",
+    "PLACEHOLDER_SUBSTITUTION_FAILED_HEADER",
+    "PLACEHOLDER_SUBSTITUTION_FAILED_STATUS",
+    "SecretEgressProxy",
+]
+
+# Public aliases for the fence's wire contract, so callers/tests assert against
+# the module's exported names rather than private constants.
+PLACEHOLDER_SUBSTITUTION_FAILED_STATUS = _PLACEHOLDER_SUBSTITUTION_FAILED_STATUS
+PLACEHOLDER_SUBSTITUTION_FAILED_HEADER = _PLACEHOLDER_SUBSTITUTION_FAILED_HEADER
+PLACEHOLDER_SUBSTITUTION_FAILED_CODE = _PLACEHOLDER_SUBSTITUTION_FAILED_CODE

--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -9,9 +9,12 @@ connection (the host comes from the TLS ClientHello SNI), mints a leaf cert
 for that host from the aios egress CA (which every sandbox already trusts,
 #875), reads the request, replaces the opaque per-session placeholder token
 with the real secret as a literal substring **in request headers + body
-only** (never the URL path/query — the URL carries the placeholder
+only** (never the URL path/query — the request-target is forwarded
 verbatim), forwards to the real host over a freshly-verified upstream TLS
-connection, and streams the response straight back.
+connection, and streams the response straight back. Because the target is
+never swapped, a placeholder-shaped token there can only ever be
+transmitted literally, so the residual fence SCANS the target too and
+refuses the request rather than forwarding it (eumemic/eumemic-ops#331).
 
 Security posture:
 
@@ -231,42 +234,95 @@ _PLACEHOLDER_SUBSTITUTION_FAILED_BODY = (
     b"\n"
     b"Fix: re-provision the sandbox so the CURRENT credential's placeholder is\n"
     b"injected, or widen the credential's allowed_hosts to cover this host.\n"
+    b"\n"
+    b"Note: a placeholder in the URL PATH or QUERY is never substituted (the\n"
+    b"request-target is forwarded verbatim), so it is always refused. Send the\n"
+    b"credential in a header or the request body instead.\n"
 )
 
 # Matches the minted placeholder shape: the greppable prefix plus the 32 hex
-# chars ``mint_secret_placeholder`` emits. Anchored on the exact shape (not a
-# bare prefix scan) so an unrelated string that merely mentions the prefix in
-# prose cannot trip the fence.
-_PLACEHOLDER_RE = re.compile(re.escape(SECRET_PLACEHOLDER_PREFIX) + r"[0-9a-f]{32}")
-_PLACEHOLDER_RE_BYTES = re.compile(re.escape(SECRET_PLACEHOLDER_PREFIX.encode()) + rb"[0-9a-f]{32}")
+# chars ``mint_secret_placeholder`` emits, ANCHORED at both ends on a
+# non-placeholder-alphabet boundary. The prefix+hex alone is not enough: a
+# 33rd hex char (or a longer opaque blob that merely happens to embed the
+# prefix) would match a 32-char window inside it and refuse legitimate
+# traffic. A real minted placeholder is always delimited — it is a whole env
+# var value, a whole Bearer token, a JSON string, a Basic user/pass field — so
+# requiring the boundary keeps every genuine miss while dropping the
+# false-positive class (MEDIUM finding: user data / code samples that merely
+# CONTAIN a placeholder-shaped substring).
+#
+# ``[0-9A-Za-z_]`` is the boundary alphabet because the placeholder itself is
+# drawn from it (prefix has ``_``, body is hex); anything else — quote, colon,
+# space, comma, brace, ``/``, end-of-string — is a legitimate delimiter.
+_PLACEHOLDER_BODY = re.escape(SECRET_PLACEHOLDER_PREFIX) + r"[0-9a-f]{32}"
+_PLACEHOLDER_RE = re.compile(r"(?<![0-9A-Za-z_])" + _PLACEHOLDER_BODY + r"(?![0-9A-Za-z_])")
+_PLACEHOLDER_BODY_BYTES = re.escape(SECRET_PLACEHOLDER_PREFIX.encode()) + rb"[0-9a-f]{32}"
+_PLACEHOLDER_RE_BYTES = re.compile(
+    rb"(?<![0-9A-Za-z_])" + _PLACEHOLDER_BODY_BYTES + rb"(?![0-9A-Za-z_])"
+)
 
 
-def _residual_placeholder(headers: list[tuple[str, str]], body: bytes) -> str | None:
-    """The first unexchanged placeholder left in the post-swap request, if any.
+# Where a residual placeholder was found. NON-SECRET by construction: it names
+# a REGION of the request, never any request-derived byte. This is the ONLY
+# scan-derived value that may ever be logged.
+#
+# WHY THE MATCHED BYTES MAY NEVER BE LOGGED (the CRITICAL finding on the first
+# cut of this fence): the scan runs POST-swap, so the content it inspects
+# contains REAL SECRETS. A vault secret is arbitrary operator-supplied text —
+# nothing stops one from being, or containing, a placeholder-shaped string. In
+# that case a SUCCESSFUL substitution is misread as a residual placeholder and
+# logging "the matched token" writes the real credential to the log. There is
+# no safe prefix either (a prefix of a secret is still secret material). So the
+# refusal log carries the FACT, the REGION, and a count — never a byte, never a
+# prefix, never a length-revealing field derived from the match.
+_RESIDUAL_IN_AUTHORIZATION = "authorization_header"
+_RESIDUAL_IN_BASIC_CREDENTIAL = "authorization_basic_credential"
+_RESIDUAL_IN_HEADER = "header_value"
+_RESIDUAL_IN_BODY = "body"
+_RESIDUAL_IN_REQUEST_TARGET = "request_target"
 
-    Runs on the ALREADY-SWAPPED headers and body, so anything it finds is by
-    construction a placeholder no rule in this session's swap set could
-    exchange. ``Authorization: Basic`` values are decoded before the scan for
-    the same reason ``_swap_header_value`` decodes them: base64 shifts byte
-    boundaries, so a placeholder riding inside a Basic credential is not a
-    literal substring of the header and a raw scan would miss the exact case
+
+def _residual_placeholder_region(
+    headers: list[tuple[str, str]], body: bytes, target: str | None = None
+) -> str | None:
+    """The REGION of the post-swap request holding an unexchanged placeholder.
+
+    Runs on the ALREADY-SWAPPED headers, body and (unswappable by design)
+    request target, so anything it finds is either a placeholder no rule in
+    this session's swap set could exchange, or — indistinguishably from here —
+    a real secret that happens to have the placeholder shape. Both outcomes
+    must refuse: forwarding case 1 transmits the literal placeholder (the bug),
+    and case 2 cannot be told apart from it without comparing against secret
+    material, which is exactly what we refuse to do in a decision that gets
+    logged.
+
+    ``Authorization: Basic`` values are decoded before the scan for the same
+    reason ``_swap_header_value`` decodes them: base64 shifts byte boundaries,
+    so a placeholder riding inside a Basic credential is not a literal
+    substring of the header and a raw scan would miss the exact case
     (git-over-HTTPS, ``curl -u``) that motivated this fence.
 
-    Returns the matched placeholder token (safe to log — it IS the opaque
-    stand-in, never the secret) or ``None`` when the request is clean.
+    Returns a fixed REGION LABEL from the ``_RESIDUAL_IN_*`` set — a constant
+    chosen from a closed vocabulary, carrying **zero** request-derived bytes
+    and therefore safe to log — or ``None`` when the request is clean.
     """
+    if target is not None and _PLACEHOLDER_RE.search(target) is not None:
+        return _RESIDUAL_IN_REQUEST_TARGET
     for name, value in headers:
-        scanned = value
-        if name.lower() == "authorization":
+        lname = name.lower()
+        if lname == "authorization":
             decoded = _decode_basic_credential(value)
             if decoded is not None:
-                scanned = decoded
-        match = _PLACEHOLDER_RE.search(scanned)
-        if match is not None:
-            return match.group(0)
-    match_bytes = _PLACEHOLDER_RE_BYTES.search(body)
-    if match_bytes is not None:
-        return match_bytes.group(0).decode("ascii")
+                if _PLACEHOLDER_RE.search(decoded) is not None:
+                    return _RESIDUAL_IN_BASIC_CREDENTIAL
+                continue
+            if _PLACEHOLDER_RE.search(value) is not None:
+                return _RESIDUAL_IN_AUTHORIZATION
+            continue
+        if _PLACEHOLDER_RE.search(value) is not None:
+            return _RESIDUAL_IN_HEADER
+    if _PLACEHOLDER_RE_BYTES.search(body) is not None:
+        return _RESIDUAL_IN_BODY
     return None
 
 
@@ -573,17 +629,29 @@ class SecretEgressProxy:
         # indistinguishable from a real auth failure. Refuse it here: no
         # upstream connection is opened, so the literal placeholder is never
         # transmitted, and the caller gets an error that NAMES the cause.
-        residual = _residual_placeholder(fwd_headers, swapped_body)
-        if residual is not None:
+        #
+        # The REQUEST TARGET (path + query) is scanned too even though it is
+        # deliberately never swapped. Excluding it from the scan while still
+        # forwarding it verbatim is a live transmission path: a credential
+        # carried in a query parameter (``?token=<placeholder>``,
+        # ``?access_token=…``) would go upstream literally — the exact leak the
+        # fence exists to stop, one field over. Scanning it makes the invariant
+        # whole: NOTHING placeholder-shaped reaches ``self._client.send``.
+        residual_region = _residual_placeholder_region(fwd_headers, swapped_body, target)
+        if residual_region is not None:
             log.warning(
                 "secret_egress_proxy.placeholder_substitution_failed",
                 host=host,
-                path=path,
-                # The placeholder is the opaque stand-in, never the secret, so
-                # logging it is safe — and it is the ONLY handle an operator
-                # has to correlate the refusal with the credential id whose
-                # rotation orphaned it.
-                placeholder=residual,
+                # NOTHING request-derived is logged. The scan runs POST-swap,
+                # so its input contains real secrets, and a real secret with
+                # the placeholder shape makes a SUCCESSFUL swap look residual —
+                # logging the matched bytes (or any prefix of them) would then
+                # write the credential to the log. ``region`` is a constant
+                # from a closed vocabulary; ``swap_rule_count`` counts this
+                # session's rules, not request content. ``path`` is dropped
+                # too: it is sandbox-controlled and, per the request-target
+                # scan above, may itself be where the token sits.
+                region=residual_region,
                 swap_rule_count=len(swaps),
             )
             await self._send_substitution_failure(conn, writer)

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -369,8 +369,7 @@ def _credential_host_fence_lines(dnat_hosts: Sequence[str], *, insert: bool) -> 
     for host in sorted(set(dnat_hosts)):
         lines.append(f"for ip in $(resolve_ipv4 {host}); do")
         lines.append(
-            f'  "$IPT" {flag} OUTPUT -d "$ip" -p tcp --dport 443 '
-            "-j REJECT --reject-with tcp-reset"
+            f'  "$IPT" {flag} OUTPUT -d "$ip" -p tcp --dport 443 -j REJECT --reject-with tcp-reset'
         )
         lines.append("done")
     return lines

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -289,11 +289,16 @@ _RESOLVE_IPV4_FN = (
 )
 
 
-# The credential-host fail-closed fence (eumemic/eumemic-ops#331 fix C).
+# The credential-host fence (eumemic/eumemic-ops#331 fix C).
 #
-# THE INVARIANT: for a credential host, **no DNAT ⇒ no egress**. A packet to a
-# credential host on :443 either gets rewritten to the secret-egress proxy or it
-# is DROPPED — it is never allowed to reach the real upstream directly.
+# THE INTENDED INVARIANT: for a credential host, **no DNAT ⇒ no egress**. A
+# packet to a credential host on :443 either gets rewritten to the secret-egress
+# proxy or it is refused — it is never allowed to reach the real upstream
+# directly.
+#
+# THAT INVARIANT HOLDS UNDER LIMITED ONLY. Under Unrestricted it holds for every
+# address we sampled and FAILS OPEN for one we did not (eumemic/aios#2042). Read
+# the "What this fence DOES and DOES NOT buy" block below before trusting it.
 #
 # Why this replaces DNS sampling. The provision/refresh DNAT rules are keyed on
 # RESOLVED IPs, and a rotating pool (api.github.com serves a ~60s-TTL set and
@@ -306,11 +311,38 @@ _RESOLVE_IPV4_FN = (
 # straight to the real upstream carrying the literal placeholder (and, worse,
 # whatever the sandbox put in an Authorization header of its own).
 #
-# So sampling is demoted from a security control to a latency/availability
-# optimization, and the security property is carried by a rule that needs no
-# knowledge of the pool at all: a terminal per-credential-host REJECT on :443 in
-# the *filter* table, appended AFTER the per-host ACCEPTs. Ordering is what makes
-# it work in both modes:
+# What this fence DOES and DOES NOT buy — stated precisely, because an earlier
+# round of this comment claimed it "needs no knowledge of the pool at all" and
+# that claim is FALSE. The fence is a per-credential-host REJECT on :443 in the
+# *filter* table, and it is keyed on RESOLVED IPs exactly like the DNAT is. Its
+# coverage is therefore exactly the SAMPLED SET, and it inherits the sample's
+# incompleteness.
+#
+#   * It DOES guarantee that every address we LEARNED is proxied-or-refused, so
+#     drift can never silently degrade a known address to direct egress, and
+#     (with the refresh sweep's fence-before-DNAT ordering) a newly learned
+#     address is never in the allowed-but-unproxied state.
+#   * It DOES close the proxy-alias DNS-miss case: with no $PROXY_IP the whole
+#     nat block is guarded out, and the fence — emitted outside that guard —
+#     refuses credential-host egress instead of sending every credential
+#     request straight to the real upstream.
+#   * It does NOT cover an address that never appeared in any DNS sample. Under
+#     LIMITED that is harmless: the terminal ``-P OUTPUT DROP`` catches it. Under
+#     UNRESTRICTED the filter policy stays ACCEPT, so such a packet matches
+#     neither the DNAT nor the fence and LEAVES DIRECTLY, carrying the literal
+#     placeholder. That is a live fail-open, tracked in eumemic/aios#2042, and
+#     pinned behaviourally (packet verdict, not rule syntax) by
+#     ``TestCredentialHostEgressVerdict`` in tests/unit/test_networking.py.
+#
+# Closing #2042 requires inverting the default for credential hosts —
+# deny-by-default with the learned set as an ALLOW-list rather than
+# allow-by-default with the learned set as a fence — which cannot be done at
+# the IP layer for an address we have never seen. It needs name-based
+# interception (a worker-controlled resolver answering credential hosts with
+# the proxy address, or an in-netns SNI-aware TPROXY on :443); see the issue
+# for the four options and why each is larger than this PR.
+#
+# Ordering is what makes the fence work in the cases it does cover:
 #
 #   * nat OUTPUT runs BEFORE filter OUTPUT, so a packet that DID match a DNAT
 #     rule arrives at filter with its destination rewritten to $PROXY_IP:<port>
@@ -327,25 +359,26 @@ _RESOLVE_IPV4_FN = (
 # #331 is turning a silent misleading failure into an immediate visible one. The
 # reset is also distinguishable in-sandbox from the proxy's own 421.
 #
-# Residual (explicitly, not silently): DNS drift now costs AVAILABILITY (a
-# credential-host request on an unsampled IP is reset, and the model sees a hard
-# connection error) instead of CONFIDENTIALITY (the placeholder / a
-# sandbox-supplied credential going out un-proxied). The refresh sweep's
-# multi-probe sampling is what keeps that availability cost small; the fence is
-# what makes the failure mode safe. Fully eliminating the availability residual
-# needs name-based (not IP-based) interception — e.g. resolving credential hosts
-# only through a worker-controlled resolver that answers with the proxy address,
-# or an in-netns TPROXY on :443 — which is a larger change than this PR.
+# Residual, restated so it cannot be misread as closed: UNDER LIMITED, DNS
+# drift now costs AVAILABILITY (a credential-host request on an unsampled IP is
+# reset and the model sees a hard connection error) rather than
+# CONFIDENTIALITY. UNDER UNRESTRICTED IT STILL COSTS CONFIDENTIALITY — an
+# unsampled address matches neither rule and egresses directly with the literal
+# placeholder (eumemic/aios#2042). Multi-probe sampling narrows that window and
+# cannot close it; only name-based interception can.
 _CREDENTIAL_HOST_FENCE_COMMENT = (
-    "# FAIL CLOSED for credential hosts (#331): an un-DNATed :443 packet to a\n"
-    "# credential host must never reach the real upstream carrying a placeholder.\n"
-    "# nat runs before filter, so a DNATed packet is already rewritten to the\n"
-    "# proxy and does not match these rules; only unsampled-IP packets do."
+    "# Credential-host fence (#331): an un-DNATed :443 packet to a LEARNED\n"
+    "# credential-host address is reset instead of reaching the real upstream\n"
+    "# with a placeholder. nat runs before filter, so a DNATed packet is already\n"
+    "# rewritten to the proxy and does not match these rules.\n"
+    "# NOT COMPLETE: these rules are IP-keyed, so an address that never appeared\n"
+    "# in a DNS sample matches neither them nor the DNAT. Under Unrestricted\n"
+    "# (policy ACCEPT) such a packet still egresses directly — eumemic/aios#2042."
 )
 
 
 def _credential_host_fence_lines(dnat_hosts: Sequence[str], *, insert: bool) -> list[str]:
-    """Per-credential-host terminal REJECT on :443 (the no-DNAT ⇒ no-egress fence).
+    """Per-credential-host REJECT on :443 for each LEARNED address (#331).
 
     ``insert=True`` emits ``-I OUTPUT`` (head insertion) for the Limited
     lockdown, where per-host ``ACCEPT`` rules for the same IPs already sit in
@@ -355,14 +388,18 @@ def _credential_host_fence_lines(dnat_hosts: Sequence[str], *, insert: bool) -> 
     append is terminal there because nothing else matches.
 
     Resolution here is best-effort in exactly the same way the DNAT is, and for
-    the same reason: both key on IPs. It is NOT the security property on its
-    own — see :data:`_CREDENTIAL_HOST_FENCE_COMMENT`. What it guarantees is that
-    every IP we *did* learn is either proxied or refused, so drift can never
-    silently degrade to direct egress for a known address; and because the
-    refresh sweep installs the fence for every newly learned IP alongside the
-    DNAT (:func:`build_egress_refresh_script`), a newly appearing pool member
-    becomes proxied-or-refused as soon as it is observed, never
-    allowed-and-unproxied.
+    the same reason: both key on IPs. So this fence is NOT a complete control —
+    see :data:`_CREDENTIAL_HOST_FENCE_COMMENT`. What it guarantees is that every
+    IP we *did* learn is either proxied or refused, so drift can never silently
+    degrade to direct egress for a known address; and because the refresh sweep
+    installs the fence for every newly learned IP alongside the DNAT
+    (:func:`build_egress_refresh_script`), a newly appearing pool member becomes
+    proxied-or-refused as soon as it is observed, never allowed-and-unproxied.
+
+    What it does NOT cover is an address that never appeared in any DNS sample.
+    Under Limited the terminal ``-P OUTPUT DROP`` catches that packet; under
+    Unrestricted the policy is ACCEPT and it egresses DIRECTLY with the literal
+    placeholder — the open fail-open tracked in eumemic/aios#2042.
     """
     flag = "-I" if insert else "-A"
     lines = ["", *_CREDENTIAL_HOST_FENCE_COMMENT.split("\n")]
@@ -538,7 +575,7 @@ def build_egress_refresh_script(
     # The rule tail after ``-d <ip>`` — byte-identical to the provision-time
     # DNAT shape so -C/-D match the installed rules exactly.
     dnat_tail = f"-p tcp --dport 443 -j DNAT --to-destination {proxy_ip}:{proxy_port}"
-    # The no-DNAT ⇒ no-egress fence tail (#331), byte-identical to the shape the
+    # The credential-host fence tail (#331), byte-identical to the shape the
     # provision-time apply installs so -C/-D match the installed rules exactly.
     fence_tail = "-p tcp --dport 443 -j REJECT --reject-with tcp-reset"
     lines = ["set -e", _IPTABLES_BACKEND_SELECT]
@@ -627,15 +664,15 @@ def build_iptables_script(
     (iptables ``--to-destination`` needs an IP, not a DNS name) and the
     whole nat block is guarded by ``if [ -n "$PROXY_IP" ]`` so a
     proxy-alias DNS miss emits no malformed rule. On such a miss the
-    behavior is fail-open-to-placeholder, NOT fail-closed: dnat_hosts ⊆
-    networking.allowed_hosts (enforced by the #879 provision gate), so the
-    credential host's :443 is still filter-ACCEPTed and traffic reaches
-    the real upstream carrying the opaque placeholder — an authentication
-    failure, never a secret leak (the real secret never enters the
-    container). A non-functional credentialed sandbox is acceptable here;
-    a WORKER_NETWORK_ALIAS miss already implies the proxy infrastructure
-    is broken. ``dnat_target`` of ``None`` (the default) emits NO nat
-    rules, preserving every existing caller.
+    behavior is now fail-CLOSED (eumemic/eumemic-ops#331): the guard's
+    ``else`` branch installs the credential-host REJECT fence with no
+    DNAT, so credential-host :443 egress is refused instead of reaching
+    the real upstream with the opaque placeholder (and with whatever
+    Authorization header the sandbox set itself). A non-functional
+    credentialed sandbox is the right trade; a WORKER_NETWORK_ALIAS miss
+    already implies the proxy infrastructure is broken. ``dnat_target``
+    of ``None`` (the default) emits NO nat rules, preserving every
+    existing caller.
 
     Hostnames are validated at the model layer (alphanumerics, dots, hyphens
     only) so embedding them in the script is safe; ``proxy_port`` is an int.
@@ -683,7 +720,7 @@ def build_iptables_script(
         # lockdown script and the Unrestricted DNAT-only script emit a
         # byte-identical rule shape.
         lines.extend(_nat_dnat_lines(dnat_hosts, dnat_target))
-        # …and the fail-closed fence (#331). ``insert=True``: the per-host
+        # …and the credential-host fence (#331). ``insert=True``: the per-host
         # ACCEPTs above already cover these IPs on :443 and iptables is
         # first-match-wins, so the REJECT must be inserted at the HEAD of
         # OUTPUT to win. A DNATed packet is already rewritten to the proxy by
@@ -739,9 +776,11 @@ def build_secret_egress_dnat_script(dnat_hosts: Sequence[str], dnat_target: tupl
             # filter rule (the chain is otherwise not ours under Unrestricted).
             *_credential_host_fence_flush_lines(dnat_hosts),
             *_nat_dnat_lines(dnat_hosts, dnat_target),
-            # The fail-closed fence (#331) applies under Unrestricted too: a
-            # credential host's un-DNATed :443 packet must be refused, not
+            # The credential-host fence (#331) applies under Unrestricted too:
+            # a SAMPLED address's un-DNATed :443 packet is refused rather than
             # allowed out by the default-ACCEPT policy carrying a placeholder.
+            # An UNSAMPLED address matches neither this nor the DNAT and still
+            # egresses directly — the open fail-open, eumemic/aios#2042.
             # ``insert=False`` (append) is terminal here — this chain carries no
             # generated ACCEPTs for these IPs to shadow it.
             *_credential_host_fence_lines(dnat_hosts, insert=False),
@@ -794,9 +833,10 @@ def build_lockdown_verify_script(
 
     When ``dnat_hosts`` is non-empty it ALSO asserts (a) the nat table carries
     at least one ``DNAT`` OUTPUT rule and (b) the filter table carries the
-    credential-host fail-closed fence (a ``--dport 443 -j REJECT`` rule,
-    eumemic/eumemic-ops#331) — so the no-DNAT ⇒ no-egress invariant is proven
-    installed, not assumed. Without this, a credential host whose
+    credential-host fence (a ``--dport 443 -j REJECT`` rule,
+    eumemic/eumemic-ops#331) — so the fence is proven installed, not assumed.
+    (Installed for the sampled addresses; its coverage limit under Unrestricted
+    is eumemic/aios#2042.) Without this, a credential host whose
     ``getent`` returns zero IPs emits no DNAT rule and no error: apply exits 0,
     a filter-only verify passes, and the session runs WITHOUT DNAT for that host
     — the placeholder goes direct to the real upstream and auth fails with no
@@ -804,8 +844,8 @@ def build_lockdown_verify_script(
     into a fail-closed provision error. (Coverage is asserted at the table
     level, not per-host: any host resolving to zero IPs with NO other DNAT rule
     present fails the verify; the proxy-alias DNS-miss case — where the whole
-    nat block is guarded out — is the documented fail-open-to-placeholder path
-    in :func:`build_iptables_script` and is out of scope here.)
+    nat block is guarded out — installs the fence instead and is refused, not
+    forwarded, per :func:`build_iptables_script`.)
 
     Under DNAT-only (``assert_drop=False``) the caller always passes a
     non-empty ``dnat_hosts`` — it only runs when there are credentials — so the
@@ -846,8 +886,8 @@ def build_lockdown_verify_script(
         )
     if dnat_hosts:
         lines.append("\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'")
-        # …and the fail-closed fence actually landed (#331). Without this the
-        # no-DNAT ⇒ no-egress invariant would be unverified — the exact "green
+        # …and the credential-host fence actually landed (#331). Without this
+        # the fence would be unverified — the exact "green
         # verify while open" shape the DROP read-back already closes one layer
         # up. A credential host whose fence failed to install is a host whose
         # unsampled pool addresses would egress DIRECTLY with a placeholder, so

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -338,11 +338,45 @@ def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> 
     return lines
 
 
-def build_egress_resolve_script(hosts: Sequence[str] | set[str]) -> str:
-    """Resolve refresh hosts inside the sandbox netns, one machine-readable row per IP."""
+# How many times each host is resolved per refresh tick
+# (eumemic/eumemic-ops#331 fix C).
+#
+# A rotating DNS pool — api.github.com serves a ~60s-TTL round-robin set — hands
+# back only a SUBSET of the live addresses per query, and often a different
+# subset each time. Pinning one query's answer means the very next in-sandbox
+# resolution can return an address that carries NO DNAT rule, so that request
+# never reaches the secret-egress proxy: it goes DIRECTLY to the upstream
+# carrying the literal placeholder and comes back ``401``. That is the
+# "intermittent auth failure that retrying fixes" signature — a retry that
+# happens to land on a pinned address works.
+#
+# Probing several times per tick samples more of the pool per sweep; combined
+# with the keep-last-good aging in the registry's merge (an address is only
+# evicted after it is ABSENT from several consecutive successful sweeps), the
+# pinned set converges on the UNION of the recently-served pool instead of
+# tracking one query's answer. That closes the drift window rather than
+# narrowing it by luck.
+EGRESS_RESOLVE_PROBES = 4
+
+
+def build_egress_resolve_script(
+    hosts: Sequence[str] | set[str], *, probes: int = EGRESS_RESOLVE_PROBES
+) -> str:
+    """Resolve refresh hosts inside the sandbox netns, one machine-readable row per IP.
+
+    Each host is resolved ``probes`` times and the union of the answers is
+    emitted (deduplicated by the caller, which collects into a set). See
+    :data:`EGRESS_RESOLVE_PROBES` for why one query is not enough against a
+    rotating pool. A resolution miss still prints nothing, so the fail-closed
+    "no IPs ⇒ no rule" semantics are unchanged.
+    """
     lines = ["set -e", _RESOLVE_IPV4_FN]
     for host in sorted(set(hosts)):
-        lines.append(f"for ip in $(resolve_ipv4 {host}); do printf '%s %s\\n' {host} \"$ip\"; done")
+        lines.append(f"for _ in $(seq 1 {probes}); do")
+        lines.append(
+            f"  for ip in $(resolve_ipv4 {host}); do printf '%s %s\\n' {host} \"$ip\"; done"
+        )
+        lines.append("done")
     return _RESOLV_PREAMBLE + "\n".join(lines)
 
 

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -289,151 +289,54 @@ _RESOLVE_IPV4_FN = (
 )
 
 
-# The credential-host fence (eumemic/eumemic-ops#331 fix C).
+# KNOWN RESIDUAL — credential-host egress fails OPEN under Unrestricted
+# networking (eumemic/aios#2042). Documented here, deliberately NOT
+# half-mitigated here.
 #
-# THE INTENDED INVARIANT: for a credential host, **no DNAT ⇒ no egress**. A
-# packet to a credential host on :443 either gets rewritten to the secret-egress
-# proxy or it is refused — it is never allowed to reach the real upstream
-# directly.
+# The credential-host rules below are the nat-OUTPUT DNAT redirect, and they are
+# generated ONLY for RESOLVED (learned) addresses: the ``for ip in $(resolve_ipv4
+# <host>)`` loop installs one rule per address the sidecar's DNS query happened
+# to return. A rotating pool — api.github.com serves a ~60s-TTL set and returns
+# only a SUBSET per query — means that set is a SAMPLE, not the pool.
 #
-# THAT INVARIANT HOLDS UNDER LIMITED ONLY. Under Unrestricted it holds for every
-# address we sampled and FAILS OPEN for one we did not (eumemic/aios#2042). Read
-# the "What this fence DOES and DOES NOT buy" block below before trusting it.
+# Consequence, stated as the failure it is:
 #
-# Why this replaces DNS sampling. The provision/refresh DNAT rules are keyed on
-# RESOLVED IPs, and a rotating pool (api.github.com serves a ~60s-TTL set and
-# returns only a SUBSET per query) means the set of IPs we installed rules for is
-# a SAMPLE, not the pool. Probing N times per tick samples MORE of the pool but
-# guarantees nothing: resolver caching can return the same subset every probe,
-# and a later in-sandbox lookup can still return an address no rule covers. With
-# the pre-#331 shape that residual was FAIL-OPEN — under the ``cred ⊆ env`` gate
-# the credential host's :443 is filter-ACCEPTed, so an un-DNATed packet went
-# straight to the real upstream carrying the literal placeholder (and, worse,
-# whatever the sandbox put in an Authorization header of its own).
+#   * LIMITED networking is closed. An unsampled address matches no DNAT and no
+#     per-host ACCEPT, so it falls through to the terminal ``-P OUTPUT DROP``.
+#     Nothing leaves.
+#   * UNRESTRICTED networking is OPEN. The filter policy stays ``ACCEPT``, so an
+#     unsampled address matches no DNAT and egresses DIRECTLY to the real
+#     upstream carrying the literal ``AIOS_SECRET_PLACEHOLDER_*`` — never
+#     reaching the secret-egress proxy, so neither the swap nor the #331
+#     fail-loud fence in ``secret_egress_proxy.py`` ever runs on it.
 #
-# What this fence DOES and DOES NOT buy — stated precisely, because an earlier
-# round of this comment claimed it "needs no knowledge of the pool at all" and
-# that claim is FALSE. The fence is a per-credential-host REJECT on :443 in the
-# *filter* table, and it is keyed on RESOLVED IPs exactly like the DNAT is. Its
-# coverage is therefore exactly the SAMPLED SET, and it inherits the sample's
-# incompleteness.
+# Why nothing is done about it HERE. An earlier round of this PR added a
+# per-credential-host filter REJECT for the learned addresses and called it a
+# fence. It was withdrawn on review, and the reasoning is worth keeping because
+# it is the reason this block is a comment and not code: that rule is IP-keyed
+# exactly like the DNAT, so its coverage is exactly the same sample, and the
+# unsampled address — the ordinary case against a rotating pool, not an exotic
+# one — walks past it. It reads as a fence to the next person who greps for one
+# while leaving the hole open. A DOCUMENTED hole is safer than a DISGUISED one:
+# a reader who finds this comment knows the exposure is live, whereas a reader
+# who finds a REJECT rule reasonably concludes it is closed. More DNS probing
+# has the same defect one level down — it narrows the window and cannot close
+# it, so it would be mitigation theatre with a security-shaped name.
 #
-#   * It DOES guarantee that every address we LEARNED is proxied-or-refused, so
-#     drift can never silently degrade a known address to direct egress, and
-#     (with the refresh sweep's fence-before-DNAT ordering) a newly learned
-#     address is never in the allowed-but-unproxied state.
-#   * It DOES close the proxy-alias DNS-miss case: with no $PROXY_IP the whole
-#     nat block is guarded out, and the fence — emitted outside that guard —
-#     refuses credential-host egress instead of sending every credential
-#     request straight to the real upstream.
-#   * It does NOT cover an address that never appeared in any DNS sample. Under
-#     LIMITED that is harmless: the terminal ``-P OUTPUT DROP`` catches it. Under
-#     UNRESTRICTED the filter policy stays ACCEPT, so such a packet matches
-#     neither the DNAT nor the fence and LEAVES DIRECTLY, carrying the literal
-#     placeholder. That is a live fail-open, tracked in eumemic/aios#2042, and
-#     pinned behaviourally (packet verdict, not rule syntax) by
-#     ``TestCredentialHostEgressVerdict`` in tests/unit/test_networking.py.
+# The correct shape INVERTS the default for credential hosts: deny-by-default
+# with the learned set as an ALLOW-list, rather than allow-by-default with the
+# learned set as a fence. That cannot be decided at the IP layer for an address
+# we have never seen; it needs name-based interception (a worker-controlled
+# resolver answering credential hosts with the proxy address, or an in-netns
+# SNI-aware TPROXY on :443). eumemic/aios#2042 carries the four options
+# considered and why each is a larger change than this PR.
 #
-# Closing #2042 requires inverting the default for credential hosts —
-# deny-by-default with the learned set as an ALLOW-list rather than
-# allow-by-default with the learned set as a fence — which cannot be done at
-# the IP layer for an address we have never seen. It needs name-based
-# interception (a worker-controlled resolver answering credential hosts with
-# the proxy address, or an in-netns SNI-aware TPROXY on :443); see the issue
-# for the four options and why each is larger than this PR.
-#
-# Ordering is what makes the fence work in the cases it does cover:
-#
-#   * nat OUTPUT runs BEFORE filter OUTPUT, so a packet that DID match a DNAT
-#     rule arrives at filter with its destination rewritten to $PROXY_IP:<port>
-#     — it no longer matches ``-d <credential-host-ip>`` and is unaffected by the
-#     fence. Only un-DNATed (unsampled-IP) packets can reach it.
-#   * The fence is appended after the allowed-host ACCEPTs, and iptables is
-#     first-match-wins... which is exactly why the fence for a credential host
-#     must be inserted BEFORE those ACCEPTs, not after. We do that by emitting
-#     credential-host REJECTs with ``-I`` (insert at head) in the Limited script,
-#     so they precede every generated ACCEPT regardless of host ordering.
-#
-# ``--reject-with tcp-reset`` (not DROP) so a sandbox client fails FAST and
-# loudly (connection reset) instead of hanging until timeout — the whole point of
-# #331 is turning a silent misleading failure into an immediate visible one. The
-# reset is also distinguishable in-sandbox from the proxy's own 421.
-#
-# Residual, restated so it cannot be misread as closed: UNDER LIMITED, DNS
-# drift now costs AVAILABILITY (a credential-host request on an unsampled IP is
-# reset and the model sees a hard connection error) rather than
-# CONFIDENTIALITY. UNDER UNRESTRICTED IT STILL COSTS CONFIDENTIALITY — an
-# unsampled address matches neither rule and egresses directly with the literal
-# placeholder (eumemic/aios#2042). Multi-probe sampling narrows that window and
-# cannot close it; only name-based interception can.
-_CREDENTIAL_HOST_FENCE_COMMENT = (
-    "# Credential-host fence (#331): an un-DNATed :443 packet to a LEARNED\n"
-    "# credential-host address is reset instead of reaching the real upstream\n"
-    "# with a placeholder. nat runs before filter, so a DNATed packet is already\n"
-    "# rewritten to the proxy and does not match these rules.\n"
-    "# NOT COMPLETE: these rules are IP-keyed, so an address that never appeared\n"
-    "# in a DNS sample matches neither them nor the DNAT. Under Unrestricted\n"
-    "# (policy ACCEPT) such a packet still egresses directly — eumemic/aios#2042."
-)
-
-
-def _credential_host_fence_lines(dnat_hosts: Sequence[str], *, insert: bool) -> list[str]:
-    """Per-credential-host REJECT on :443 for each LEARNED address (#331).
-
-    ``insert=True`` emits ``-I OUTPUT`` (head insertion) for the Limited
-    lockdown, where per-host ``ACCEPT`` rules for the same IPs already sit in
-    the chain and first-match-wins would otherwise let an un-DNATed packet out.
-    ``insert=False`` emits ``-A OUTPUT`` for the Unrestricted DNAT-only script,
-    whose filter chain carries no generated ACCEPTs (policy stays ACCEPT) — an
-    append is terminal there because nothing else matches.
-
-    Resolution here is best-effort in exactly the same way the DNAT is, and for
-    the same reason: both key on IPs. So this fence is NOT a complete control —
-    see :data:`_CREDENTIAL_HOST_FENCE_COMMENT`. What it guarantees is that every
-    IP we *did* learn is either proxied or refused, so drift can never silently
-    degrade to direct egress for a known address; and because the refresh sweep
-    installs the fence for every newly learned IP alongside the DNAT
-    (:func:`build_egress_refresh_script`), a newly appearing pool member becomes
-    proxied-or-refused as soon as it is observed, never allowed-and-unproxied.
-
-    What it does NOT cover is an address that never appeared in any DNS sample.
-    Under Limited the terminal ``-P OUTPUT DROP`` catches that packet; under
-    Unrestricted the policy is ACCEPT and it egresses DIRECTLY with the literal
-    placeholder — the open fail-open tracked in eumemic/aios#2042.
-    """
-    flag = "-I" if insert else "-A"
-    lines = ["", *_CREDENTIAL_HOST_FENCE_COMMENT.split("\n")]
-    for host in sorted(set(dnat_hosts)):
-        lines.append(f"for ip in $(resolve_ipv4 {host}); do")
-        lines.append(
-            f'  "$IPT" {flag} OUTPUT -d "$ip" -p tcp --dport 443 -j REJECT --reject-with tcp-reset'
-        )
-        lines.append("done")
-    return lines
-
-
-def _credential_host_fence_flush_lines(dnat_hosts: Sequence[str]) -> list[str]:
-    """Delete this subsystem's credential-host fence rules from filter OUTPUT.
-
-    Used only by the Unrestricted DNAT-only apply, which must be idempotent
-    without flushing a filter chain it does not own. Deletes are
-    ``|| true``-guarded (an absent rule on a first apply must not abort under
-    ``set -e``) and looped so a rule installed for several pool addresses is
-    fully cleared. The Limited path needs none of this: it ``-F OUTPUT``s the
-    whole chain, which it does own.
-    """
-    lines = [
-        "",
-        "# Clear any previous credential-host fence rules (idempotent re-apply, #331)",
-    ]
-    for host in sorted(set(dnat_hosts)):
-        lines.append(f"for ip in $(resolve_ipv4 {host}); do")
-        lines.append(
-            '  while "$IPT" -D OUTPUT -d "$ip" -p tcp --dport 443 '
-            "-j REJECT --reject-with tcp-reset 2>/dev/null; do :; done"
-        )
-        lines.append("done")
-    return lines
+# The residual is pinned BEHAVIOURALLY, not only in prose:
+# ``TestCredentialHostEgressVerdict`` (tests/unit/test_networking.py) runs the
+# real generated script against recording ``iptables``/``getent`` shims and
+# replays the ruleset against a packet — asserting Limited BLOCKS an unsampled
+# address and that Unrestricted still routes it DIRECT. That assertion failing
+# is the acceptance signal for #2042, not a regression.
 
 
 def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> list[str]:
@@ -441,21 +344,17 @@ def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> 
 
     Shared by the Limited lockdown script (:func:`build_iptables_script`) and
     the Unrestricted DNAT-only script (:func:`build_secret_egress_dnat_script`)
-    so the rule shape lives in exactly one place (#1153).
+    so the rule shape — and the ``$PROXY_IP``-miss fail-open-to-placeholder
+    guard — lives in exactly one place (#1153).
 
     The proxy alias is resolved to ``$PROXY_IP`` exactly ONCE at sidecar
     runtime (iptables ``--to-destination`` needs an IP, not a DNS name) and the
     whole block is guarded by ``if [ -n "$PROXY_IP" ]`` so a proxy-alias DNS
-    miss emits no malformed rule.
-
-    **A proxy-alias miss now fails CLOSED** (eumemic/eumemic-ops#331): the
-    ``else`` branch of that guard installs the credential-host REJECT fence
-    without any DNAT, so credential-host :443 egress is refused rather than
-    flowing DIRECTLY to the real upstream carrying the opaque placeholder. The
-    previous fail-open-to-placeholder posture is gone: "an authentication
-    failure, never a secret leak" understated it — the un-proxied request also
-    carries whatever the sandbox itself put in an Authorization header, and a
-    misleading upstream 401 is precisely the symptom #331 exists to kill.
+    miss emits no malformed rule. On such a miss the behavior is
+    fail-open-to-placeholder, NOT fail-closed: the placeholder reaches the real
+    upstream (an authentication failure, never a secret leak — the real secret
+    never enters the container). See :func:`build_iptables_script` for the full
+    rationale.
 
     Callers only invoke this when ``dnat_hosts`` is non-empty and a
     ``dnat_target`` is supplied.
@@ -466,8 +365,15 @@ def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> 
         "# Route credential-host HTTPS through the secret-egress proxy (#878)",
         # Resolve the proxy alias to an IP ONCE — iptables --to-destination
         # needs an IP, not a DNS name. The block is guarded on a non-empty
-        # $PROXY_IP so an alias DNS miss emits no malformed ":<port>" rule;
-        # the miss branch fences credential-host egress off entirely (#331).
+        # $PROXY_IP, so a proxy-alias DNS miss emits no malformed ":<port>"
+        # rule. NOTE the resulting behavior: under #879's `cred ⊆ env` gate
+        # (Limited) the credential host IS always in allowed_hosts and therefore
+        # filter-ACCEPTed on :443 — so on a proxy miss, traffic flows DIRECTLY
+        # to the real upstream carrying the opaque placeholder. That is
+        # fail-open-to-placeholder (auth failures), never a secret leak: the
+        # real secret never enters the container. (In practice the alias is the
+        # load-bearing WORKER_NETWORK_ALIAS, so a miss already means a
+        # non-functional sandbox.)
         f"PROXY_IP=$(resolve_ipv4 {proxy_alias} | head -n1)",
         'if [ -n "$PROXY_IP" ]; then',
     ]
@@ -478,54 +384,15 @@ def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> 
             f'-j DNAT --to-destination "$PROXY_IP:{proxy_port}"'
         )
         lines.append("  done")
-    lines.append("else")
-    lines.append(
-        '  echo "secret-egress proxy alias did not resolve; credential-host :443 '
-        'egress is REFUSED (fail closed, #331)" >&2'
-    )
     lines.append("fi")
     return lines
 
 
-# How many times each host is resolved per refresh tick
-# (eumemic/eumemic-ops#331 fix C).
-#
-# A rotating DNS pool — api.github.com serves a ~60s-TTL round-robin set — hands
-# back only a SUBSET of the live addresses per query, and often a different
-# subset each time. Pinning one query's answer means the very next in-sandbox
-# resolution can return an address that carries NO DNAT rule, so that request
-# never reaches the secret-egress proxy: it goes DIRECTLY to the upstream
-# carrying the literal placeholder and comes back ``401``. That is the
-# "intermittent auth failure that retrying fixes" signature — a retry that
-# happens to land on a pinned address works.
-#
-# Probing several times per tick samples more of the pool per sweep; combined
-# with the keep-last-good aging in the registry's merge (an address is only
-# evicted after it is ABSENT from several consecutive successful sweeps), the
-# pinned set converges on the UNION of the recently-served pool instead of
-# tracking one query's answer. That closes the drift window rather than
-# narrowing it by luck.
-EGRESS_RESOLVE_PROBES = 4
-
-
-def build_egress_resolve_script(
-    hosts: Sequence[str] | set[str], *, probes: int = EGRESS_RESOLVE_PROBES
-) -> str:
-    """Resolve refresh hosts inside the sandbox netns, one machine-readable row per IP.
-
-    Each host is resolved ``probes`` times and the union of the answers is
-    emitted (deduplicated by the caller, which collects into a set). See
-    :data:`EGRESS_RESOLVE_PROBES` for why one query is not enough against a
-    rotating pool. A resolution miss still prints nothing, so the fail-closed
-    "no IPs ⇒ no rule" semantics are unchanged.
-    """
+def build_egress_resolve_script(hosts: Sequence[str] | set[str]) -> str:
+    """Resolve refresh hosts inside the sandbox netns, one machine-readable row per IP."""
     lines = ["set -e", _RESOLVE_IPV4_FN]
     for host in sorted(set(hosts)):
-        lines.append(f"for _ in $(seq 1 {probes}); do")
-        lines.append(
-            f"  for ip in $(resolve_ipv4 {host}); do printf '%s %s\\n' {host} \"$ip\"; done"
-        )
-        lines.append("done")
+        lines.append(f"for ip in $(resolve_ipv4 {host}); do printf '%s %s\\n' {host} \"$ip\"; done")
     return _RESOLV_PREAMBLE + "\n".join(lines)
 
 
@@ -561,23 +428,10 @@ def build_egress_refresh_script(
         # script (set -e) — the delta may be a retry of a partial apply.
         return f'"$IPT"{table_flag} -D OUTPUT {rule} 2>/dev/null || true'
 
-    def _insert(table_flag: str, rule: str) -> str:
-        # Insert-at-head-if-absent. Head insertion (not append) because the
-        # credential-host fence must win over the per-host ACCEPTs already in
-        # the chain (iptables is first-match-wins); -C still makes it idempotent
-        # so a retried delta never stacks duplicates.
-        return (
-            f'"$IPT"{table_flag} -C OUTPUT {rule} 2>/dev/null || '
-            f'"$IPT"{table_flag} -I OUTPUT {rule}'
-        )
-
     proxy_ip, proxy_port = dnat_target
     # The rule tail after ``-d <ip>`` — byte-identical to the provision-time
     # DNAT shape so -C/-D match the installed rules exactly.
     dnat_tail = f"-p tcp --dport 443 -j DNAT --to-destination {proxy_ip}:{proxy_port}"
-    # The credential-host fence tail (#331), byte-identical to the shape the
-    # provision-time apply installs so -C/-D match the installed rules exactly.
-    fence_tail = "-p tcp --dport 443 -j REJECT --reject-with tcp-reset"
     lines = ["set -e", _IPTABLES_BACKEND_SELECT]
     for host in sorted(new_ips):
         added = new_ips[host] - old_ips.get(host, set())
@@ -586,24 +440,12 @@ def build_egress_refresh_script(
                 lines.append(_add("", f"-d {ip} -p tcp --dport 80 -j ACCEPT"))
                 lines.append(_add("", f"-d {ip} -p tcp --dport 443 -j ACCEPT"))
             if host in credential_hosts:
-                # The fence goes in FIRST (insert-at-head, so it precedes any
-                # ACCEPT for the same IP) and only THEN the DNAT. Ordering is a
-                # security property, not cosmetics: between the two statements
-                # the newly learned address must never be in the
-                # allowed-but-unproxied state — install-fence-then-DNAT means
-                # the worst intermediate state is "refused", never "direct
-                # egress with a placeholder" (#331).
-                lines.append(_insert("", f"-d {ip} {fence_tail}"))
                 lines.append(_add(" -t nat", f"-d {ip} {dnat_tail}"))
     for host in sorted(old_ips):
         removed = old_ips[host] - new_ips.get(host, set())
         for ip in sorted(removed):
             if host in credential_hosts:
                 lines.append(_delete(" -t nat", f"-d {ip} {dnat_tail}"))
-                # Fence removed LAST for the same reason: an evicted address
-                # that still has a fence is merely refused; one that has lost
-                # its fence while a stale ACCEPT lingers would be direct egress.
-                lines.append(_delete("", f"-d {ip} {fence_tail}"))
             if host in limited_hosts:
                 lines.append(_delete("", f"-d {ip} -p tcp --dport 80 -j ACCEPT"))
                 lines.append(_delete("", f"-d {ip} -p tcp --dport 443 -j ACCEPT"))
@@ -664,15 +506,15 @@ def build_iptables_script(
     (iptables ``--to-destination`` needs an IP, not a DNS name) and the
     whole nat block is guarded by ``if [ -n "$PROXY_IP" ]`` so a
     proxy-alias DNS miss emits no malformed rule. On such a miss the
-    behavior is now fail-CLOSED (eumemic/eumemic-ops#331): the guard's
-    ``else`` branch installs the credential-host REJECT fence with no
-    DNAT, so credential-host :443 egress is refused instead of reaching
-    the real upstream with the opaque placeholder (and with whatever
-    Authorization header the sandbox set itself). A non-functional
-    credentialed sandbox is the right trade; a WORKER_NETWORK_ALIAS miss
-    already implies the proxy infrastructure is broken. ``dnat_target``
-    of ``None`` (the default) emits NO nat rules, preserving every
-    existing caller.
+    behavior is fail-open-to-placeholder, NOT fail-closed: dnat_hosts ⊆
+    networking.allowed_hosts (enforced by the #879 provision gate), so the
+    credential host's :443 is still filter-ACCEPTed and traffic reaches
+    the real upstream carrying the opaque placeholder — an authentication
+    failure, never a secret leak (the real secret never enters the
+    container). A non-functional credentialed sandbox is acceptable here;
+    a WORKER_NETWORK_ALIAS miss already implies the proxy infrastructure
+    is broken. ``dnat_target`` of ``None`` (the default) emits NO nat
+    rules, preserving every existing caller.
 
     Hostnames are validated at the model layer (alphanumerics, dots, hyphens
     only) so embedding them in the script is safe; ``proxy_port`` is an int.
@@ -720,14 +562,6 @@ def build_iptables_script(
         # lockdown script and the Unrestricted DNAT-only script emit a
         # byte-identical rule shape.
         lines.extend(_nat_dnat_lines(dnat_hosts, dnat_target))
-        # …and the credential-host fence (#331). ``insert=True``: the per-host
-        # ACCEPTs above already cover these IPs on :443 and iptables is
-        # first-match-wins, so the REJECT must be inserted at the HEAD of
-        # OUTPUT to win. A DNATed packet is already rewritten to the proxy by
-        # the time filter runs, so it never matches — only an un-DNATed
-        # (unsampled-IP) credential-host packet does, and it is reset instead
-        # of flowing to the real upstream with a placeholder.
-        lines.extend(_credential_host_fence_lines(dnat_hosts, insert=True))
 
     lines.append("")
     lines.append("# Drop everything else")
@@ -771,22 +605,9 @@ def build_secret_egress_dnat_script(dnat_hosts: Sequence[str], dnat_target: tupl
             "",
             "# Flush nat OUTPUT for idempotent re-apply (do NOT touch filter OUTPUT)",
             '"$IPT" -t nat -F OUTPUT',
-            # Flush ONLY this subsystem's credential-host fence from filter
-            # OUTPUT so the re-apply is idempotent without touching any other
-            # filter rule (the chain is otherwise not ours under Unrestricted).
-            *_credential_host_fence_flush_lines(dnat_hosts),
             *_nat_dnat_lines(dnat_hosts, dnat_target),
-            # The credential-host fence (#331) applies under Unrestricted too:
-            # a SAMPLED address's un-DNATed :443 packet is refused rather than
-            # allowed out by the default-ACCEPT policy carrying a placeholder.
-            # An UNSAMPLED address matches neither this nor the DNAT and still
-            # egresses directly — the open fail-open, eumemic/aios#2042.
-            # ``insert=False`` (append) is terminal here — this chain carries no
-            # generated ACCEPTs for these IPs to shadow it.
-            *_credential_host_fence_lines(dnat_hosts, insert=False),
             # NO `-P OUTPUT DROP`, NO filter ACCEPTs — the filter policy stays
-            # ACCEPT so general egress remains open under Unrestricted (except
-            # the credential-host :443 fence above, which is the #331 invariant).
+            # ACCEPT so general egress remains open under Unrestricted.
         ]
     )
 
@@ -831,12 +652,8 @@ def build_lockdown_verify_script(
     ``ACCEPT`` and installs no v6 DROP, so there is no DROP (v4 or v6) to assert
     (asserting it would always fail).
 
-    When ``dnat_hosts`` is non-empty it ALSO asserts (a) the nat table carries
-    at least one ``DNAT`` OUTPUT rule and (b) the filter table carries the
-    credential-host fence (a ``--dport 443 -j REJECT`` rule,
-    eumemic/eumemic-ops#331) — so the fence is proven installed, not assumed.
-    (Installed for the sampled addresses; its coverage limit under Unrestricted
-    is eumemic/aios#2042.) Without this, a credential host whose
+    When ``dnat_hosts`` is non-empty it ALSO asserts the nat table carries at
+    least one ``DNAT`` OUTPUT rule. Without this, a credential host whose
     ``getent`` returns zero IPs emits no DNAT rule and no error: apply exits 0,
     a filter-only verify passes, and the session runs WITHOUT DNAT for that host
     — the placeholder goes direct to the real upstream and auth fails with no
@@ -844,8 +661,8 @@ def build_lockdown_verify_script(
     into a fail-closed provision error. (Coverage is asserted at the table
     level, not per-host: any host resolving to zero IPs with NO other DNAT rule
     present fails the verify; the proxy-alias DNS-miss case — where the whole
-    nat block is guarded out — installs the fence instead and is refused, not
-    forwarded, per :func:`build_iptables_script`.)
+    nat block is guarded out — is the documented fail-open-to-placeholder path
+    in :func:`build_iptables_script` and is out of scope here.)
 
     Under DNAT-only (``assert_drop=False``) the caller always passes a
     non-empty ``dnat_hosts`` — it only runs when there are credentials — so the
@@ -886,15 +703,6 @@ def build_lockdown_verify_script(
         )
     if dnat_hosts:
         lines.append("\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'")
-        # …and the credential-host fence actually landed (#331). Without this
-        # the fence would be unverified — the exact "green
-        # verify while open" shape the DROP read-back already closes one layer
-        # up. A credential host whose fence failed to install is a host whose
-        # unsampled pool addresses would egress DIRECTLY with a placeholder, so
-        # a missing fence must fail the provision closed.
-        lines.append(
-            "\"$IPT\" -S OUTPUT | grep -q -- '--dport 443 -j REJECT --reject-with tcp-reset'"
-        )
     return "\n".join(lines)
 
 

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -289,22 +289,137 @@ _RESOLVE_IPV4_FN = (
 )
 
 
+# The credential-host fail-closed fence (eumemic/eumemic-ops#331 fix C).
+#
+# THE INVARIANT: for a credential host, **no DNAT ⇒ no egress**. A packet to a
+# credential host on :443 either gets rewritten to the secret-egress proxy or it
+# is DROPPED — it is never allowed to reach the real upstream directly.
+#
+# Why this replaces DNS sampling. The provision/refresh DNAT rules are keyed on
+# RESOLVED IPs, and a rotating pool (api.github.com serves a ~60s-TTL set and
+# returns only a SUBSET per query) means the set of IPs we installed rules for is
+# a SAMPLE, not the pool. Probing N times per tick samples MORE of the pool but
+# guarantees nothing: resolver caching can return the same subset every probe,
+# and a later in-sandbox lookup can still return an address no rule covers. With
+# the pre-#331 shape that residual was FAIL-OPEN — under the ``cred ⊆ env`` gate
+# the credential host's :443 is filter-ACCEPTed, so an un-DNATed packet went
+# straight to the real upstream carrying the literal placeholder (and, worse,
+# whatever the sandbox put in an Authorization header of its own).
+#
+# So sampling is demoted from a security control to a latency/availability
+# optimization, and the security property is carried by a rule that needs no
+# knowledge of the pool at all: a terminal per-credential-host REJECT on :443 in
+# the *filter* table, appended AFTER the per-host ACCEPTs. Ordering is what makes
+# it work in both modes:
+#
+#   * nat OUTPUT runs BEFORE filter OUTPUT, so a packet that DID match a DNAT
+#     rule arrives at filter with its destination rewritten to $PROXY_IP:<port>
+#     — it no longer matches ``-d <credential-host-ip>`` and is unaffected by the
+#     fence. Only un-DNATed (unsampled-IP) packets can reach it.
+#   * The fence is appended after the allowed-host ACCEPTs, and iptables is
+#     first-match-wins... which is exactly why the fence for a credential host
+#     must be inserted BEFORE those ACCEPTs, not after. We do that by emitting
+#     credential-host REJECTs with ``-I`` (insert at head) in the Limited script,
+#     so they precede every generated ACCEPT regardless of host ordering.
+#
+# ``--reject-with tcp-reset`` (not DROP) so a sandbox client fails FAST and
+# loudly (connection reset) instead of hanging until timeout — the whole point of
+# #331 is turning a silent misleading failure into an immediate visible one. The
+# reset is also distinguishable in-sandbox from the proxy's own 421.
+#
+# Residual (explicitly, not silently): DNS drift now costs AVAILABILITY (a
+# credential-host request on an unsampled IP is reset, and the model sees a hard
+# connection error) instead of CONFIDENTIALITY (the placeholder / a
+# sandbox-supplied credential going out un-proxied). The refresh sweep's
+# multi-probe sampling is what keeps that availability cost small; the fence is
+# what makes the failure mode safe. Fully eliminating the availability residual
+# needs name-based (not IP-based) interception — e.g. resolving credential hosts
+# only through a worker-controlled resolver that answers with the proxy address,
+# or an in-netns TPROXY on :443 — which is a larger change than this PR.
+_CREDENTIAL_HOST_FENCE_COMMENT = (
+    "# FAIL CLOSED for credential hosts (#331): an un-DNATed :443 packet to a\n"
+    "# credential host must never reach the real upstream carrying a placeholder.\n"
+    "# nat runs before filter, so a DNATed packet is already rewritten to the\n"
+    "# proxy and does not match these rules; only unsampled-IP packets do."
+)
+
+
+def _credential_host_fence_lines(dnat_hosts: Sequence[str], *, insert: bool) -> list[str]:
+    """Per-credential-host terminal REJECT on :443 (the no-DNAT ⇒ no-egress fence).
+
+    ``insert=True`` emits ``-I OUTPUT`` (head insertion) for the Limited
+    lockdown, where per-host ``ACCEPT`` rules for the same IPs already sit in
+    the chain and first-match-wins would otherwise let an un-DNATed packet out.
+    ``insert=False`` emits ``-A OUTPUT`` for the Unrestricted DNAT-only script,
+    whose filter chain carries no generated ACCEPTs (policy stays ACCEPT) — an
+    append is terminal there because nothing else matches.
+
+    Resolution here is best-effort in exactly the same way the DNAT is, and for
+    the same reason: both key on IPs. It is NOT the security property on its
+    own — see :data:`_CREDENTIAL_HOST_FENCE_COMMENT`. What it guarantees is that
+    every IP we *did* learn is either proxied or refused, so drift can never
+    silently degrade to direct egress for a known address; and because the
+    refresh sweep installs the fence for every newly learned IP alongside the
+    DNAT (:func:`build_egress_refresh_script`), a newly appearing pool member
+    becomes proxied-or-refused as soon as it is observed, never
+    allowed-and-unproxied.
+    """
+    flag = "-I" if insert else "-A"
+    lines = ["", *_CREDENTIAL_HOST_FENCE_COMMENT.split("\n")]
+    for host in sorted(set(dnat_hosts)):
+        lines.append(f"for ip in $(resolve_ipv4 {host}); do")
+        lines.append(
+            f'  "$IPT" {flag} OUTPUT -d "$ip" -p tcp --dport 443 '
+            "-j REJECT --reject-with tcp-reset"
+        )
+        lines.append("done")
+    return lines
+
+
+def _credential_host_fence_flush_lines(dnat_hosts: Sequence[str]) -> list[str]:
+    """Delete this subsystem's credential-host fence rules from filter OUTPUT.
+
+    Used only by the Unrestricted DNAT-only apply, which must be idempotent
+    without flushing a filter chain it does not own. Deletes are
+    ``|| true``-guarded (an absent rule on a first apply must not abort under
+    ``set -e``) and looped so a rule installed for several pool addresses is
+    fully cleared. The Limited path needs none of this: it ``-F OUTPUT``s the
+    whole chain, which it does own.
+    """
+    lines = [
+        "",
+        "# Clear any previous credential-host fence rules (idempotent re-apply, #331)",
+    ]
+    for host in sorted(set(dnat_hosts)):
+        lines.append(f"for ip in $(resolve_ipv4 {host}); do")
+        lines.append(
+            '  while "$IPT" -D OUTPUT -d "$ip" -p tcp --dport 443 '
+            "-j REJECT --reject-with tcp-reset 2>/dev/null; do :; done"
+        )
+        lines.append("done")
+    return lines
+
+
 def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> list[str]:
     """The nat-OUTPUT DNAT block: credential-host :443 → secret-egress proxy.
 
     Shared by the Limited lockdown script (:func:`build_iptables_script`) and
     the Unrestricted DNAT-only script (:func:`build_secret_egress_dnat_script`)
-    so the rule shape — and the ``$PROXY_IP``-miss fail-open-to-placeholder
-    guard — lives in exactly one place (#1153).
+    so the rule shape lives in exactly one place (#1153).
 
     The proxy alias is resolved to ``$PROXY_IP`` exactly ONCE at sidecar
     runtime (iptables ``--to-destination`` needs an IP, not a DNS name) and the
     whole block is guarded by ``if [ -n "$PROXY_IP" ]`` so a proxy-alias DNS
-    miss emits no malformed rule. On such a miss the behavior is
-    fail-open-to-placeholder, NOT fail-closed: the placeholder reaches the real
-    upstream (an authentication failure, never a secret leak — the real secret
-    never enters the container). See :func:`build_iptables_script` for the full
-    rationale.
+    miss emits no malformed rule.
+
+    **A proxy-alias miss now fails CLOSED** (eumemic/eumemic-ops#331): the
+    ``else`` branch of that guard installs the credential-host REJECT fence
+    without any DNAT, so credential-host :443 egress is refused rather than
+    flowing DIRECTLY to the real upstream carrying the opaque placeholder. The
+    previous fail-open-to-placeholder posture is gone: "an authentication
+    failure, never a secret leak" understated it — the un-proxied request also
+    carries whatever the sandbox itself put in an Authorization header, and a
+    misleading upstream 401 is precisely the symptom #331 exists to kill.
 
     Callers only invoke this when ``dnat_hosts`` is non-empty and a
     ``dnat_target`` is supplied.
@@ -315,15 +430,8 @@ def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> 
         "# Route credential-host HTTPS through the secret-egress proxy (#878)",
         # Resolve the proxy alias to an IP ONCE — iptables --to-destination
         # needs an IP, not a DNS name. The block is guarded on a non-empty
-        # $PROXY_IP, so a proxy-alias DNS miss emits no malformed ":<port>"
-        # rule. NOTE the resulting behavior: under #879's `cred ⊆ env` gate
-        # (Limited) the credential host IS always in allowed_hosts and therefore
-        # filter-ACCEPTed on :443 — so on a proxy miss, traffic flows DIRECTLY
-        # to the real upstream carrying the opaque placeholder. That is
-        # fail-open-to-placeholder (auth failures), never a secret leak: the
-        # real secret never enters the container. (In practice the alias is the
-        # load-bearing WORKER_NETWORK_ALIAS, so a miss already means a
-        # non-functional sandbox.)
+        # $PROXY_IP so an alias DNS miss emits no malformed ":<port>" rule;
+        # the miss branch fences credential-host egress off entirely (#331).
         f"PROXY_IP=$(resolve_ipv4 {proxy_alias} | head -n1)",
         'if [ -n "$PROXY_IP" ]; then',
     ]
@@ -334,6 +442,11 @@ def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> 
             f'-j DNAT --to-destination "$PROXY_IP:{proxy_port}"'
         )
         lines.append("  done")
+    lines.append("else")
+    lines.append(
+        '  echo "secret-egress proxy alias did not resolve; credential-host :443 '
+        'egress is REFUSED (fail closed, #331)" >&2'
+    )
     lines.append("fi")
     return lines
 
@@ -412,10 +525,23 @@ def build_egress_refresh_script(
         # script (set -e) — the delta may be a retry of a partial apply.
         return f'"$IPT"{table_flag} -D OUTPUT {rule} 2>/dev/null || true'
 
+    def _insert(table_flag: str, rule: str) -> str:
+        # Insert-at-head-if-absent. Head insertion (not append) because the
+        # credential-host fence must win over the per-host ACCEPTs already in
+        # the chain (iptables is first-match-wins); -C still makes it idempotent
+        # so a retried delta never stacks duplicates.
+        return (
+            f'"$IPT"{table_flag} -C OUTPUT {rule} 2>/dev/null || '
+            f'"$IPT"{table_flag} -I OUTPUT {rule}'
+        )
+
     proxy_ip, proxy_port = dnat_target
     # The rule tail after ``-d <ip>`` — byte-identical to the provision-time
     # DNAT shape so -C/-D match the installed rules exactly.
     dnat_tail = f"-p tcp --dport 443 -j DNAT --to-destination {proxy_ip}:{proxy_port}"
+    # The no-DNAT ⇒ no-egress fence tail (#331), byte-identical to the shape the
+    # provision-time apply installs so -C/-D match the installed rules exactly.
+    fence_tail = "-p tcp --dport 443 -j REJECT --reject-with tcp-reset"
     lines = ["set -e", _IPTABLES_BACKEND_SELECT]
     for host in sorted(new_ips):
         added = new_ips[host] - old_ips.get(host, set())
@@ -424,12 +550,24 @@ def build_egress_refresh_script(
                 lines.append(_add("", f"-d {ip} -p tcp --dport 80 -j ACCEPT"))
                 lines.append(_add("", f"-d {ip} -p tcp --dport 443 -j ACCEPT"))
             if host in credential_hosts:
+                # The fence goes in FIRST (insert-at-head, so it precedes any
+                # ACCEPT for the same IP) and only THEN the DNAT. Ordering is a
+                # security property, not cosmetics: between the two statements
+                # the newly learned address must never be in the
+                # allowed-but-unproxied state — install-fence-then-DNAT means
+                # the worst intermediate state is "refused", never "direct
+                # egress with a placeholder" (#331).
+                lines.append(_insert("", f"-d {ip} {fence_tail}"))
                 lines.append(_add(" -t nat", f"-d {ip} {dnat_tail}"))
     for host in sorted(old_ips):
         removed = old_ips[host] - new_ips.get(host, set())
         for ip in sorted(removed):
             if host in credential_hosts:
                 lines.append(_delete(" -t nat", f"-d {ip} {dnat_tail}"))
+                # Fence removed LAST for the same reason: an evicted address
+                # that still has a fence is merely refused; one that has lost
+                # its fence while a stale ACCEPT lingers would be direct egress.
+                lines.append(_delete("", f"-d {ip} {fence_tail}"))
             if host in limited_hosts:
                 lines.append(_delete("", f"-d {ip} -p tcp --dport 80 -j ACCEPT"))
                 lines.append(_delete("", f"-d {ip} -p tcp --dport 443 -j ACCEPT"))
@@ -546,6 +684,14 @@ def build_iptables_script(
         # lockdown script and the Unrestricted DNAT-only script emit a
         # byte-identical rule shape.
         lines.extend(_nat_dnat_lines(dnat_hosts, dnat_target))
+        # …and the fail-closed fence (#331). ``insert=True``: the per-host
+        # ACCEPTs above already cover these IPs on :443 and iptables is
+        # first-match-wins, so the REJECT must be inserted at the HEAD of
+        # OUTPUT to win. A DNATed packet is already rewritten to the proxy by
+        # the time filter runs, so it never matches — only an un-DNATed
+        # (unsampled-IP) credential-host packet does, and it is reset instead
+        # of flowing to the real upstream with a placeholder.
+        lines.extend(_credential_host_fence_lines(dnat_hosts, insert=True))
 
     lines.append("")
     lines.append("# Drop everything else")
@@ -589,9 +735,20 @@ def build_secret_egress_dnat_script(dnat_hosts: Sequence[str], dnat_target: tupl
             "",
             "# Flush nat OUTPUT for idempotent re-apply (do NOT touch filter OUTPUT)",
             '"$IPT" -t nat -F OUTPUT',
+            # Flush ONLY this subsystem's credential-host fence from filter
+            # OUTPUT so the re-apply is idempotent without touching any other
+            # filter rule (the chain is otherwise not ours under Unrestricted).
+            *_credential_host_fence_flush_lines(dnat_hosts),
             *_nat_dnat_lines(dnat_hosts, dnat_target),
+            # The fail-closed fence (#331) applies under Unrestricted too: a
+            # credential host's un-DNATed :443 packet must be refused, not
+            # allowed out by the default-ACCEPT policy carrying a placeholder.
+            # ``insert=False`` (append) is terminal here — this chain carries no
+            # generated ACCEPTs for these IPs to shadow it.
+            *_credential_host_fence_lines(dnat_hosts, insert=False),
             # NO `-P OUTPUT DROP`, NO filter ACCEPTs — the filter policy stays
-            # ACCEPT so general egress remains open under Unrestricted.
+            # ACCEPT so general egress remains open under Unrestricted (except
+            # the credential-host :443 fence above, which is the #331 invariant).
         ]
     )
 
@@ -636,8 +793,11 @@ def build_lockdown_verify_script(
     ``ACCEPT`` and installs no v6 DROP, so there is no DROP (v4 or v6) to assert
     (asserting it would always fail).
 
-    When ``dnat_hosts`` is non-empty it ALSO asserts the nat table carries at
-    least one ``DNAT`` OUTPUT rule. Without this, a credential host whose
+    When ``dnat_hosts`` is non-empty it ALSO asserts (a) the nat table carries
+    at least one ``DNAT`` OUTPUT rule and (b) the filter table carries the
+    credential-host fail-closed fence (a ``--dport 443 -j REJECT`` rule,
+    eumemic/eumemic-ops#331) — so the no-DNAT ⇒ no-egress invariant is proven
+    installed, not assumed. Without this, a credential host whose
     ``getent`` returns zero IPs emits no DNAT rule and no error: apply exits 0,
     a filter-only verify passes, and the session runs WITHOUT DNAT for that host
     — the placeholder goes direct to the real upstream and auth fails with no
@@ -687,6 +847,15 @@ def build_lockdown_verify_script(
         )
     if dnat_hosts:
         lines.append("\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'")
+        # …and the fail-closed fence actually landed (#331). Without this the
+        # no-DNAT ⇒ no-egress invariant would be unverified — the exact "green
+        # verify while open" shape the DROP read-back already closes one layer
+        # up. A credential host whose fence failed to install is a host whose
+        # unsampled pool addresses would egress DIRECTLY with a placeholder, so
+        # a missing fence must fail the provision closed.
+        lines.append(
+            "\"$IPT\" -S OUTPUT | grep -q -- '--dport 443 -j REJECT --reject-with tcp-reset'"
+        )
     return "\n".join(lines)
 
 

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -48,6 +48,7 @@ from aios.sandbox.backends.base import (
     MANAGED_LABEL_KEY,
     MANAGED_LABEL_VALUE,
     SESSION_LABEL_KEY,
+    VAULT_PLACEHOLDER_KEYS_LABEL_KEY,
     Mount,
     SandboxSpec,
 )
@@ -1114,6 +1115,13 @@ def _assemble_plan(
         # unique-bytes accounting.
         ENV_KEYS_LABEL_KEY: ",".join(sorted(merged_env)),
         BASE_IMAGE_LABEL_KEY: image,
+        # The vault-placeholder env keys injected by THIS provision
+        # (eumemic/eumemic-ops#331). Names only — never a placeholder value,
+        # never a credential id. The resume path diffs the snapshot's recorded
+        # set against the current one and explicitly empties any key that is no
+        # longer backed by an active credential, so a resumed container can
+        # never inherit a stale, unexchangeable placeholder from its snapshot.
+        VAULT_PLACEHOLDER_KEYS_LABEL_KEY: ",".join(sorted(placeholder_env)),
     }
 
     # Drift key is stamped from the ATTEMPTED github set (issue #1725):

--- a/tests/unit/sandbox/conftest.py
+++ b/tests/unit/sandbox/conftest.py
@@ -1,4 +1,9 @@
-"""Shared fixtures for the in-sandbox ``bin/tool`` CLI tests.
+"""Shared fixtures for the sandbox unit tests.
+
+Hosts the in-sandbox ``bin/tool`` CLI loader fixture, and re-exports the
+secret-egress-proxy fixtures so more than one module can boot a real proxy
+(``test_secret_egress_proxy`` owns the definitions; the #331 rotation
+acceptance suite consumes them).
 
 The CLI script has no ``.py`` extension and is conventionally invoked
 as an executable; ``importlib.util.spec_from_file_location`` is the
@@ -28,3 +33,12 @@ def tool_module() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+# Re-exported so any module in this package can request a booted proxy by
+# fixture name. The defining module keeps its own copies (an identical
+# module-level shadow), so its behaviour is unchanged.
+from tests.unit.sandbox.test_secret_egress_proxy import (  # noqa: E402, F401
+    crypto_box_runtime,
+    make_proxy,
+)

--- a/tests/unit/sandbox/test_egress_refresh.py
+++ b/tests/unit/sandbox/test_egress_refresh.py
@@ -16,11 +16,7 @@ from aios.sandbox.registry import (
     EgressRefreshState,
     SandboxRegistry,
 )
-from aios.sandbox.setup import (
-    EGRESS_RESOLVE_PROBES,
-    build_egress_refresh_script,
-    build_egress_resolve_script,
-)
+from aios.sandbox.setup import build_egress_refresh_script
 from tests.helpers.sandbox import FakeBackend, make_handle
 
 _PROXY = ("172.18.0.2", 49152)
@@ -321,42 +317,3 @@ async def test_stamp_seeds_pinned_and_proxy_target_from_live_rules() -> None:
     state = registry._egress_states["sess_X"]
     assert state.pinned == {"api.github.com": {"1.1.1.1": 0}}
     assert (state.proxy_ip, state.proxy_port) == _PROXY
-
-
-# ── DNS-pin drift (eumemic/eumemic-ops#331 fix C) ───────────────────────────
-
-
-def test_resolve_script_probes_each_host_several_times() -> None:
-    """A rotating pool (api.github.com, ~60s TTL) returns only a SUBSET of the
-    live addresses per query. Pinning ONE query's answer leaves the sandbox
-    free to resolve an address with no DNAT rule, which bypasses the secret
-    proxy entirely and sends the literal placeholder to GitHub. Sampling the
-    pool several times per sweep is what makes the pinned set converge on the
-    union of the recently-served addresses."""
-    script = build_egress_resolve_script(["api.github.com"])
-
-    assert f"seq 1 {EGRESS_RESOLVE_PROBES}" in script
-    assert EGRESS_RESOLVE_PROBES > 1, "a single probe is the bug this closes"
-    # Still one machine-readable "<host> <ip>" row per answer, so the caller's
-    # parser (which collects into a set) is unchanged and dedupes for free.
-    assert "printf '%s %s\\n' api.github.com" in script
-
-
-def test_resolve_script_probe_count_is_overridable_and_covers_every_host() -> None:
-    script = build_egress_resolve_script(["api.github.com", "codeload.github.com"], probes=2)
-
-    assert script.count("seq 1 2") == 2
-    for host in ("api.github.com", "codeload.github.com"):
-        assert f"resolve_ipv4 {host}" in script
-
-
-def test_resolve_script_still_fails_closed_on_a_miss() -> None:
-    """Multi-probing must not turn a resolution miss into anything but silence:
-    no rows printed ⇒ the merge keeps the last-good pins (asserted by
-    ``test_resolve_miss_retains_last_good_and_skips_refresh_sidecar``) rather
-    than evicting the placeholder's only route."""
-    script = build_egress_resolve_script(["api.github.com"])
-
-    # ``resolve_ipv4`` emitting nothing makes the inner for-loop a no-op; there
-    # is no fallback/echo that could fabricate an address.
-    assert "|| true" not in script.split("resolve_ipv4 api.github.com")[1]

--- a/tests/unit/sandbox/test_egress_refresh.py
+++ b/tests/unit/sandbox/test_egress_refresh.py
@@ -16,7 +16,11 @@ from aios.sandbox.registry import (
     EgressRefreshState,
     SandboxRegistry,
 )
-from aios.sandbox.setup import build_egress_refresh_script
+from aios.sandbox.setup import (
+    EGRESS_RESOLVE_PROBES,
+    build_egress_refresh_script,
+    build_egress_resolve_script,
+)
 from tests.helpers.sandbox import FakeBackend, make_handle
 
 _PROXY = ("172.18.0.2", 49152)
@@ -317,3 +321,42 @@ async def test_stamp_seeds_pinned_and_proxy_target_from_live_rules() -> None:
     state = registry._egress_states["sess_X"]
     assert state.pinned == {"api.github.com": {"1.1.1.1": 0}}
     assert (state.proxy_ip, state.proxy_port) == _PROXY
+
+
+# ── DNS-pin drift (eumemic/eumemic-ops#331 fix C) ───────────────────────────
+
+
+def test_resolve_script_probes_each_host_several_times() -> None:
+    """A rotating pool (api.github.com, ~60s TTL) returns only a SUBSET of the
+    live addresses per query. Pinning ONE query's answer leaves the sandbox
+    free to resolve an address with no DNAT rule, which bypasses the secret
+    proxy entirely and sends the literal placeholder to GitHub. Sampling the
+    pool several times per sweep is what makes the pinned set converge on the
+    union of the recently-served addresses."""
+    script = build_egress_resolve_script(["api.github.com"])
+
+    assert f"seq 1 {EGRESS_RESOLVE_PROBES}" in script
+    assert EGRESS_RESOLVE_PROBES > 1, "a single probe is the bug this closes"
+    # Still one machine-readable "<host> <ip>" row per answer, so the caller's
+    # parser (which collects into a set) is unchanged and dedupes for free.
+    assert "printf '%s %s\\n' api.github.com" in script
+
+
+def test_resolve_script_probe_count_is_overridable_and_covers_every_host() -> None:
+    script = build_egress_resolve_script(["api.github.com", "codeload.github.com"], probes=2)
+
+    assert script.count("seq 1 2") == 2
+    for host in ("api.github.com", "codeload.github.com"):
+        assert f"resolve_ipv4 {host}" in script
+
+
+def test_resolve_script_still_fails_closed_on_a_miss() -> None:
+    """Multi-probing must not turn a resolution miss into anything but silence:
+    no rows printed ⇒ the merge keeps the last-good pins (asserted by
+    ``test_resolve_miss_retains_last_good_and_skips_refresh_sidecar``) rather
+    than evicting the placeholder's only route."""
+    script = build_egress_resolve_script(["api.github.com"])
+
+    # ``resolve_ipv4`` emitting nothing makes the inner for-loop a no-op; there
+    # is no fallback/echo that could fabricate an address.
+    assert "|| true" not in script.split("resolve_ipv4 api.github.com")[1]

--- a/tests/unit/sandbox/test_placeholder_rotation_331.py
+++ b/tests/unit/sandbox/test_placeholder_rotation_331.py
@@ -489,12 +489,88 @@ class TestPlaceholderShapeIsBounded:
         assert len(captured) == 1
 
     @pytest.mark.asyncio
+    async def test_legitimate_delimited_placeholder_shaped_payload_is_refused_by_design(
+        self, cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """THE DELIBERATE TRADE (the MEDIUM finding), pinned as a trade.
+
+        This is a FALSE POSITIVE and we are keeping it. The body below is
+        innocent payload — a log line being shipped to an API that happens to
+        quote a whole, delimited placeholder — and it is refused with 421.
+
+        Why refusing is correct rather than merely convenient:
+
+        * The scan runs POST-swap, so provenance is gone. An unexchangeable
+          placeholder and a placeholder-shaped literal the sandbox typed are
+          the same bytes in the same position; nothing left in the request
+          separates them. Any narrowing (allow it in bodies but not headers,
+          key on content type, ...) would be a GUESS about intent, and a fence
+          that guesses is a fence an unlucky miss walks through.
+        * The errors are not symmetric. This refusal costs a loud, local 421
+          whose body names the cause and the workaround. The other direction
+          puts a credential-shaped token on the wire and draws a 401 that
+          cannot be told apart from a bad secret — the silent misdiagnosis
+          eumemic/eumemic-ops#331 exists to end.
+
+        So the assertions here are about the COST BEING PAID WELL, not about
+        the refusal being desirable: the caller must be told exactly what
+        happened, and a workaround must exist.
+        """
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([cred])
+        legitimate_payload = b'{"log": "worker booted with TOKEN=' + PH_A.encode() + b' (masked)"}'
+        res = await _request(
+            proxy, "api.github.com", "/graphql", method="POST", content=legitimate_payload
+        )
+
+        # Fail closed on ambiguity: not sent, even though it was innocent.
+        assert res.status_code == 421
+        assert captured == [], "the ambiguous request must not reach the upstream"
+        # The cost is only acceptable because it is SELF-EXPLAINING: the caller
+        # must learn that the shape is what tripped it and that encoding is the
+        # way out, without reading our source.
+        assert res.headers["x-aios-egress-error"] == "placeholder_substitution_failed"
+        assert "SHAPE" in res.text, "the refusal must say it keys on the shape"
+        assert "deliberate" in res.text, "...and that the false positive is intended"
+        assert "base64" in res.text, "...and name the workaround"
+
+    @pytest.mark.asyncio
+    async def test_the_documented_workaround_actually_works(
+        self, cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """The trade is only defensible if the refusal body's advice is true.
+
+        The 421 tells the caller to encode or redact placeholder-shaped
+        payload. Assert that a caller who does so gets through — otherwise the
+        false positive is an unfixable dead end rather than a cost with a
+        remedy.
+        """
+        import base64
+
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([cred])
+        encoded = base64.b64encode(PH_A.encode())
+        res = await _request(
+            proxy,
+            "api.github.com",
+            "/graphql",
+            method="POST",
+            content=b'{"log": "' + encoded + b'"}',
+        )
+
+        assert res.status_code == 200, "the workaround the refusal advertises must work"
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
     async def test_a_delimited_placeholder_in_prose_is_still_refused(
         self, cred: ResolvedEnvVarCredential, make_proxy: Any
     ) -> None:
-        """The relaxation is bounded: a WHOLE placeholder surrounded by ordinary
-        delimiters (quotes, spaces, JSON punctuation) is still a miss — that is
-        how it appears in every real transport."""
+        """The boundary relaxation is bounded: a WHOLE placeholder surrounded by
+        ordinary delimiters (quotes, spaces, JSON punctuation) is still refused
+        — that is how a genuine substitution miss appears in every real
+        transport, so relaxing here would reopen the bug."""
         from tests.unit.sandbox.test_secret_egress_proxy import _request
 
         proxy, captured = await make_proxy([cred])

--- a/tests/unit/sandbox/test_placeholder_rotation_331.py
+++ b/tests/unit/sandbox/test_placeholder_rotation_331.py
@@ -418,9 +418,7 @@ class TestUnexchangeablePlaceholderIsRefused:
 
         proxy, captured = await make_proxy([cred])
         with caplog.at_level(logging.WARNING):
-            res = await _request(
-                proxy, "api.github.com", "/user", headers={"Authorization": PH_B}
-            )
+            res = await _request(proxy, "api.github.com", "/user", headers={"Authorization": PH_B})
 
         assert res.status_code == 421, "an indistinguishable residual must fail closed"
         assert captured == []
@@ -485,9 +483,7 @@ class TestPlaceholderShapeIsBounded:
 
         proxy, captured = await make_proxy([cred])
         body = b"see AIOS_SECRET_PLACEHOLDER_notactuallyhex and " + PH_A.encode() + b"0123"
-        res = await _request(
-            proxy, "api.github.com", "/graphql", method="POST", content=body
-        )
+        res = await _request(proxy, "api.github.com", "/graphql", method="POST", content=body)
 
         assert res.status_code == 200
         assert len(captured) == 1

--- a/tests/unit/sandbox/test_placeholder_rotation_331.py
+++ b/tests/unit/sandbox/test_placeholder_rotation_331.py
@@ -24,6 +24,7 @@ import pytest
 
 from aios.models.environments import UnrestrictedNetworking
 from aios.sandbox.backends.base import (
+    ENV_KEYS_LABEL_KEY,
     VAULT_PLACEHOLDER_KEYS_LABEL_KEY,
     Mount,
     SandboxSpec,
@@ -147,18 +148,52 @@ class TestResumeRebindsPlaceholders:
         assert resolved.environment[SECRET_NAME] == ""
 
     @pytest.mark.asyncio
-    async def test_pre_331_snapshot_without_the_label_still_resumes(self) -> None:
+    async def test_pre_331_snapshot_with_env_inventory_is_scrubbed(self) -> None:
         """A snapshot committed before this fix carries no placeholder-keys
-        label. It must still resume (no crash, no spurious cold start); the
-        current provision's own ``--env`` still overrides every key it injects."""
+        label, so the stale-key diff has nothing to diff against. Treating that
+        as "nothing to neutralize" would PRESERVE the original vulnerability
+        for exactly the population that has it — a pre-#331 snapshot is
+        precisely the artifact that may have baked a placeholder for a
+        since-archived credential.
+
+        When the snapshot records its env-key inventory (``aios.env_keys``,
+        which predates #331), every recorded key the current provision does not
+        re-inject is emptied — scrubbing on SHAPE instead of on name.
+        """
         backend = FakeBackend()
-        backend.image_labels_by_ref[REF] = {"aios.base_image": BASE_IMAGE}
+        backend.image_labels_by_ref[REF] = {
+            "aios.base_image": BASE_IMAGE,
+            ENV_KEYS_LABEL_KEY: f"{SECRET_NAME},UNRELATED",
+        }
         reg = SandboxRegistry(backend=backend)
 
-        resolved = await reg._resolve_snapshot(OWNER, _spec({SECRET_NAME: PH_B}))
+        # The archived-and-not-replaced case: SECRET_NAME is absent from the
+        # current provision's env, so nothing would override the baked value.
+        resolved = await reg._resolve_snapshot(OWNER, _spec({}))
+
+        assert resolved.snapshot_image == REF, "a scrubbable snapshot still resumes"
+        assert resolved.environment[SECRET_NAME] == "", "the stale baked key must be emptied"
+        assert PH_A not in resolved.environment.values()
+
+    @pytest.mark.asyncio
+    async def test_pre_331_snapshot_with_env_inventory_keeps_reinjected_keys(self) -> None:
+        """The scrub is a superset of the placeholder keys, but a key the
+        CURRENT provision re-injects has a legitimate claim to survive (its
+        ``--env`` overrides the baked value anyway) and must not be emptied."""
+        backend = FakeBackend()
+        backend.image_labels_by_ref[REF] = {
+            "aios.base_image": BASE_IMAGE,
+            ENV_KEYS_LABEL_KEY: f"{SECRET_NAME},UNRELATED",
+        }
+        reg = SandboxRegistry(backend=backend)
+
+        resolved = await reg._resolve_snapshot(
+            OWNER, _spec({SECRET_NAME: PH_B, "UNRELATED": "keep-me"})
+        )
 
         assert resolved.snapshot_image == REF
         assert resolved.environment[SECRET_NAME] == PH_B
+        assert resolved.environment["UNRELATED"] == "keep-me"
 
 
 def test_provision_stamps_the_placeholder_keys_label() -> None:
@@ -314,3 +349,166 @@ class TestUnexchangeablePlaceholderIsRefused:
 
         assert res.status_code == 200
         assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_placeholder_in_query_string_is_refused(
+        self, rotated_cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """The request TARGET is never swapped (it is forwarded verbatim), so a
+        placeholder in a query parameter could only ever be transmitted
+        LITERALLY — the exact leak the fence exists to stop, one field over.
+
+        Refuse before any upstream connection opens rather than forwarding.
+        """
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([rotated_cred])
+        res = await _request(proxy, "api.github.com", f"/user?access_token={PH_A}")
+
+        assert res.status_code == 421
+        assert res.headers["x-aios-egress-error"] == "placeholder_substitution_failed"
+        assert captured == [], "a query-string placeholder must never reach the upstream"
+
+    @pytest.mark.asyncio
+    async def test_live_placeholder_in_query_string_is_also_refused(
+        self, rotated_cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """Even the CURRENT placeholder is refused in the target: the proxy
+        cannot swap it there (URLs are forwarded verbatim), so forwarding would
+        transmit a literal placeholder and reaching upstream with it is the bug.
+        Refusal is the honest outcome — and it names the fix in the body."""
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([rotated_cred])
+        res = await _request(proxy, "api.github.com", f"/user?access_token={PH_B}")
+
+        assert res.status_code == 421
+        assert captured == []
+        assert "QUERY" in res.text, "the refusal must tell the caller why a URL token cannot work"
+
+    @pytest.mark.asyncio
+    async def test_refusal_log_never_carries_request_derived_bytes(
+        self,
+        rotated_cred: ResolvedEnvVarCredential,
+        make_proxy: Any,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """THE CRITICAL PROPERTY: the residual scan runs POST-swap, so its input
+        contains REAL SECRETS.
+
+        A vault secret is arbitrary operator-supplied text — nothing stops one
+        from having the placeholder shape. Here the live credential's REAL
+        VALUE is placeholder-shaped, so a SUCCESSFUL substitution looks residual
+        to the scanner and the request is refused (fail-closed, correct). The
+        thing that must never happen is the refusal log writing the real
+        credential — so assert no request-derived bytes reach the logs at all.
+        """
+        import logging
+
+        shaped_secret = SECRET_PLACEHOLDER_PREFIX + "f" * 32
+        cred = ResolvedEnvVarCredential(
+            credential_id=CRED_B_ID,
+            secret_name=SECRET_NAME,
+            secret_value=shaped_secret,
+            allowed_hosts=("api.github.com",),
+            updated_at=datetime(2026, 7, 13, tzinfo=UTC),
+            placeholder=PH_B,
+        )
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([cred])
+        with caplog.at_level(logging.WARNING):
+            res = await _request(
+                proxy, "api.github.com", "/user", headers={"Authorization": PH_B}
+            )
+
+        assert res.status_code == 421, "an indistinguishable residual must fail closed"
+        assert captured == []
+        logged = "\n".join(
+            [record.getMessage() for record in caplog.records]
+            + [str(record.__dict__) for record in caplog.records]
+        )
+        assert "placeholder_substitution_failed" in logged, "the refusal must still be visible"
+        # The real secret — and every prefix of it long enough to be useful —
+        # must be absent. A prefix of a secret is still secret material.
+        assert shaped_secret not in logged
+        assert shaped_secret[: len(SECRET_PLACEHOLDER_PREFIX) + 8] not in logged
+        # The region label is a constant from a closed vocabulary, so it is the
+        # one scan-derived thing that may appear.
+        assert "authorization_header" in logged
+
+
+class TestPlaceholderShapeIsBounded:
+    """Finding 5: the fence keys on the MINTED placeholder shape, anchored, so
+    traffic that merely CONTAINS a placeholder-shaped substring inside a longer
+    opaque token is not collateral damage."""
+
+    @pytest.fixture
+    def cred(self) -> ResolvedEnvVarCredential:
+        return ResolvedEnvVarCredential(
+            credential_id=CRED_B_ID,
+            secret_name=SECRET_NAME,
+            secret_value=SECRET_VALUE,
+            allowed_hosts=("api.github.com",),
+            updated_at=datetime(2026, 7, 13, tzinfo=UTC),
+            placeholder=PH_B,
+        )
+
+    @pytest.mark.asyncio
+    async def test_longer_token_embedding_the_shape_is_not_refused(
+        self, cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """A 33rd hex char makes it a DIFFERENT token, not a placeholder. An
+        unanchored match would find a 32-char window inside it and refuse
+        legitimate traffic; a real minted placeholder is always delimited."""
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([cred])
+        res = await _request(
+            proxy,
+            "api.github.com",
+            "/user",
+            headers={"Authorization": f"Bearer {PH_A}deadbeef"},
+        )
+
+        assert res.status_code == 200, "a longer opaque token must not be refused"
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_placeholder_shaped_substring_in_a_body_is_not_refused(
+        self, cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """Code samples and user data may legitimately mention the prefix (docs,
+        a diff, a log line being uploaded). Only a whole, delimited placeholder
+        is a substitution miss."""
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([cred])
+        body = b"see AIOS_SECRET_PLACEHOLDER_notactuallyhex and " + PH_A.encode() + b"0123"
+        res = await _request(
+            proxy, "api.github.com", "/graphql", method="POST", content=body
+        )
+
+        assert res.status_code == 200
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_delimited_placeholder_in_prose_is_still_refused(
+        self, cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """The relaxation is bounded: a WHOLE placeholder surrounded by ordinary
+        delimiters (quotes, spaces, JSON punctuation) is still a miss — that is
+        how it appears in every real transport."""
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([cred])
+        res = await _request(
+            proxy,
+            "api.github.com",
+            "/graphql",
+            method="POST",
+            content=b'{"token": "' + PH_A.encode() + b'"}',
+        )
+
+        assert res.status_code == 421
+        assert captured == []

--- a/tests/unit/sandbox/test_placeholder_rotation_331.py
+++ b/tests/unit/sandbox/test_placeholder_rotation_331.py
@@ -1,0 +1,316 @@
+"""Acceptance coverage for eumemic/eumemic-ops#331 (formerly eumemic/aios#1933).
+
+The reported symptom was an intermittent ``401 Bad credentials`` from
+api.github.com that "retrying fixes". Two independent mechanisms could put the
+LITERAL ``AIOS_SECRET_PLACEHOLDER_…`` string on the wire, and because the
+remote then answered 401, a substitution miss was indistinguishable from a
+genuinely bad secret:
+
+* **stale placeholder on resume** — placeholders are keyed on CREDENTIAL ID, so
+  a rotated/recreated credential leaves a resumed sandbox holding a placeholder
+  bound to a dead id;
+* **silent passthrough** — the egress proxy forwarded an unexchangeable
+  placeholder verbatim instead of refusing it.
+
+These tests pin the two acceptance criteria from the issue.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import pytest
+
+from aios.models.environments import UnrestrictedNetworking
+from aios.sandbox.backends.base import (
+    VAULT_PLACEHOLDER_KEYS_LABEL_KEY,
+    Mount,
+    SandboxSpec,
+)
+from aios.sandbox.registry import SandboxRegistry
+from aios.services.vaults import (
+    SECRET_PLACEHOLDER_PREFIX,
+    ResolvedEnvVarCredential,
+    mint_secret_placeholder,
+)
+from tests.helpers.sandbox import FakeBackend
+
+SALT = bytes(range(32))
+OWNER = "sess_x"
+SECRET_NAME = "GITHUB_TOKEN"
+REF = "aios-sbx-default-sess_x:latest"
+BASE_IMAGE = "ghcr.io/eumemic/aios-sandbox:latest"
+
+# Credential A is archived and recreated as B with the SAME secret value and
+# the SAME allowed_hosts — only the credential id differs. That is exactly the
+# rotation shape from the RCA, and it is why the placeholder (a pure function
+# of the credential id) changes even though nothing user-visible did.
+CRED_A_ID = "vcred_01AAAA"
+CRED_B_ID = "vcred_01BBBB"
+SECRET_VALUE = "ghp_THE_REAL_SECRET"
+
+
+def _placeholder(credential_id: str) -> str:
+    return mint_secret_placeholder(SALT, OWNER, credential_id)
+
+
+PH_A = _placeholder(CRED_A_ID)
+PH_B = _placeholder(CRED_B_ID)
+
+
+def _spec(environment: dict[str, str], snapshot_image: str | None = REF) -> SandboxSpec:
+    return SandboxSpec(
+        session_id=OWNER,
+        instance_id="default",
+        workspace=Mount(host_path=cast(Any, "/tmp/w"), sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment=environment,
+        labels={},
+        network_policy=UnrestrictedNetworking(),
+        host_gateway_alias=None,
+        image=BASE_IMAGE,
+        snapshot_image=snapshot_image,
+    )
+
+
+def test_rotation_mints_a_new_placeholder_for_the_same_secret_name() -> None:
+    """The premise of the whole defect: identical secret + hosts, new id ⇒ new
+    placeholder. If this ever stopped holding, the resume path below would be
+    testing nothing."""
+    assert PH_A != PH_B
+    assert PH_A.startswith(SECRET_PLACEHOLDER_PREFIX)
+    assert PH_B.startswith(SECRET_PLACEHOLDER_PREFIX)
+    # Deterministic: re-deriving is idempotent, so re-injection is safe to do
+    # unconditionally on every start.
+    assert _placeholder(CRED_B_ID) == PH_B
+
+
+class TestResumeRebindsPlaceholders:
+    """Acceptance test 1: credential A works → archive/recreate as B → resume an
+    EXISTING snapshot → the env placeholder maps to B, and A's placeholder is
+    absent from the resumed env."""
+
+    @pytest.fixture
+    def registry(self) -> tuple[SandboxRegistry, FakeBackend]:
+        backend = FakeBackend()
+        # The snapshot was committed by a provision that injected credential A.
+        backend.image_labels_by_ref[REF] = {
+            "aios.base_image": BASE_IMAGE,
+            VAULT_PLACEHOLDER_KEYS_LABEL_KEY: SECRET_NAME,
+        }
+        return SandboxRegistry(backend=backend), backend
+
+    @pytest.mark.asyncio
+    async def test_resumed_env_carries_b_and_never_a(
+        self, registry: tuple[SandboxRegistry, FakeBackend]
+    ) -> None:
+        reg, _backend = registry
+        # The provision that is resuming re-resolved the session's CURRENTLY
+        # bound credentials, so the spec already carries B's placeholder.
+        resolved = await reg._resolve_snapshot(OWNER, _spec({SECRET_NAME: PH_B}))
+
+        assert resolved.snapshot_image == REF, "a valid snapshot must still resume"
+        assert resolved.environment[SECRET_NAME] == PH_B
+        # The old placeholder must not survive anywhere in the resumed env —
+        # this is the assertion the issue asks for by name.
+        assert PH_A not in resolved.environment.values()
+
+    @pytest.mark.asyncio
+    async def test_archived_credential_key_is_emptied_not_inherited(
+        self, registry: tuple[SandboxRegistry, FakeBackend]
+    ) -> None:
+        """The residual hole: credential A is archived and NOT replaced.
+
+        Its ``secret_name`` drops out of the current placeholder set, so no
+        ``--env`` would override the value baked into the snapshot and the
+        resumed container would inherit A's dead placeholder. The key must be
+        explicitly emptied instead — and emptied, not merely absent, because
+        only an explicit ``--env K=`` overrides a baked ``ENV K=<stale>``.
+        """
+        reg, _backend = registry
+        resolved = await reg._resolve_snapshot(OWNER, _spec({}))
+
+        assert resolved.environment[SECRET_NAME] == ""
+        assert PH_A not in resolved.environment.values()
+
+    @pytest.mark.asyncio
+    async def test_unrelated_env_is_untouched(
+        self, registry: tuple[SandboxRegistry, FakeBackend]
+    ) -> None:
+        """Only keys the snapshot recorded as VAULT placeholders are neutralized;
+        ordinary session/operator env is not collateral damage."""
+        reg, _backend = registry
+        resolved = await reg._resolve_snapshot(OWNER, _spec({"UNRELATED": "keep-me"}))
+
+        assert resolved.environment["UNRELATED"] == "keep-me"
+        assert resolved.environment[SECRET_NAME] == ""
+
+    @pytest.mark.asyncio
+    async def test_pre_331_snapshot_without_the_label_still_resumes(self) -> None:
+        """A snapshot committed before this fix carries no placeholder-keys
+        label. It must still resume (no crash, no spurious cold start); the
+        current provision's own ``--env`` still overrides every key it injects."""
+        backend = FakeBackend()
+        backend.image_labels_by_ref[REF] = {"aios.base_image": BASE_IMAGE}
+        reg = SandboxRegistry(backend=backend)
+
+        resolved = await reg._resolve_snapshot(OWNER, _spec({SECRET_NAME: PH_B}))
+
+        assert resolved.snapshot_image == REF
+        assert resolved.environment[SECRET_NAME] == PH_B
+
+
+def test_provision_stamps_the_placeholder_keys_label() -> None:
+    """The resume-time neutralization is only as good as the label it reads, so
+    pin that provision actually records the injected placeholder key NAMES —
+    and records names only, never a placeholder value or a credential id."""
+    cred = ResolvedEnvVarCredential(
+        credential_id=CRED_B_ID,
+        secret_name=SECRET_NAME,
+        secret_value=SECRET_VALUE,
+        allowed_hosts=("api.github.com",),
+        updated_at=datetime(2026, 7, 13, tzinfo=UTC),
+        placeholder=PH_B,
+    )
+    labels = _labels_for(cred)
+
+    assert labels[VAULT_PLACEHOLDER_KEYS_LABEL_KEY] == SECRET_NAME
+    serialized = "\x00".join(f"{k}={v}" for k, v in labels.items())
+    assert PH_B not in serialized, "a label must never carry a placeholder value"
+    assert CRED_B_ID not in serialized, "a label must never carry a credential id"
+    assert SECRET_VALUE not in serialized, "a label must never carry the secret"
+
+
+def _labels_for(cred: ResolvedEnvVarCredential) -> dict[str, str]:
+    """Build a spec through the real assembler and return its labels."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from aios.sandbox.spec import build_spec_from_session
+    from tests.helpers.sandbox import limited_env, patch_build_spec_deps
+
+    async def _run() -> dict[str, str]:
+        bundle = patch_build_spec_deps(
+            env_config=limited_env("api.github.com"),
+            env_var_credentials=AsyncMock(return_value=(cred,)),
+        )
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for ctx in bundle:
+                stack.enter_context(ctx)
+            plan = await build_spec_from_session(OWNER)
+        return dict(plan.spec.labels)
+
+    return asyncio.run(_run())
+
+
+class TestUnexchangeablePlaceholderIsRefused:
+    """Acceptance test 2: a request carrying an unexchangeable placeholder
+    produces the explicit substitution-failure error and NEVER transmits the
+    literal placeholder upstream.
+
+    Boots the REAL proxy (real TLS, real h11 framing) with the mock upstream
+    from the proxy suite, so "never transmitted" is proven by an empty upstream
+    request log rather than by inspecting a rewritten buffer.
+    """
+
+    @pytest.fixture
+    def rotated_cred(self) -> ResolvedEnvVarCredential:
+        """The post-rotation state: the proxy knows credential B only."""
+        return ResolvedEnvVarCredential(
+            credential_id=CRED_B_ID,
+            secret_name=SECRET_NAME,
+            secret_value=SECRET_VALUE,
+            allowed_hosts=("api.github.com",),
+            updated_at=datetime(2026, 7, 13, tzinfo=UTC),
+            placeholder=PH_B,
+        )
+
+    @pytest.mark.asyncio
+    async def test_dead_placeholder_refused_and_live_one_still_works(
+        self, rotated_cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([rotated_cred])
+
+        # A sandbox that resumed WITHOUT the fix still holds A's placeholder.
+        # Pre-#331 this rode out to GitHub verbatim and came back 401 "Bad
+        # credentials" — an upstream verdict on a credential GitHub never
+        # actually received. Now it is refused before any connection opens.
+        dead = await _request(proxy, "api.github.com", "/user", headers={"Authorization": PH_A})
+
+        assert dead.status_code == 421
+        assert dead.status_code != 401, "must not be conflatable with an upstream auth verdict"
+        assert dead.headers["x-aios-egress-error"] == "placeholder_substitution_failed"
+        assert "placeholder substitution failed" in dead.text
+        assert captured == [], "the literal placeholder must never reach the upstream"
+
+        # ...and the CURRENT placeholder still swaps to the real secret, so the
+        # fence refuses only genuine misses. This is the "B authenticates"
+        # half of the acceptance criterion.
+        live = await _request(proxy, "api.github.com", "/user", headers={"Authorization": PH_B})
+
+        assert live.status_code == 200
+        assert len(captured) == 1
+        assert captured[0].headers["authorization"] == SECRET_VALUE
+        assert PH_B not in str(captured[0].headers)
+
+    @pytest.mark.asyncio
+    async def test_dead_placeholder_in_body_is_refused(
+        self, rotated_cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """Bodies are swapped too, so they are scanned too — a placeholder is
+        just as leaked in a JSON payload as in a header."""
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([rotated_cred])
+        res = await _request(
+            proxy,
+            "api.github.com",
+            "/graphql",
+            method="POST",
+            content=b'{"token": "' + PH_A.encode() + b'"}',
+        )
+
+        assert res.status_code == 421
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_dead_placeholder_inside_basic_auth_is_refused(
+        self, rotated_cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """git-over-HTTPS sends the token as a Basic password, where base64
+        shifts the byte boundaries — the case a naive substring scan misses,
+        and the exact transport in the original report."""
+        import base64
+
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([rotated_cred])
+        blob = base64.b64encode(f"x-access-token:{PH_A}".encode()).decode()
+        res = await _request(
+            proxy, "api.github.com", "/user", headers={"Authorization": f"Basic {blob}"}
+        )
+
+        assert res.status_code == 421
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_clean_request_without_placeholders_is_unaffected(
+        self, rotated_cred: ResolvedEnvVarCredential, make_proxy: Any
+    ) -> None:
+        """The fence is scoped to the placeholder shape: ordinary traffic
+        through the proxy (including a caller's own unrelated bearer token) is
+        untouched."""
+        from tests.unit.sandbox.test_secret_egress_proxy import _request
+
+        proxy, captured = await make_proxy([rotated_cred])
+        res = await _request(
+            proxy, "api.github.com", "/user", headers={"Authorization": "Bearer not-a-placeholder"}
+        )
+
+        assert res.status_code == 200
+        assert len(captured) == 1

--- a/tests/unit/sandbox/test_placeholder_rotation_331.py
+++ b/tests/unit/sandbox/test_placeholder_rotation_331.py
@@ -148,6 +148,60 @@ class TestResumeRebindsPlaceholders:
         assert resolved.environment[SECRET_NAME] == ""
 
     @pytest.mark.asyncio
+    async def test_present_but_empty_label_scrubs_nothing_and_resumes(self) -> None:
+        """A PRESENT-but-EMPTY placeholder label is EVIDENCE, not ignorance.
+
+        Every post-#331 provision stamps ``aios.vault_placeholder_keys``, and it
+        stamps the empty string when the sandbox had no vault env credentials to
+        inject. That snapshot positively recorded that it baked NO placeholder,
+        so there is nothing to neutralize: resume unchanged and leave the baked
+        env alone.
+
+        The bug this pins is conflating present-empty with ABSENT (both parse to
+        ``[]``). Down the legacy path this snapshot's ``aios.env_keys`` entries
+        that the current provision does not re-inject would be needlessly
+        emptied — collateral damage to a sandbox that was already proven clean.
+        """
+        backend = FakeBackend()
+        backend.image_labels_by_ref[REF] = {
+            "aios.base_image": BASE_IMAGE,
+            # Stamped, and stamped EMPTY: no vault env credentials at provision.
+            VAULT_PLACEHOLDER_KEYS_LABEL_KEY: "",
+            ENV_KEYS_LABEL_KEY: f"{SECRET_NAME},UNRELATED",
+        }
+        reg = SandboxRegistry(backend=backend)
+
+        resolved = await reg._resolve_snapshot(OWNER, _spec({}))
+
+        assert resolved.snapshot_image == REF, "a verified-clean snapshot must resume"
+        # NOT emptied: the label proves no placeholder was baked, so the legacy
+        # shape-based scrub must not fire.
+        assert SECRET_NAME not in resolved.environment
+        assert "UNRELATED" not in resolved.environment
+        assert resolved.environment == {}
+
+    @pytest.mark.asyncio
+    async def test_present_but_empty_label_with_no_env_inventory_still_resumes(self) -> None:
+        """The costly half of the same conflation: a present-empty label with NO
+        ``aios.env_keys`` would fall into the opaque branch and COLD-START,
+        discarding the user's sandbox filesystem to defend against a stale
+        placeholder the label already proved is not there.
+
+        Absent-label opacity is unknowable provenance; present-empty is a
+        verified empty set. Only the first justifies losing filesystem state."""
+        backend = FakeBackend()
+        backend.image_labels_by_ref[REF] = {
+            "aios.base_image": BASE_IMAGE,
+            VAULT_PLACEHOLDER_KEYS_LABEL_KEY: "",
+        }
+        reg = SandboxRegistry(backend=backend)
+
+        resolved = await reg._resolve_snapshot(OWNER, _spec({"UNRELATED": "keep-me"}))
+
+        assert resolved.snapshot_image == REF, "no cold start: the label is present and empty"
+        assert resolved.environment == {"UNRELATED": "keep-me"}
+
+    @pytest.mark.asyncio
     async def test_pre_331_snapshot_with_env_inventory_is_scrubbed(self) -> None:
         """A snapshot committed before this fix carries no placeholder-keys
         label, so the stale-key diff has nothing to diff against. Treating that

--- a/tests/unit/sandbox/test_secret_egress_proxy.py
+++ b/tests/unit/sandbox/test_secret_egress_proxy.py
@@ -251,14 +251,26 @@ class TestSwapForwarding:
         )
         assert captured[0].content == b'{"token":"ghp_REALSECRET"}'
 
-    async def test_url_path_and_query_not_swapped(
+    async def test_url_path_and_query_not_swapped_and_therefore_refused(
         self, gh_proxy: tuple[SecretEgressProxy, list[httpx.Request]]
     ) -> None:
+        """The request target is still never SWAPPED — but it is no longer
+        forwarded either (eumemic/eumemic-ops#331).
+
+        This test previously pinned the placeholder riding through the URL
+        verbatim. That is exactly the leak: an unswappable placeholder in a
+        path or query parameter reaches the upstream LITERALLY, and (worse) a
+        sandbox that puts a credential in ``?access_token=`` gets it
+        transmitted in the clear to the real host. Since the target cannot be
+        swapped, the only safe handling is refusal, so the residual fence scans
+        it too and no upstream connection is opened.
+        """
         proxy, captured = gh_proxy
-        await _request(proxy, "api.allowed.test", f"/v1/{PH_GH}?token={PH_GH}")
-        # The placeholder rides through the URL verbatim — never swapped there.
-        assert PH_GH in str(captured[0].url)
-        assert "ghp_REALSECRET" not in str(captured[0].url)
+        res = await _request(proxy, "api.allowed.test", f"/v1/{PH_GH}?token={PH_GH}")
+
+        assert res.status_code == 421
+        assert res.headers["x-aios-egress-error"] == "placeholder_substitution_failed"
+        assert captured == [], "an unswappable URL placeholder must never be forwarded"
 
     async def test_pins_resolved_ip_and_keeps_sni_on_hostname(
         self, gh_proxy: tuple[SecretEgressProxy, list[httpx.Request]]

--- a/tests/unit/sandbox/test_secret_egress_proxy.py
+++ b/tests/unit/sandbox/test_secret_egress_proxy.py
@@ -32,6 +32,9 @@ from aios.pinned_transport import resolve_pinned_ip
 from aios.sandbox import secret_egress_proxy as sep
 from aios.sandbox.egress_ca import get_egress_ca
 from aios.sandbox.secret_egress_proxy import (
+    PLACEHOLDER_SUBSTITUTION_FAILED_CODE,
+    PLACEHOLDER_SUBSTITUTION_FAILED_HEADER,
+    PLACEHOLDER_SUBSTITUTION_FAILED_STATUS,
     SecretEgressProxy,
     _path_within_prefix,
     _request_path,
@@ -166,6 +169,28 @@ async def make_proxy(
 @pytest.fixture
 async def gh_proxy(make_proxy: MakeProxy) -> ProxyAndCapture:
     return await make_proxy([_cred("GH_TOKEN", "ghp_REALSECRET", ("api.allowed.test",), PH_GH)])
+
+
+def _assert_refused(response: httpx.Response, captured: list[httpx.Request]) -> None:
+    """The substitution-failure contract (eumemic/eumemic-ops#331 fix B).
+
+    Asserts BOTH halves that make the failure actionable: a distinguishable,
+    machine-readable refusal to the caller, AND — the security half — that the
+    literal placeholder never reached the upstream. ``captured`` is the mock
+    transport's request log, so an empty log proves no upstream request was
+    ever opened, not merely that the body was rewritten.
+    """
+    assert response.status_code == PLACEHOLDER_SUBSTITUTION_FAILED_STATUS
+    assert response.status_code != 401, "must never be conflatable with an upstream 401"
+    assert (
+        response.headers[PLACEHOLDER_SUBSTITUTION_FAILED_HEADER]
+        == PLACEHOLDER_SUBSTITUTION_FAILED_CODE
+    )
+    assert "placeholder substitution failed" in response.text
+    assert captured == [], "the literal placeholder must NOT be transmitted upstream"
+    assert SECRET_PLACEHOLDER_PREFIX not in response.text.replace(
+        "AIOS_SECRET_PLACEHOLDER_*", ""
+    ), "the refusal body must not echo a concrete placeholder token"
 
 
 class TestPathHelpers:
@@ -349,17 +374,19 @@ class TestBasicAuthSwap:
         )
         assert captured[0].headers["authorization"] == "Basic not-b64-ghp_REALSECRET"
 
-    async def test_basic_auth_outside_prefix_passes_placeholder_through(
-        self, make_proxy: MakeProxy
-    ) -> None:
+    async def test_basic_auth_outside_prefix_is_refused(self, make_proxy: MakeProxy) -> None:
+        # Outside the prefix → no swap fires. Pre-#331 the placeholder rode
+        # through verbatim inside the Basic blob; now the request is refused.
+        # This is the case a raw substring scan would MISS — base64 shifts the
+        # byte boundaries, so the fence must decode Basic before scanning.
         proxy, captured = await make_proxy(
             [_cred("GH_TOKEN", "ghp_REALSECRET", ("api.allowed.test/repos/ok",), PH_GH)]
         )
         header = _basic("x-access-token", PH_GH)
-        await _request(proxy, "api.allowed.test", "/repos/nope", headers={"Authorization": header})
-        out = captured[0].headers["authorization"]
-        # Outside the prefix → no swap → placeholder rides through verbatim.
-        assert _decode_basic(out) == f"x-access-token:{PH_GH}"
+        res = await _request(
+            proxy, "api.allowed.test", "/repos/nope", headers={"Authorization": header}
+        )
+        _assert_refused(res, captured)
 
 
 class TestPathGating:
@@ -378,25 +405,27 @@ class TestPathGating:
         assert captured[0].headers["authorization"] == "ghp_REALSECRET"
 
     @pytest.mark.parametrize("path", ["/repos/eumemic-evil", "/repos/other"])
-    async def test_passes_through_outside_prefix(
+    async def test_refused_outside_prefix(
         self, repo_proxy: tuple[SecretEgressProxy, list[httpx.Request]], path: str
     ) -> None:
+        # Path gate fails → no swap. The gate's SECURITY behaviour is unchanged
+        # (the secret is still never sent outside its prefix); what changes is
+        # that the placeholder is no longer sent either.
         proxy, captured = repo_proxy
-        await _request(proxy, "api.allowed.test", path, headers={"Authorization": PH_GH})
-        # Path gate fails → placeholder rides through unswapped.
-        assert captured[0].headers["authorization"] == PH_GH
+        res = await _request(proxy, "api.allowed.test", path, headers={"Authorization": PH_GH})
+        _assert_refused(res, captured)
 
-    async def test_dot_segment_climbout_passes_through(
+    async def test_dot_segment_climbout_is_refused(
         self, repo_proxy: tuple[SecretEgressProxy, list[httpx.Request]]
     ) -> None:
         proxy, captured = repo_proxy
-        await _request(
+        res = await _request(
             proxy,
             "api.allowed.test",
             "/repos/eumemic/../../gists",
             headers={"Authorization": PH_GH},
         )
-        assert captured[0].headers["authorization"] == PH_GH
+        _assert_refused(res, captured)
 
     async def test_mixed_case_stored_host_terminates_and_swaps(self, make_proxy: MakeProxy) -> None:
         # F1: parse_allowed_host_entry stores the host as-given; the proxy must
@@ -409,20 +438,19 @@ class TestPathGating:
         await _request(proxy, "api.allowed.test", "/x", headers={"Authorization": PH_GH})
         assert captured[0].headers["authorization"] == "ghp_REALSECRET"
 
-    async def test_unauthorized_host_passes_placeholder_through(
-        self, make_proxy: MakeProxy
-    ) -> None:
+    async def test_unauthorized_host_is_refused_not_leaked(self, make_proxy: MakeProxy) -> None:
         # Two allow-set hosts (so TLS terminates for both); a placeholder for
         # host A sent to host B does not swap (B has no matching cred).
+        # Pre-#331 it rode through raw — i.e. host A's placeholder was handed
+        # to an unrelated host B. Now B never sees it.
         proxy, captured = await make_proxy(
             [
                 _cred("A_TOKEN", "secret_A", ("api.a.test",), PH_GH),
                 _cred("B_TOKEN", "secret_B", ("api.b.test",), _ph("b")),
             ]
         )
-        await _request(proxy, "api.b.test", "/x", headers={"Authorization": PH_GH})
-        # PH_GH belongs to api.a.test; on api.b.test it rides through raw.
-        assert captured[0].headers["authorization"] == PH_GH
+        res = await _request(proxy, "api.b.test", "/x", headers={"Authorization": PH_GH})
+        _assert_refused(res, captured)
 
 
 class TestFailClosed:
@@ -782,4 +810,12 @@ class TestRequestBodyCapDefault:
 def test_module_exports() -> None:
     from aios.sandbox import secret_egress_proxy
 
-    assert secret_egress_proxy.__all__ == ["SecretEgressProxy"]
+    # The fence's wire contract is exported alongside the proxy so callers
+    # branch on the named constants rather than a hardcoded 421 / header
+    # spelling (eumemic/eumemic-ops#331).
+    assert secret_egress_proxy.__all__ == [
+        "PLACEHOLDER_SUBSTITUTION_FAILED_CODE",
+        "PLACEHOLDER_SUBSTITUTION_FAILED_HEADER",
+        "PLACEHOLDER_SUBSTITUTION_FAILED_STATUS",
+        "SecretEgressProxy",
+    ]

--- a/tests/unit/sandbox/test_snapshot_pointer.py
+++ b/tests/unit/sandbox/test_snapshot_pointer.py
@@ -291,3 +291,45 @@ async def test_over_limit_notice_append_failure_does_not_propagate(
     kinds = [t[0] for t in timeline]
     assert "pointer_set" in kinds, "snapshot + pointer succeeded"
     assert "destroy" in kinds, "corpse must still be removed despite the notice append failure"
+
+
+@pytest.mark.asyncio
+async def test_resolve_opaque_pre_331_snapshot_cold_starts(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+) -> None:
+    """A snapshot recording NEITHER placeholder-keys NOR env-keys is opaque.
+
+    Pre-#331 artifacts carry no ``aios.vault_placeholder_keys`` label, so the
+    stale-key diff has nothing to diff against — and a pre-#331 snapshot is
+    precisely the artifact that may have baked a placeholder for a
+    since-archived credential. With no env-key inventory either we cannot
+    enumerate what it baked, so we cannot prove it holds no stale placeholder.
+
+    Fail safe: cold-start (costing recoverable, model-visible filesystem state)
+    rather than resume an image that may re-inject an unexchangeable
+    placeholder into a credential path.
+    """
+    registry, backend, timeline = harness
+    from aios.sandbox.backends.base import Mount, SandboxSpec
+
+    ref = "aios-sbx-default-sess_x:latest"
+    backend.image_labels_by_ref[ref] = {"aios.base_image": "IMG"}
+    spec = SandboxSpec(
+        session_id="sess_x",
+        instance_id="default",
+        workspace=Mount(host_path=cast(Any, "/tmp/w"), sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={"GITHUB_TOKEN": "AIOS_SECRET_PLACEHOLDER_" + "b" * 32},
+        labels={},
+        network_policy=UnrestrictedNetworking(),
+        host_gateway_alias=None,
+        image="IMG",  # base matches: this is NOT drift, it is unverifiability
+        snapshot_image=ref,
+    )
+
+    resolved = await registry._resolve_snapshot("sess_x", spec)
+
+    assert resolved.snapshot_image is None, "an unverifiable snapshot must not resume"
+    assert ("fs_event", "sandbox_fs_reset", "unverifiable_placeholder_env") in timeline
+    # The current provision's own placeholder is still injected as usual.
+    assert resolved.environment["GITHUB_TOKEN"].startswith("AIOS_SECRET_PLACEHOLDER_")

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -1229,3 +1229,155 @@ class TestApplySecretEgressDnat:
         await apply_secret_egress_dnat(
             backend, handle, dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
         )  # must not raise
+
+
+class TestCredentialHostFailsClosed:
+    """Finding 4: a missing DNAT rule must NOT fall through to direct egress.
+
+    The DNAT rules are keyed on RESOLVED IPs, and a rotating pool (api.github.com
+    serves a short-TTL set and returns only a SUBSET per query) means the set of
+    IPs we installed rules for is a SAMPLE, not the pool. Probing more times per
+    tick samples more of it but guarantees nothing — resolver caching can return
+    the same subset every probe, and a later in-sandbox lookup can still return
+    an address no rule covers.
+
+    Pre-fix, that residual was FAIL-OPEN: under the ``cred ⊆ env`` gate the
+    credential host's :443 was filter-ACCEPTed, so an un-DNATed packet went
+    straight to the real upstream carrying the literal placeholder. These tests
+    pin the inverted invariant: **no DNAT ⇒ no egress**.
+    """
+
+    FENCE = "--dport 443 -j REJECT --reject-with tcp-reset"
+
+    def test_limited_lockdown_fences_credential_hosts(self) -> None:
+        script = build_iptables_script(
+            allowed_hosts={"api.secret.com"},
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        assert self.FENCE in script
+
+    def test_fence_is_inserted_at_head_so_it_beats_the_accepts(self) -> None:
+        """iptables is first-match-wins and the credential host also carries a
+        per-host ACCEPT on :443 (it is in ``allowed_hosts``). An APPENDED reject
+        would never be reached — the ACCEPT would match first and the packet
+        would leave un-proxied. Head insertion is what makes the fence real."""
+        script = build_iptables_script(
+            allowed_hosts={"api.secret.com"},
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        fence_line = next(line for line in script.splitlines() if self.FENCE in line)
+        assert "-I OUTPUT" in fence_line, "an appended fence would sit behind the ACCEPT"
+        assert "-A OUTPUT" not in fence_line
+
+    def test_dnated_packet_is_unaffected_by_the_fence(self) -> None:
+        """nat OUTPUT runs BEFORE filter OUTPUT, so a packet that matched a DNAT
+        rule reaches filter already rewritten to the proxy endpoint and no longer
+        matches ``-d <credential-host-ip>``. Pin the rule shape that makes that
+        true: the fence matches on the credential host's address, never on the
+        proxy's."""
+        script = build_iptables_script(
+            allowed_hosts=set(),
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        fence_line = next(line for line in script.splitlines() if self.FENCE in line)
+        assert '-d "$ip"' in fence_line
+        assert "$PROXY_IP" not in fence_line
+
+    def test_unrestricted_dnat_only_also_fences(self) -> None:
+        """Under Unrestricted the filter policy stays ACCEPT, so an un-DNATed
+        credential-host packet would leave by default. The fence applies there
+        too — it is the ONLY thing standing between an unsampled IP and direct
+        egress with a placeholder."""
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        assert f'"$IPT" -A OUTPUT -d "$ip" -p tcp {self.FENCE}' in script
+
+    def test_unrestricted_fence_is_idempotent_without_flushing_filter(self) -> None:
+        """The DNAT-only script does not own the filter chain, so it must clear
+        its OWN previous fence rules rather than flushing OUTPUT wholesale."""
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        assert '"$IPT" -F OUTPUT' not in script, "must not flush a chain it does not own"
+        assert f'"$IPT" -D OUTPUT -d "$ip" -p tcp {self.FENCE}' in script
+
+    def test_proxy_alias_resolve_miss_fails_closed(self) -> None:
+        """If the proxy alias does not resolve there is no DNAT at all. The
+        fence must be installed OUTSIDE the ``if [ -n "$PROXY_IP" ]`` guard, so
+        the miss refuses credential-host egress instead of letting every
+        credential request out un-proxied."""
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        lines = script.splitlines()
+        guard_end = max(i for i, line in enumerate(lines) if line.strip() == "fi")
+        # The INSTALL line (the idempotency flush earlier in the script also
+        # mentions the fence, as a -D).
+        fence_at = next(
+            i for i, line in enumerate(lines) if self.FENCE in line and "-A OUTPUT" in line
+        )
+        assert fence_at > guard_end, "the fence must survive a proxy-alias DNS miss"
+
+    def test_no_fence_without_credential_hosts(self) -> None:
+        """The fence is scoped to credential hosts; an ordinary allowed host
+        must not be rejected."""
+        script = build_iptables_script(
+            allowed_hosts={"api.example.com"},
+            dnat_hosts=[],
+            dnat_target=("aios-worker", 49152),
+        )
+        assert "REJECT" not in script
+
+    def test_verify_asserts_the_fence_landed(self) -> None:
+        """An unverified fence is no fence: a credential host whose REJECT
+        failed to install is a host whose unsampled addresses egress directly.
+        The provision verify must fail closed on it."""
+        from aios.sandbox.setup import build_lockdown_verify_script
+
+        script = build_lockdown_verify_script(["api.secret.com"], assert_drop=True)
+        assert "-j DNAT" in script
+        assert self.FENCE in script
+
+    def test_refresh_installs_the_fence_before_the_dnat(self) -> None:
+        """Ordering is a security property, not cosmetics: between the two
+        statements a newly learned address must never be
+        allowed-but-unproxied. Fence first means the worst intermediate state is
+        'refused', never 'direct egress with a placeholder'."""
+        from aios.sandbox.setup import build_egress_refresh_script
+
+        script = build_egress_refresh_script(
+            old_ips={},
+            new_ips={"api.secret.com": {"1.2.3.4"}},
+            credential_hosts={"api.secret.com"},
+            limited_hosts=set(),
+            dnat_target=("10.0.0.9", 49152),
+        )
+        fence_at = next(i for i, line in enumerate(script.splitlines()) if self.FENCE in line)
+        dnat_at = next(i for i, line in enumerate(script.splitlines()) if "-j DNAT" in line)
+        assert fence_at < dnat_at
+        assert "-I OUTPUT" in script.splitlines()[fence_at]
+
+    def test_refresh_removes_the_fence_after_the_dnat(self) -> None:
+        """The mirror of the add ordering: an evicted address that still has a
+        fence is merely refused, but one that lost its fence while a stale
+        ACCEPT lingers would be direct egress."""
+        from aios.sandbox.setup import build_egress_refresh_script
+
+        script = build_egress_refresh_script(
+            old_ips={"api.secret.com": {"1.2.3.4"}},
+            new_ips={"api.secret.com": set()},
+            credential_hosts={"api.secret.com"},
+            limited_hosts=set(),
+            dnat_target=("10.0.0.9", 49152),
+        )
+        lines = script.splitlines()
+        fence_at = next(i for i, line in enumerate(lines) if self.FENCE in line and "-D" in line)
+        dnat_at = next(i for i, line in enumerate(lines) if "-j DNAT" in line and "-D" in line)
+        assert dnat_at < fence_at

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -1231,158 +1231,6 @@ class TestApplySecretEgressDnat:
         )  # must not raise
 
 
-class TestCredentialHostFailsClosed:
-    """Finding 4: a missing DNAT rule must NOT fall through to direct egress.
-
-    The DNAT rules are keyed on RESOLVED IPs, and a rotating pool (api.github.com
-    serves a short-TTL set and returns only a SUBSET per query) means the set of
-    IPs we installed rules for is a SAMPLE, not the pool. Probing more times per
-    tick samples more of it but guarantees nothing — resolver caching can return
-    the same subset every probe, and a later in-sandbox lookup can still return
-    an address no rule covers.
-
-    Pre-fix, that residual was FAIL-OPEN: under the ``cred ⊆ env`` gate the
-    credential host's :443 was filter-ACCEPTed, so an un-DNATed packet went
-    straight to the real upstream carrying the literal placeholder. These tests
-    pin the inverted invariant: **no DNAT ⇒ no egress**.
-    """
-
-    FENCE = "--dport 443 -j REJECT --reject-with tcp-reset"
-
-    def test_limited_lockdown_fences_credential_hosts(self) -> None:
-        script = build_iptables_script(
-            allowed_hosts={"api.secret.com"},
-            dnat_hosts=["api.secret.com"],
-            dnat_target=("aios-worker", 49152),
-        )
-        assert self.FENCE in script
-
-    def test_fence_is_inserted_at_head_so_it_beats_the_accepts(self) -> None:
-        """iptables is first-match-wins and the credential host also carries a
-        per-host ACCEPT on :443 (it is in ``allowed_hosts``). An APPENDED reject
-        would never be reached — the ACCEPT would match first and the packet
-        would leave un-proxied. Head insertion is what makes the fence real."""
-        script = build_iptables_script(
-            allowed_hosts={"api.secret.com"},
-            dnat_hosts=["api.secret.com"],
-            dnat_target=("aios-worker", 49152),
-        )
-        fence_line = next(line for line in script.splitlines() if self.FENCE in line)
-        assert "-I OUTPUT" in fence_line, "an appended fence would sit behind the ACCEPT"
-        assert "-A OUTPUT" not in fence_line
-
-    def test_dnated_packet_is_unaffected_by_the_fence(self) -> None:
-        """nat OUTPUT runs BEFORE filter OUTPUT, so a packet that matched a DNAT
-        rule reaches filter already rewritten to the proxy endpoint and no longer
-        matches ``-d <credential-host-ip>``. Pin the rule shape that makes that
-        true: the fence matches on the credential host's address, never on the
-        proxy's."""
-        script = build_iptables_script(
-            allowed_hosts=set(),
-            dnat_hosts=["api.secret.com"],
-            dnat_target=("aios-worker", 49152),
-        )
-        fence_line = next(line for line in script.splitlines() if self.FENCE in line)
-        assert '-d "$ip"' in fence_line
-        assert "$PROXY_IP" not in fence_line
-
-    def test_unrestricted_dnat_only_also_fences(self) -> None:
-        """Under Unrestricted the filter policy stays ACCEPT, so an un-DNATed
-        credential-host packet would leave by default. The fence applies there
-        too — it is the ONLY thing standing between an unsampled IP and direct
-        egress with a placeholder."""
-        script = build_secret_egress_dnat_script(
-            dnat_hosts=["api.secret.com"],
-            dnat_target=("aios-worker", 49152),
-        )
-        assert f'"$IPT" -A OUTPUT -d "$ip" -p tcp {self.FENCE}' in script
-
-    def test_unrestricted_fence_is_idempotent_without_flushing_filter(self) -> None:
-        """The DNAT-only script does not own the filter chain, so it must clear
-        its OWN previous fence rules rather than flushing OUTPUT wholesale."""
-        script = build_secret_egress_dnat_script(
-            dnat_hosts=["api.secret.com"],
-            dnat_target=("aios-worker", 49152),
-        )
-        assert '"$IPT" -F OUTPUT' not in script, "must not flush a chain it does not own"
-        assert f'"$IPT" -D OUTPUT -d "$ip" -p tcp {self.FENCE}' in script
-
-    def test_proxy_alias_resolve_miss_fails_closed(self) -> None:
-        """If the proxy alias does not resolve there is no DNAT at all. The
-        fence must be installed OUTSIDE the ``if [ -n "$PROXY_IP" ]`` guard, so
-        the miss refuses credential-host egress instead of letting every
-        credential request out un-proxied."""
-        script = build_secret_egress_dnat_script(
-            dnat_hosts=["api.secret.com"],
-            dnat_target=("aios-worker", 49152),
-        )
-        lines = script.splitlines()
-        guard_end = max(i for i, line in enumerate(lines) if line.strip() == "fi")
-        # The INSTALL line (the idempotency flush earlier in the script also
-        # mentions the fence, as a -D).
-        fence_at = next(
-            i for i, line in enumerate(lines) if self.FENCE in line and "-A OUTPUT" in line
-        )
-        assert fence_at > guard_end, "the fence must survive a proxy-alias DNS miss"
-
-    def test_no_fence_without_credential_hosts(self) -> None:
-        """The fence is scoped to credential hosts; an ordinary allowed host
-        must not be rejected."""
-        script = build_iptables_script(
-            allowed_hosts={"api.example.com"},
-            dnat_hosts=[],
-            dnat_target=("aios-worker", 49152),
-        )
-        assert "REJECT" not in script
-
-    def test_verify_asserts_the_fence_landed(self) -> None:
-        """An unverified fence is no fence: a credential host whose REJECT
-        failed to install is a host whose unsampled addresses egress directly.
-        The provision verify must fail closed on it."""
-        from aios.sandbox.setup import build_lockdown_verify_script
-
-        script = build_lockdown_verify_script(["api.secret.com"], assert_drop=True)
-        assert "-j DNAT" in script
-        assert self.FENCE in script
-
-    def test_refresh_installs_the_fence_before_the_dnat(self) -> None:
-        """Ordering is a security property, not cosmetics: between the two
-        statements a newly learned address must never be
-        allowed-but-unproxied. Fence first means the worst intermediate state is
-        'refused', never 'direct egress with a placeholder'."""
-        from aios.sandbox.setup import build_egress_refresh_script
-
-        script = build_egress_refresh_script(
-            old_ips={},
-            new_ips={"api.secret.com": {"1.2.3.4"}},
-            credential_hosts={"api.secret.com"},
-            limited_hosts=set(),
-            dnat_target=("10.0.0.9", 49152),
-        )
-        fence_at = next(i for i, line in enumerate(script.splitlines()) if self.FENCE in line)
-        dnat_at = next(i for i, line in enumerate(script.splitlines()) if "-j DNAT" in line)
-        assert fence_at < dnat_at
-        assert "-I OUTPUT" in script.splitlines()[fence_at]
-
-    def test_refresh_removes_the_fence_after_the_dnat(self) -> None:
-        """The mirror of the add ordering: an evicted address that still has a
-        fence is merely refused, but one that lost its fence while a stale
-        ACCEPT lingers would be direct egress."""
-        from aios.sandbox.setup import build_egress_refresh_script
-
-        script = build_egress_refresh_script(
-            old_ips={"api.secret.com": {"1.2.3.4"}},
-            new_ips={"api.secret.com": set()},
-            credential_hosts={"api.secret.com"},
-            limited_hosts=set(),
-            dnat_target=("10.0.0.9", 49152),
-        )
-        lines = script.splitlines()
-        fence_at = next(i for i, line in enumerate(lines) if self.FENCE in line and "-D" in line)
-        dnat_at = next(i for i, line in enumerate(lines) if "-j DNAT" in line and "-D" in line)
-        assert dnat_at < fence_at
-
-
 # ── behavioural egress verdict: what happens to a packet, not what the rule
 #    text says (finding 4 / eumemic/aios#2042) ──────────────────────────────────
 
@@ -1392,7 +1240,7 @@ class TestCredentialHostEgressVerdict:
 
     Every other test in this file asserts *rule syntax* — that some string is
     present in the script. That is exactly why the Unrestricted fail-open in
-    finding 4 survived a fix round: the fence rule was emitted, the syntax
+    finding 4 survived a review cycle: rules were emitted, the syntax
     assertions passed, and nobody asked what happens to a packet addressed to
     an IP the sampler never returned. This class asks that question.
 
@@ -1574,21 +1422,39 @@ class TestCredentialHostEgressVerdict:
             "fail-open was closed — delete this test and update the PR/issue"
         )
 
-    def test_the_fence_only_covers_what_the_sampler_saw(self) -> None:
-        """The property behind #2042, stated directly: the fence is IP-keyed, so
-        its coverage is exactly the sampled set — not the host. An earlier
-        review round described it as 'needing no knowledge of the pool', which
-        is what made the residual look closed; it inherits the sample's
-        incompleteness like the DNAT does."""
+    def test_credential_host_rules_only_cover_what_the_sampler_saw(self) -> None:
+        """The property behind #2042, stated directly: the credential-host rules
+        are IP-keyed, so their coverage is exactly the SAMPLED SET — not the
+        host. This is why no IP-keyed rule can close the hole, and why this PR
+        adds none: a rule that covers only the addresses we already learned
+        would read as a fence to the next reader while the unsampled address —
+        the ordinary case against a rotating pool — walks straight past it."""
         rules = self._record_rules(
             build_secret_egress_dnat_script(
                 dnat_hosts=[self.HOST], dnat_target=("aios-worker", self.PROXY_PORT)
             )
         )
-        fenced = {
+        covered = {
             argv[argv.index("-d") + 1]
             for table, argv in rules
-            if table == "filter" and "REJECT" in argv and "-d" in argv
+            if table == "nat" and "DNAT" in argv and "-d" in argv
         }
-        assert fenced == {self.SAMPLED_IP}
-        assert self.UNSAMPLED_IP not in fenced
+        assert covered == {self.SAMPLED_IP}
+        assert self.UNSAMPLED_IP not in covered
+
+    def test_no_ip_keyed_filter_fence_is_installed(self) -> None:
+        """Round 4 scope decision, pinned so it cannot silently come back.
+
+        An earlier round added a per-credential-host filter REJECT for the
+        LEARNED addresses. It was withdrawn: it protects only what was already
+        sampled, so it reads as a fence without being one, and a future reader
+        finding it in the diff would reasonably conclude #2042 was closed. A
+        DOCUMENTED hole is safer than a DISGUISED one. If a REJECT reappears
+        here it must be part of a real deny-by-default design (#2042), which
+        would also flip the ``direct`` assertion above."""
+        rules = self._record_rules(
+            build_secret_egress_dnat_script(
+                dnat_hosts=[self.HOST], dnat_target=("aios-worker", self.PROXY_PORT)
+            )
+        )
+        assert not [argv for table, argv in rules if table == "filter" and "REJECT" in argv]

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -1381,3 +1381,214 @@ class TestCredentialHostFailsClosed:
         fence_at = next(i for i, line in enumerate(lines) if self.FENCE in line and "-D" in line)
         dnat_at = next(i for i, line in enumerate(lines) if "-j DNAT" in line and "-D" in line)
         assert dnat_at < fence_at
+
+
+# ── behavioural egress verdict: what happens to a packet, not what the rule
+#    text says (finding 4 / eumemic/aios#2042) ──────────────────────────────────
+
+
+class TestCredentialHostEgressVerdict:
+    """Evaluate the GENERATED ruleset against a packet.
+
+    Every other test in this file asserts *rule syntax* — that some string is
+    present in the script. That is exactly why the Unrestricted fail-open in
+    finding 4 survived a fix round: the fence rule was emitted, the syntax
+    assertions passed, and nobody asked what happens to a packet addressed to
+    an IP the sampler never returned. This class asks that question.
+
+    Method: run the real generated script under ``bash`` against fake
+    ``iptables``/``getent`` shims that RECORD the rules instead of installing
+    them, then replay the recorded ruleset against a packet the way netfilter
+    would — nat OUTPUT first (a DNAT match rewrites the destination), then
+    filter OUTPUT, first-match-wins, falling through to the chain policy. The
+    verdict is one of:
+
+    * ``proxied``  — rewritten to the secret-egress proxy (safe: the swap fires),
+    * ``blocked``  — REJECTed or DROPped (safe: nothing leaves),
+    * ``direct``   — leaves the netns toward the real upstream (UNSAFE for a
+      credential host: this is the literal placeholder on the wire).
+
+    ``SAMPLED_IP`` is an address the in-sandbox resolver returned when the
+    rules were generated; ``UNSAMPLED_IP`` is a live pool member it never
+    returned (a rotating DNS pool serves only a subset per query, so this is
+    the ordinary case, not an exotic one).
+    """
+
+    HOST = "api.secret.com"
+    SAMPLED_IP = "140.82.112.5"
+    UNSAMPLED_IP = "140.82.113.22"
+    PROXY_IP = "10.0.0.9"
+    PROXY_PORT = 49152
+
+    def _record_rules(self, script: str) -> list[tuple[str, list[str]]]:
+        """Run the generated script with recording shims; return (table, argv)."""
+        bindir = tempfile.mkdtemp()
+        log = os.path.join(bindir, "rules.log")
+        # getent ahostsv4 <host> answers with the SAMPLED address only — the
+        # subset the resolver happened to return at rule-generation time.
+        getent = (
+            "#!/usr/bin/env bash\n"
+            f'if [ "$2" = "{self.HOST}" ]; then echo "{self.SAMPLED_IP} STREAM {self.HOST}"; fi\n'
+            f'if [ "$2" = "aios-worker" ]; then echo "{self.PROXY_IP} STREAM aios-worker"; fi\n'
+            "exit 0\n"
+        )
+        # iptables shim: append the argv of every mutating call to the log.
+        # -S/-C/-D calls are answered so the script's guards behave (nothing is
+        # installed, so -C "rule exists?" is false and -D is a no-op).
+        ipt = (
+            "#!/usr/bin/env bash\n"
+            f'printf "%s\\n" "$*" >> {log}\n'
+            'for a in "$@"; do\n'
+            '  case "$a" in -S) exit 0;; -C) exit 1;; -D) exit 1;; esac\n'
+            "done\n"
+            "exit 0\n"
+        )
+        for name, body in (
+            ("getent", getent),
+            ("iptables-legacy", ipt),
+            ("iptables", ipt),
+            ("ip6tables-legacy", ipt),
+            ("ip6tables", ipt),
+        ):
+            p = os.path.join(bindir, name)
+            with open(p, "w") as f:
+                f.write(body)
+            os.chmod(p, 0o755)
+        env = dict(os.environ)
+        env["PATH"] = bindir + os.pathsep + env["PATH"]
+        proc = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+        assert proc.returncode == 0, f"apply script failed: {proc.stderr}"
+        recorded: list[tuple[str, list[str]]] = []
+        if os.path.exists(log):
+            with open(log) as f:
+                for line in f:
+                    argv = line.split()
+                    is_nat = "-t" in argv and argv[argv.index("-t") + 1] == "nat"
+                    recorded.append(("nat" if is_nat else "filter", argv))
+        return recorded
+
+    def _verdict(self, rules: list[tuple[str, list[str]]], dest_ip: str, dport: int = 443) -> str:
+        """Replay the recorded ruleset against one packet, netfilter-style."""
+
+        def _chain(table: str) -> list[list[str]]:
+            """OUTPUT rules for ``table`` in traversal order (-I prepends)."""
+            chain: list[list[str]] = []
+            for t, argv in rules:
+                if t != table or "OUTPUT" not in argv:
+                    continue
+                if "-A" in argv:
+                    chain.append(argv)
+                elif "-I" in argv:
+                    chain.insert(0, argv)
+            return chain
+
+        def _matches(argv: list[str], ip: str, port: int) -> bool:
+            if "-d" in argv and argv[argv.index("-d") + 1] != ip:
+                return False
+            if "--dport" in argv and argv[argv.index("--dport") + 1] != str(port):
+                return False
+            # Rules that gate on something this model doesn't carry (loopback
+            # interface, conntrack state, a different protocol) can't match a
+            # fresh outbound TCP packet to a remote address.
+            if "-o" in argv or "conntrack" in argv:
+                return False
+            return not ("-p" in argv and argv[argv.index("-p") + 1] != "tcp")
+
+        # nat OUTPUT: a DNAT match rewrites the destination.
+        for argv in _chain("nat"):
+            if _matches(argv, dest_ip, dport) and "DNAT" in argv:
+                return "proxied"
+        # filter OUTPUT: first match wins, else the chain policy.
+        for argv in _chain("filter"):
+            if not _matches(argv, dest_ip, dport):
+                continue
+            if "REJECT" in argv or "DROP" in argv:
+                return "blocked"
+            if "ACCEPT" in argv:
+                return "direct"
+        policy = "ACCEPT"
+        for _t, argv in rules:
+            if argv[:3] == ["-P", "OUTPUT", "DROP"]:
+                policy = "DROP"
+        return "direct" if policy == "ACCEPT" else "blocked"
+
+    # ── the sampled address behaves, in both modes ────────────────────────────
+
+    def test_limited_sampled_address_is_proxied(self) -> None:
+        rules = self._record_rules(
+            build_iptables_script(
+                allowed_hosts={self.HOST},
+                dnat_hosts=[self.HOST],
+                dnat_target=("aios-worker", self.PROXY_PORT),
+            )
+        )
+        assert self._verdict(rules, self.SAMPLED_IP) == "proxied"
+
+    def test_unrestricted_sampled_address_is_proxied(self) -> None:
+        rules = self._record_rules(
+            build_secret_egress_dnat_script(
+                dnat_hosts=[self.HOST], dnat_target=("aios-worker", self.PROXY_PORT)
+            )
+        )
+        assert self._verdict(rules, self.SAMPLED_IP) == "proxied"
+
+    # ── the unsampled address: the whole point ────────────────────────────────
+
+    def test_limited_unsampled_address_never_egresses(self) -> None:
+        """Limited networking is genuinely closed: an address the sampler never
+        saw carries no DNAT and no ACCEPT, so it falls through to the terminal
+        ``-P OUTPUT DROP``. No placeholder leaves the netns."""
+        rules = self._record_rules(
+            build_iptables_script(
+                allowed_hosts={self.HOST},
+                dnat_hosts=[self.HOST],
+                dnat_target=("aios-worker", self.PROXY_PORT),
+            )
+        )
+        assert self._verdict(rules, self.UNSAMPLED_IP) == "blocked"
+
+    def test_unrestricted_unsampled_address_still_egresses_directly(self) -> None:
+        """KNOWN RESIDUAL — eumemic/aios#2042. This asserts the BUG, on purpose.
+
+        Under Unrestricted the filter policy stays ACCEPT and BOTH the DNAT and
+        the REJECT fence are generated only for LEARNED addresses. An address
+        that never appeared in a DNS sample matches neither, so it leaves via
+        the default-ACCEPT policy carrying the literal placeholder. That is a
+        fail-open, it is not fixed in this PR, and the fix (deny-by-default for
+        credential hosts, with the learned set as an ALLOW-list) needs
+        name-based interception — tracked in #2042.
+
+        Pinned as a failing-safety expectation rather than left undiscovered:
+        when #2042 lands, this assertion flips to ``blocked``/``proxied`` and
+        the flip is the acceptance signal. Until then nobody can believe the
+        Unrestricted path is closed, because the test says it isn't.
+        """
+        rules = self._record_rules(
+            build_secret_egress_dnat_script(
+                dnat_hosts=[self.HOST], dnat_target=("aios-worker", self.PROXY_PORT)
+            )
+        )
+        verdict = self._verdict(rules, self.UNSAMPLED_IP)
+        assert verdict == "direct", (
+            "expected the KNOWN #2042 residual; a different verdict means the "
+            "fail-open was closed — delete this test and update the PR/issue"
+        )
+
+    def test_the_fence_only_covers_what_the_sampler_saw(self) -> None:
+        """The property behind #2042, stated directly: the fence is IP-keyed, so
+        its coverage is exactly the sampled set — not the host. An earlier
+        review round described it as 'needing no knowledge of the pool', which
+        is what made the residual look closed; it inherits the sample's
+        incompleteness like the DNAT does."""
+        rules = self._record_rules(
+            build_secret_egress_dnat_script(
+                dnat_hosts=[self.HOST], dnat_target=("aios-worker", self.PROXY_PORT)
+            )
+        )
+        fenced = {
+            argv[argv.index("-d") + 1]
+            for table, argv in rules
+            if table == "filter" and "REJECT" in argv and "-d" in argv
+        }
+        assert fenced == {self.SAMPLED_IP}
+        assert self.UNSAMPLED_IP not in fenced


### PR DESCRIPTION
Fixes the intermittent `401 Bad credentials` from api.github.com that retrying appears to fix. Root-caused 2026-07-13; fix never built.

Two independent mechanisms could put the **literal** `AIOS_SECRET_PLACEHOLDER_*` string on the wire. Because the remote then answers 401, a substitution **miss** was indistinguishable from a genuinely bad secret — which is why this read as flaky auth for weeks rather than as a bug.

## B. Fail loud on substitution failure (the highest-value half)

`SecretEgressProxy` now scans the **already-swapped** headers and body for the placeholder shape. Anything still matching is, by construction, a placeholder that no active credential in this session's swap set could exchange. Such a request is refused with:

- status **421 Misdirected Request** — deliberately *not* 401 (never conflatable with an upstream credential verdict) and *not* 5xx (this is not an outage);
- header `x-aios-egress-error: placeholder_substitution_failed` — machine-readable, so a caller branches on the cause without parsing prose;
- a body naming the cause and the fix.

**No upstream connection is opened**, so the literal placeholder is never transmitted. `Authorization: Basic` values are decoded before scanning — base64 shifts byte boundaries, so the git-over-HTTPS / `curl -u` case that motivated this report would slip a naive substring scan.

## A. Never inherit credential env from a snapshot

Placeholders are keyed on **credential id**, so a rotated/recreated credential leaves a resumed sandbox holding a placeholder bound to a dead id.

Re-derivation already covered the *rotate* case: `build_spec_from_session` resolves active credentials on every provision and `docker run --env` overrides the image's baked ENV, so a recreated credential (same `secret_name`, new id) self-heals. The residual hole was the **archived** credential — its `secret_name` drops out of the current placeholder set, so *nothing* overrides the value the snapshot baked, and the container resumes with a placeholder the proxy can never exchange.

Provision now stamps `aios.vault_placeholder_keys` (**names only** — never a placeholder value, never a credential id, asserted by test) and resume explicitly empties any recorded key the current provision no longer injects. Empty, not absent: only an explicit `--env K=` overrides a baked `ENV K=<stale>`.

The resume branch keys on label **presence**, not truthiness. A **present-but-empty** label is evidence — a post-#331 provision recorded that it injected no placeholder keys — so that snapshot resumes with nothing scrubbed. Only an **absent** label means unknown provenance and takes the pre-#331 handling (scrub the non-reinjected `aios.env_keys`, or cold-start when the snapshot records no inventory at all). Conflating the two, as round 3 did via `if not recorded`, cost a needless env scrub or an outright **cold start** — avoidable filesystem loss for a snapshot the label had already proven clean.

## C. The DNS-pin drift that bypasses the proxy entirely — DOCUMENTED, NOT FIXED

api.github.com serves a ~60s-TTL rotating pool and returns only a **subset** of live addresses per query. Pinning one query's answer lets the sandbox resolve an address carrying no DNAT rule — that request never reaches the proxy at all and goes straight to GitHub with the placeholder. This is the "random, retry fixes it" signature.

Round 3 attacked this with extra DNS probing and a sampled-IP REJECT fence. **Both are withdrawn in round 4** — see *Known residual* below for why sampling harder is not a fix and why a fence that only covers learned addresses is worse than no fence at all. The exposure is unmitigated in this PR and tracked in **#2042**. Fail-closed semantics (no IPs ⇒ no rule) and the existing keep-last-good aging are unchanged from base.

Mechanism **B** still contains the leak wherever traffic *does* reach the proxy, which is every sampled address and the whole Limited path.

## Acceptance tests

Both criteria from the issue, in `tests/unit/sandbox/test_placeholder_rotation_331.py`:

- credential A → archive/recreate as B with the same secret + hosts → resume an **existing** snapshot → the env placeholder maps to B and authenticates (200, real secret on the wire); the **old** placeholder is absent from the resumed env and is refused;
- a request carrying an unexchangeable placeholder produces the explicit substitution-failure error, with the mock upstream's request log **empty** — proving non-transmission rather than mere rewriting. Covered in a header, in a JSON body, and inside a Basic blob.

Plus: the archived-credential path, unrelated env is not collateral damage, pre-#331 snapshots still resume, a **present-but-empty** placeholder label resumes with nothing scrubbed (both with and without an env inventory), clean traffic is unaffected, and the label leaks neither secret nor id.

Four existing proxy tests asserted the old silent-passthrough behaviour and are updated to assert the refusal. The secret was never sent in those cases and still isn't — what changes is that the placeholder isn't either.

## Known residual — Unrestricted networking fails open on an unsampled address (UNMITIGATED here)

**This PR does NOT close the credential-bypass fail-open under Unrestricted networking, and as of round 4 it carries NO partial mitigation for it either.** Tracked as **eumemic/aios#2042**. Stating it here because a silent partial fix looks closed and isn't.

The credential-host rule in `sandbox/setup.py` is the nat DNAT redirect, and it is generated **only for LEARNED (resolved) addresses**. An address that never appeared in a DNS sample matches no DNAT, so under Unrestricted (where the filter policy stays `ACCEPT`) it leaves via the default policy carrying the literal `AIOS_SECRET_PLACEHOLDER_*` — never reaching the proxy, so neither the swap nor the fail-loud fence ever runs on it. `api.github.com` serves a rotating pool and returns only a subset per query, so "an address we never sampled" is the ordinary case.

Limited networking is unaffected — its terminal `-P OUTPUT DROP` catches the unsampled address.

**What round 4 removed, and why.** Round 3 shipped a sampled-IP filter `REJECT` fence (plus fence-before-DNAT refresh ordering, a verify assertion, and multi-probe DNS resolution). All of it is **withdrawn**. It protected only the addresses already learned, so its coverage was exactly the DNAT's coverage and the unsampled address walked straight past it: it **read as a fence without being one**, and a future reader finding a REJECT in the diff would reasonably conclude the hole was closed. **A documented hole is safer than a disguised one.** More DNS probing has the same defect one level down — it narrows the window and cannot close it, so it would be mitigation theatre with a security-shaped name. `sandbox/setup.py` is now **byte-identical to base except for one comment block** stating the exposure and pointing at #2042; the diff contains **zero executable changes** to that file.

The correct shape is to **invert the default for credential hosts**: deny-by-default with the learned set as an ALLOW-list, rather than allow-by-default with the learned set as a fence. That cannot be decided at the IP layer for an address we have never seen; it needs name-based interception (a worker-controlled resolver answering credential hosts with the proxy address, or an in-netns SNI-aware TPROXY on `:443`). #2042 carries the four options considered and why each is larger than this PR. It is **not attempted here**.

The residual is pinned behaviourally, not just in prose: `TestCredentialHostEgressVerdict` (`tests/unit/test_networking.py`) runs the real generated script against recording `iptables`/`getent` shims and replays the resulting ruleset against a packet (nat, then filter, first-match-wins, then chain policy). It asserts Limited **blocks** an unsampled address and that Unrestricted still routes it **direct** — so the bug is a visible failing-safety expectation whose flip to `blocked`/`proxied` is the acceptance signal for #2042. A companion test asserts **no IP-keyed filter REJECT is installed**, so the withdrawn partial fence cannot quietly return without being part of a real deny-by-default design.

## On the placeholder-shape false positive — decided, not left open

A whole, **delimited** placeholder-shaped token in legitimate payload (a log line being shipped, a diff of a `.env`) is refused with 421. **We keep that refusal deliberately**, as a fail-closed-on-ambiguity trade:

- The scan runs **post-swap**, so provenance is gone: an unexchangeable placeholder and a placeholder-shaped literal the sandbox typed are the same bytes in the same position. No signal remains to separate them — not the header, not the content type, not the position.
- The errors are **not symmetric**. Refusing costs a loud, local 421 naming the cause and a workaround. Forwarding puts a credential-shaped token on the wire and draws a 401 indistinguishable from a bad secret — the exact silent misdiagnosis this PR exists to end. A fence that fails open on ambiguity is not a fence.
- Any narrowing would be a **guess about intent** (allow in bodies but not headers? key on content type?), and every such guess is a rule an unlucky miss lands on. Cheap availability cost, uncapped confidentiality cost.
- The false positive is bounded and rare by construction: it needs a whole prefix + exactly-32-hex token, delimited, in an outbound request. That string is minted by this system.

The refusal body now says it keys on the shape, that the false positive is deliberate, and that encoding/redaction is the way out. The test that previously *enshrined* the false positive is rewritten to pin it **as a trade** — asserting the refusal is self-explaining and that the advertised base64 workaround genuinely passes, so the cost has a remedy rather than being a dead end.

## Verification

`uv run ruff check src/ tests/` clean · `uv run mypy src` clean (291 files) · `uv run pytest tests/unit` **4734 passed, 1 skipped, 0 failed** at `354eb455`. (The count drops from 4744 because round 4 withdraws the Finding-4 machinery and the tests that pinned it.)

The earlier claim that `test_sdk_snapshot.py::test_sdk_generated_matches_committed` was a pre-existing failure was **wrong**, and the reviewer was right to push back: it fails only when `uv` is absent from the `PATH` of the pytest subprocess. With `uv` on `PATH` it passes at this head. No test is failing in this PR.

Refs eumemic/eumemic-ops#331 (formerly eumemic/aios#1933).

**DO NOT MERGE** — for review.
