### PR TITLE
Work-state reconciler, phase 1: observe-only label-vs-run join (#2043)

### DIFF
--- a/infra/workflows/work-state-reconciler.wf.py
+++ b/infra/workflows/work-state-reconciler.wf.py
@@ -51,7 +51,25 @@ DEV_PIPELINE_WORKFLOW_ID = "wf_01KV4YGV4PSGP08TJBAY32J2VK"
 LIVE = {"pending", "running"}
 SUSPENDED = {"suspended"}
 TERMINAL = {"completed", "errored", "cancelled"}
-CLASSES = ["ZOMBIE", "DEAD", "MISLABELLED", "LAGGING"]
+CLASSES = ["ZOMBIE", "AMBIGUOUS", "DEAD", "MISLABELLED", "LAGGING"]
+
+# C1 — the UNION of "work is in flight" assertions, NOT the single literal
+# `dispatched`. The seat stripped `dispatched` from all nine confirmed zombies on
+# 2026-07-26; they still carry `autodev:in-progress` + `needs:human/build`, which
+# claim exactly the same thing. Keying on one label would have reported
+# "0 ZOMBIE" over nine dead issues. Mirrors IN_FLIGHT_LABELS in the library.
+IN_FLIGHT_LABELS = {"dispatched", "autodev:in-progress", "design:in-progress"}
+IN_FLIGHT_PREFIXES = ("needs:human/",)
+NOT_IN_FLIGHT_LABELS = {"autodev:built", "autodev:failed", "hold", "paused"}
+
+# B3 — ZOMBIE cannot prove "never picked up": list_runs filters archived_at IS NULL
+# and archiving requires a TERMINAL run, so a completed-then-archived run reads as
+# "no run, ever". Stated in every report rather than left to inference.
+ZOMBIE_MEANS = (
+    "no UNARCHIVED run exists for this item. `list_runs` cannot see archived runs "
+    "(archived_at IS NULL) and archiving requires a TERMINAL run, so ZOMBIE cannot "
+    "distinguish 'never picked up' from 'ran and was tidied away'."
+)
 
 PIPELINE_LABELS = {
     "dispatched",
@@ -71,6 +89,71 @@ MAX_RUN_PAGES = 200
 
 class ReadFailure(Exception):
     """A source read failed. NEVER degrades to an empty list."""
+
+
+def _check_issue_row(repo, row):
+    """Validate ONE issue row. Raises ReadFailure — never AttributeError.
+
+    A 2xx carrying a non-object row used to reach ``row.get()`` and raise
+    AttributeError OUTSIDE the ReadFailure handlers, killing the workflow instead of
+    returning verdict:ALARM. A malformed row is a FAILED READ, which must alarm.
+    """
+    if not isinstance(row, dict):
+        raise ReadFailure(
+            "issue list for %s contained a non-object row (%s)" % (repo, type(row).__name__)
+        )
+    raw_labels = row.get("labels")
+    if raw_labels is not None and not isinstance(raw_labels, list):
+        raise ReadFailure(
+            "issue row %s#%s has a non-list 'labels' (%s)"
+            % (repo, row.get("number"), type(raw_labels).__name__)
+        )
+    return raw_labels or []
+
+
+def _check_run_row(row):
+    """Validate ONE run row. Same contract as :func:`_check_issue_row`."""
+    if not isinstance(row, dict):
+        raise ReadFailure("list_runs returned a non-object run row (%s)" % type(row).__name__)
+    return row
+
+
+def _paginate_check(rows):
+    """Return the keyset cursor for the next page, or None when the page is the last.
+
+    B2 — the mirror of B1 in the CLI. A FULL page whose last row carries no ``id``
+    leaves no cursor: the run history is TRUNCATED and we cannot continue. The old
+    code broke out of the loop with ``exhaustive`` still True, so a truncated read
+    rendered as exhaustive — and every ZOMBIE verdict rests on "no run exists in the
+    list I read". Refusing here is what keeps a partial read from reading as health.
+    """
+    if len(rows) < 200:
+        return None
+    after = rows[-1].get("id")
+    if not after:
+        raise ReadFailure(
+            "list_runs returned a full page (%d rows) whose last row has no 'id' — no "
+            "pagination cursor, so the run history is TRUNCATED. Refusing to report a "
+            "truncated read as exhaustive." % len(rows)
+        )
+    return after
+
+
+def is_in_flight_label(label):
+    """True iff ``label`` asserts work is in flight (a run ought to exist)."""
+    if label in NOT_IN_FLIGHT_LABELS:
+        return False
+    if label in IN_FLIGHT_LABELS:
+        return True
+    for prefix in IN_FLIGHT_PREFIXES:
+        if label.startswith(prefix):
+            return True
+    return False
+
+
+def in_flight_assertions(labels):
+    """Every in-flight assertion in ``labels``, sorted — the trigger set."""
+    return sorted({x for x in labels if is_in_flight_label(x)})
 
 
 def is_pipeline_label(label):
@@ -157,14 +240,16 @@ async def _read_items(repos):
                 raise ReadFailure("issue list for %s was not a JSON array" % repo)
             pages += 1
             for row in body:
+                raw_labels = _check_issue_row(repo, row)
                 labels = sorted(
                     [
                         x.get("name", "") if isinstance(x, dict) else str(x)
-                        for x in (row.get("labels") or [])
+                        for x in raw_labels
                     ]
                 )
-                if not any(is_pipeline_label(x) for x in labels):
-                    continue
+                # C5: unlabelled items are KEPT. LAGGING is defined by the ABSENCE of an
+                # in-flight assertion, so filtering enumeration on presence-of-some-label
+                # makes a live run against an unlabelled issue structurally undetectable.
                 items.append(
                     {
                         "repo": repo,
@@ -275,24 +360,28 @@ async def _read_runs(workflow_ids):
                 # A missing 'runs' key is a CONTRACT failure, not an empty page.
                 raise ReadFailure("list_runs response has no 'runs' list")
             pages += 1
+            for row in rows:
+                _check_run_row(row)
             runs.extend(rows)
-            if len(rows) < 200:
-                break
-            after = rows[-1].get("id")
-            if not after:
+            after = _paginate_check(rows)
+            if after is None:
                 break
     return runs, exhaustive
 
 
 def classify(item, runs):
-    """Classify one item against its runs. ``None`` == the label agrees.
+    """Classify one item against its runs. ``None`` == the labels agree.
 
-    Precedence: live > suspended > terminal. One live run means work really is
-    happening. With none live, a SUSPENDED run is parked at a gate — a different
-    condition from running, so MISLABELLED, not 'agree' (folding parked into agree
-    is how a gate-parked item hides behind `dispatched` forever).
+    MIRROR of ``aios.reconcilers.work_state.classify_item`` — kept in lockstep by
+    the drift tests. Two things this must NOT get wrong:
+
+    * C1 — "claims in flight" is the UNION of in-flight assertions, never the single
+      literal ``dispatched``. The trigger label(s) ride on the finding.
+    * C3 — precedence is live > suspended > UNKNOWN > terminal. An unrecognised
+      status is never evidence of death, not even beside a terminal sibling.
     """
-    dispatched = "dispatched" in item["labels"]
+    labels = item["labels"]
+    triggers = in_flight_assertions(labels)
     live = [r for r in runs if r.get("status") in LIVE]
     suspended = [r for r in runs if r.get("status") in SUSPENDED]
     terminal = [r for r in runs if r.get("status") in TERMINAL]
@@ -304,7 +393,7 @@ def classify(item, runs):
         and r.get("status") not in TERMINAL
     ]
 
-    def mk(classification, detail, subject, caveats=()):
+    def mk(classification, detail, subject, caveats=(), trigger_labels=None):
         return {
             "classification": classification,
             "repo": item["repo"],
@@ -312,41 +401,83 @@ def classify(item, runs):
             "kind": item["kind"],
             "title": item["title"],
             "url": item["url"],
-            "labels": [x for x in item["labels"] if is_pipeline_label(x)],
+            "labels": [x for x in labels if is_pipeline_label(x)],
             "detail": detail,
             "run_ids": [r.get("id", "") for r in subject],
             "run_statuses": sorted({r.get("status", "") for r in subject}),
             "updated_at": item["updated_at"],
             "caveats": list(caveats),
+            "trigger_labels": list(triggers if trigger_labels is None else trigger_labels),
         }
 
-    if not dispatched:
+    def _statuses(rs):
+        return ", ".join(sorted({r.get("status", "") for r in rs}))
+
+    if not triggers:
         if live:
             return mk(
                 "LAGGING",
-                "%d live run(s) but no `dispatched` label" % len(live),
+                "%d live run(s) (%s) but NO in-flight label (no `dispatched`, no "
+                "`autodev:in-progress`, no `needs:human/*`)" % (len(live), _statuses(live)),
                 live,
+                trigger_labels=[],
             )
         return None
+
+    claim = ", ".join(["`%s`" % x for x in triggers])
+
     if live:
         return None
-    if unknown and not suspended and not terminal:
+    if unknown:
+        # C3: handled BEFORE terminal. An unknown status may be live under a name this
+        # vocabulary has not learned; a terminal sibling does not make it dead.
+        others = suspended + terminal
+        extra = ""
+        if others:
+            extra = (
+                " (alongside %d run(s) in %s — a terminal sibling does NOT make an "
+                "unknown status dead)" % (len(others), _statuses(others))
+            )
         return mk(
             "MISLABELLED",
-            "run(s) in unrecognised status — cannot prove live; treat as parked pending triage",
-            unknown,
+            "%s and run(s) in unrecognised status (%s) — cannot prove live; treat as "
+            "parked pending triage%s" % (claim, _statuses(unknown), extra),
+            unknown + others,
             ("unrecognised-run-status",),
         )
     if suspended:
         return mk(
             "MISLABELLED",
-            "%d run(s) suspended at a gate — parked is NOT running" % len(suspended),
+            "%s but %d run(s) suspended at a gate — parked is NOT running"
+            % (claim, len(suspended)),
             suspended,
         )
     if terminal:
-        return mk("DEAD", "`dispatched` but every run is terminal", terminal)
+        return mk(
+            "DEAD",
+            "%s but every run is terminal (%s)" % (claim, _statuses(terminal)),
+            terminal,
+        )
+    linked = item.get("linked_pr_numbers") or []
+    if linked:
+        # C2: linked PRs mean work demonstrably happened, so this is NOT a zombie and
+        # must not land in counts["ZOMBIE"]. Its own class; phase 2 acts on the class.
+        prs = ", ".join(["#%s" % n for n in linked])
+        return mk(
+            "AMBIGUOUS",
+            "%s and no unarchived run — BUT PR(s) %s reference this issue. Work "
+            "demonstrably happened, so the join key (or the run's archival) is the "
+            "suspect, not the item. NEEDS TRIAGE — deliberately NOT counted as a ZOMBIE."
+            % (claim, prs),
+            [],
+            ("has-linked-prs", "excluded-from-zombie-count"),
+        )
     return mk(
-        "ZOMBIE", "`dispatched` but NO run exists for this issue — nothing ever picked it up", []
+        "ZOMBIE",
+        "%s but NO unarchived run exists for this issue — nothing (visible) ever "
+        "picked it up" % claim,
+        [],
+        ("zombie-means-no-unarchived-run",),
     )
 
 
@@ -360,6 +491,7 @@ def build(items, items_exhaustive, runs, runs_exhaustive, failures):
         return {
             "verdict": "ALARM",
             "counts": None,
+            "zombie_means": ZOMBIE_MEANS,
             "total_disagreements": None,
             "failures": failures,
             "disagreements": [],
@@ -386,16 +518,21 @@ def build(items, items_exhaustive, runs, runs_exhaustive, failures):
     unmatched = []
     for run in runs:
         repo, number = _run_key(run)
-        if run.get("status") not in LIVE and run.get("status") not in SUSPENDED:
-            continue
         if repo is None or number is None:
+            # B4: terminal runs included. Dropping an unkeyable `errored` run makes its
+            # issue read as ZOMBIE with no trace of the run that did exist — a
+            # manufactured false ZOMBIE, the exact failure this is meant to prevent.
             unmatched.append(
                 {
                     "run_id": run.get("id", ""),
                     "status": run.get("status", ""),
                     "repo": repo,
                     "issue_number": number,
-                    "reason": "run.input carries no usable (repo, issue_number)",
+                    "reason": (
+                        "run.input carries no usable (repo, issue_number) — join key "
+                        "unreadable (status %s); any item this run belonged to may "
+                        "therefore read as a FALSE ZOMBIE" % (run.get("status") or "unknown")
+                    ),
                 }
             )
         elif run.get("status") in LIVE and (repo, number) not in open_keys:
@@ -415,6 +552,9 @@ def build(items, items_exhaustive, runs, runs_exhaustive, failures):
     return {
         "verdict": "OK",
         "counts": counts,
+        "zombie_means": ZOMBIE_MEANS,
+        "in_flight_labels_checked": sorted(IN_FLIGHT_LABELS)
+        + [x + "*" for x in IN_FLIGHT_PREFIXES],
         "total_disagreements": len(disagreements),
         "failures": [],
         "disagreements": disagreements,
@@ -440,8 +580,14 @@ def disagreement_hash(report):
     else:
         parts = sorted(
             [
-                "%s:%s#%s:%s"
-                % (d["classification"], d["repo"], d["number"], ",".join(sorted(d["run_statuses"])))
+                "%s:%s#%s:%s:%s"
+                % (
+                    d["classification"],
+                    d["repo"],
+                    d["number"],
+                    ",".join(sorted(d["run_statuses"])),
+                    ",".join(sorted(d.get("trigger_labels") or [])),
+                )
                 for d in report["disagreements"]
             ]
         )

--- a/infra/workflows/work-state-reconciler.wf.py
+++ b/infra/workflows/work-state-reconciler.wf.py
@@ -20,6 +20,11 @@ Input::
 Output: the report dict from ``aios.reconcilers.work_state.ReconcileReport.to_dict``,
 plus ``changed`` / ``wake_seat``.
 
+C4 note on the read surface: besides the issue-list and timeline reads, the run also
+GETs ``/repos/{repo}/issues/{n}`` for each run join key that matched NO enumerated
+item (the stale-key probe). Still GET, still under the same GET-only ``github``
+http_server route.
+
 WRITES NOTHING. Only ``GET`` is ever issued (``_gh`` hard-refuses any other verb),
 and the github http_server this runs under is declared GET-only. No label edit, no
 comment on a reconciled item, no re-dispatch, no close. Phase 2 (demotion) is gated
@@ -94,6 +99,11 @@ MAX_TIMELINE_PAGES = 20
 #: silent following in the CLI so the two forms enumerate the same items.
 MAX_REDIRECT_HOPS = 5
 
+#: Ceiling on the C4 stale-join-key probes issued per run. Hitting it is NOT silently
+#: ignored: a note says how many keys went UNPROBED, so a transfer we did not look for
+#: is visible as a gap rather than as a zombie.
+MAX_TRANSFER_PROBES = 400
+
 #: A GitHub 3xx on an issue read IS the transfer signal (C4). ``http_request`` does
 #: NOT follow redirects (httpx defaults ``follow_redirects=False``), so a
 #: transferred issue comes back as a literal 301 carrying ``Location``; the urllib
@@ -113,6 +123,37 @@ def transfer_note(repo, number, dest):
     return (
         f"{repo}#{number} was REDIRECTED to {dest} — the issue appears to have been TRANSFERRED, "
         "so any run keyed to these coordinates cannot join (C4)"
+    )
+
+
+def parse_issue_ref(url):
+    """``(repo, number)`` from a GitHub issue API/HTML url; ``None`` when unreadable.
+
+    Mirror of ``aios.reconcilers.work_state.parse_issue_ref``. Never guesses — a
+    guessed join key manufactures a phantom 'agree', the exact false health this
+    reconciler exists to prevent.
+    """
+    if not isinstance(url, str) or not url:
+        return None
+    parts = [p for p in url.split("?", 1)[0].rstrip("/").split("/") if p]
+    if len(parts) < 4 or parts[-2] not in ("issues", "pull", "pulls"):
+        return None
+    number = _issue_number(parts[-1])
+    owner, name = parts[-4], parts[-3]
+    if number is None or owner in ("repos", "github.com", "api.github.com"):
+        return None
+    return (f"{owner}/{name}", number)
+
+
+def stale_key_transfer_note(stale_repo, stale_number, dest, run_ids=()):
+    """The C4 note for an INVERTED probe hit. Byte-identical to the library form —
+    pinned by the reader drift guard, so the two forms cannot describe the same
+    transfer differently."""
+    ids = ", ".join(sorted(run_ids)) or "(none)"
+    return (
+        f"STALE JOIN KEY: {stale_repo}#{stale_number} — held by run(s) {ids} — RESOLVES to "
+        f"{dest}. The issue was TRANSFERRED, so that run can never join, and the issue at "
+        "its NEW coordinates would otherwise read as a FALSE ZOMBIE (C4)"
     )
 
 
@@ -408,6 +449,102 @@ async def _read_items(repos, enrich_linked_prs=True):
     return items, exhaustive, notes
 
 
+# ─── C4: the INVERTED stale-join-key probe (the mirror of probe_stale_keys) ──
+
+
+def _stale_run_keys(items, runs):
+    """Every run join key that matched NO enumerated item — the C4 probe list.
+
+    This INVERSION is what makes transfer detection possible at all. A completed
+    transfer is invisible from the new coordinates (they answer 200 as themselves) and
+    invisible from enumeration (which only ever returns the new pair). It survives in
+    exactly one place: the OLD pair held in ``run.input``. The first cut of C4 started
+    from an ENUMERATED issue and waited for a redirect — a world production cannot
+    present — so all 68 issues that moved repos on 2026-07-25 still became false
+    ZOMBIEs. Returns ``{(repo, number): [run_id, ...]}``.
+    """
+    open_keys = {(i["repo"], i["number"]) for i in items}
+    stale = {}
+    for run in runs:
+        repo, number = _run_key(run)
+        if repo is None or number is None or (repo, number) in open_keys:
+            continue
+        stale.setdefault((repo, number), []).append(run.get("id", ""))
+    return {k: sorted(v) for k, v in sorted(stale.items())}
+
+
+async def _probe_transfer(repo, number):
+    """GET the STALE coordinates directly (GET-only). Returns the destination or ``""``.
+
+    ``http_request`` does not follow redirects, so a TRANSFERRED issue answers with a
+    literal 3xx + ``Location`` — the authoritative evidence. A 200 whose body names
+    DIFFERENT coordinates than the ones asked for is the same event seen through a
+    transport that did follow the hop (which is what the urllib CLI sees), so both are
+    accepted and the two forms observe the same transfer.
+    """
+    path = f"/repos/{repo}/issues/{number}"
+    body, _link, location = await _gh(path, allow_redirect=True)
+    if location:
+        ref = parse_issue_ref(location)
+        if ref is None or ref != (repo, number):
+            return location
+        return ""
+    if isinstance(body, dict):
+        for field in ("url", "html_url"):
+            ref = parse_issue_ref(body.get(field))
+            if ref is not None and ref != (repo, number):
+                return body[field]
+    return ""
+
+
+async def _probe_stale_keys(items, runs):
+    """Probe every stale join key (C4). Returns ``(transfers, notes)``. GET-only.
+
+    A key that resolves to itself yields nothing — most stale keys are just runs
+    against CLOSED issues, which is normal and not a finding.
+
+    A read error here is a NOTE, not an ALARM: a run against a deleted or invisible
+    issue is an expected shape of history and the run is already reported as unmatched.
+    Failing the whole reconcile on it would turn routine history into an outage.
+    """
+    stale = _stale_run_keys(items, runs)
+    keys = list(stale.items())
+    notes = []
+    transfers = []
+    if len(keys) > MAX_TRANSFER_PROBES:
+        notes.append(
+            f"C4 stale-key probe capped at {MAX_TRANSFER_PROBES} of {len(keys)} stale join "
+            f"key(s) — {len(keys) - MAX_TRANSFER_PROBES} were NOT probed, so a transfer among "
+            "them would be unreported. Counts involving ZOMBIE are therefore floors for "
+            "those items."
+        )
+        keys = keys[:MAX_TRANSFER_PROBES]
+    for (repo, number), run_ids in keys:
+        try:
+            destination = await _probe_transfer(repo, number)
+        except ReadFailure as exc:
+            notes.append(
+                f"C4 stale-key probe could not read {repo}#{number} ({exc}) — a transfer "
+                "there would be unreported; the run(s) holding this key remain listed as "
+                "unmatched ({})".format(", ".join(run_ids))
+            )
+            continue
+        if not destination:
+            continue
+        ref = parse_issue_ref(destination)
+        transfers.append(
+            {
+                "stale_repo": repo,
+                "stale_number": number,
+                "destination": destination,
+                "new_repo": None if ref is None else ref[0],
+                "new_number": None if ref is None else ref[1],
+                "run_ids": list(run_ids),
+            }
+        )
+    return transfers, notes
+
+
 def _normalise_repo(raw, default_owner="eumemic"):
     """Canonicalise a repo reference from ``run.input``; ``None`` when unreadable.
 
@@ -511,7 +648,7 @@ async def _read_runs(workflow_ids):
     return runs, exhaustive
 
 
-def classify(item, runs):
+def classify(item, runs, transfer=None):
     """Classify one item against its runs. ``None`` == the labels agree.
 
     MIRROR of ``aios.reconcilers.work_state.classify_item`` — kept in lockstep by
@@ -521,6 +658,9 @@ def classify(item, runs):
       literal ``dispatched``. The trigger label(s) ride on the finding.
     * C3 — precedence is live > suspended > UNKNOWN > terminal. An unrecognised
       status is never evidence of death, not even beside a terminal sibling.
+    * C4 — ``transfer`` is evidence from the INVERTED probe that a run exists but is
+      keyed to this issue's OLD coordinates. A stale join key is not a dead issue:
+      AMBIGUOUS/NEEDS-TRIAGE, kept OUT of ``counts["ZOMBIE"]``.
     """
     labels = item["labels"]
     triggers = in_flight_assertions(labels)
@@ -599,6 +739,25 @@ def classify(item, runs):
             f"{claim} but every run is terminal ({_statuses(terminal)})",
             terminal,
         )
+    if transfer is not None:
+        # C4: a run DOES exist for this work — under the coordinates the issue had
+        # before it was TRANSFERRED, so it cannot join here. "No run" is false, and
+        # ZOMBIE would be a verdict manufactured out of a stale join key.
+        moved_from = "{}#{}".format(transfer["stale_repo"], transfer["stale_number"])
+        ids = ", ".join(transfer.get("run_ids") or []) or "(none)"
+        linked_now = item.get("linked_pr_numbers") or []
+        prs = (
+            " Linked PR(s): " + ", ".join([f"#{n}" for n in linked_now]) + "." if linked_now else ""
+        )
+        return mk(
+            "AMBIGUOUS",
+            f"{claim} and no unarchived run at THESE coordinates — BUT {moved_from} "
+            f"RESOLVES here, i.e. this issue was TRANSFERRED and run(s) {ids} still hold "
+            f"the OLD join key. The key is stale, not the work missing.{prs} "
+            "NEEDS TRIAGE — deliberately NOT counted as a ZOMBIE.",
+            [],
+            ("transferred-stale-join-key", "excluded-from-zombie-count"),
+        )
     linked = item.get("linked_pr_numbers") or []
     if linked:
         # C2: linked PRs mean work demonstrably happened, so this is NOT a zombie and
@@ -621,7 +780,17 @@ def classify(item, runs):
     )
 
 
-def build(items, items_exhaustive, runs, runs_exhaustive, failures, notes=()):
+def _transfer_note_of(evidence):
+    """Render ONE piece of C4 stale-key evidence as its note (single source of truth)."""
+    return stale_key_transfer_note(
+        evidence["stale_repo"],
+        evidence["stale_number"],
+        evidence["destination"],
+        evidence.get("run_ids") or [],
+    )
+
+
+def build(items, items_exhaustive, runs, runs_exhaustive, failures, notes=(), transfers=()):
     """Join + classify. **Any failure ⇒ ALARM with counts:null.**
 
     The counts key is ``None`` — not ``{}``, not zeros — on ALARM, so a consumer
@@ -634,7 +803,10 @@ def build(items, items_exhaustive, runs, runs_exhaustive, failures, notes=()):
             "zombie_means": ZOMBIE_MEANS,
             "total_disagreements": None,
             "failures": failures,
-            "notes": list(notes),
+            # C4 evidence rides even on the ALARM path so a NEWLY-found stale key still
+            # changes the hash and wakes the seat.
+            "transfers": list(transfers),
+            "notes": list(notes) + [_transfer_note_of(t) for t in transfers],
             "disagreements": [],
             "unmatched_runs": [],
             "exhaustive": False,
@@ -650,9 +822,23 @@ def build(items, items_exhaustive, runs, runs_exhaustive, failures, notes=()):
         index.setdefault((repo, number), []).append(run)
 
     open_keys = {(i["repo"], i["number"]) for i in items}
+
+    # C4: index the transfer evidence by the item it LANDS ON (the new coordinates) —
+    # that is the item otherwise facing a false ZOMBIE verdict.
+    transfers_by_new_key = {}
+    for evidence in transfers:
+        if evidence.get("new_repo") and evidence.get("new_number"):
+            transfers_by_new_key.setdefault(
+                (evidence["new_repo"], evidence["new_number"]), evidence
+            )
+
     disagreements = []
     for item in sorted(items, key=lambda i: (i["repo"], i["number"])):
-        verdict = classify(item, index.get((item["repo"], item["number"]), []))
+        verdict = classify(
+            item,
+            index.get((item["repo"], item["number"]), []),
+            transfers_by_new_key.get((item["repo"], item["number"])),
+        )
         if verdict is not None:
             disagreements.append(verdict)
 
@@ -700,8 +886,11 @@ def build(items, items_exhaustive, runs, runs_exhaustive, failures, notes=()):
         "failures": [],
         # C4 — transfer notes ride on the report, never suppressed. A stale join key
         # is DATA a triager must see; swallowing it is how a transfer masquerades as
-        # a zombie.
-        "notes": list(notes),
+        # a zombie. Notes are emitted for EVERY piece of evidence, including a
+        # transfer whose destination is outside the scanned repos, where no item
+        # exists to carry the caveat and the note is the only trace.
+        "notes": list(notes) + [_transfer_note_of(t) for t in transfers],
+        "transfers": list(transfers),
         "disagreements": disagreements,
         "unmatched_runs": unmatched,
         "exhaustive": bool(items_exhaustive and runs_exhaustive),
@@ -741,6 +930,15 @@ def disagreement_hash(report):
                 for d in report["disagreements"]
             ]
         )
+    # ITEM 2 / C4 — the transfer notes are part of the change identity. A stale key
+    # whose destination is outside the scanned repos produces NO disagreement at all,
+    # so a hash blind to these would read a newly-discovered transfer as "unchanged,
+    # nothing to say" and leave the seat asleep. Hashed as their own SORTED section so
+    # adding them cannot collide with a disagreement identity. Mirrors
+    # ReconcileReport.transfer_notes / disagreement_hash in the library.
+    transfer_parts = sorted({_transfer_note_of(t) for t in report.get("transfers") or []})
+    if transfer_parts:
+        parts = [*list(parts), "TRANSFERS", *transfer_parts]
     return hashlib.sha256("\n".join(parts).encode()).hexdigest()
 
 
@@ -767,8 +965,25 @@ async def main(input):
     except ReadFailure as exc:
         failures.append({"source": "aios-runs", "reason": str(exc)})
 
+    # C4 — the INVERTED probe. It needs BOTH sources (a stale join key is only knowable
+    # once enumeration and the run list are both in hand), so it runs here. Skipped when
+    # either read failed: the report already ALARMs, and probing coordinates derived
+    # from a partial read would attach confident transfer evidence to an unreliable join.
+    phase("probe-stale-keys")  # noqa: F821
+    transfers = []
+    if not failures:
+        try:
+            transfers, probe_notes = await _probe_stale_keys(items, runs)
+            notes = list(notes) + list(probe_notes)
+        except ReadFailure as exc:
+            notes = [
+                *list(notes),
+                f"C4 stale-key probe failed: {exc} — a transferred issue among the stale "
+                "join keys would be unreported",
+            ]
+
     phase("join")  # noqa: F821
-    report = build(items, items_exhaustive, runs, runs_exhaustive, failures, notes)
+    report = build(items, items_exhaustive, runs, runs_exhaustive, failures, notes, transfers)
     current_hash = disagreement_hash(report)
     report["disagreement_hash"] = current_hash
     report["changed"] = previous_hash != current_hash

--- a/infra/workflows/work-state-reconciler.wf.py
+++ b/infra/workflows/work-state-reconciler.wf.py
@@ -1,0 +1,493 @@
+"""Work-state reconciler, phase 1 (OBSERVE-ONLY) — the durable aios workflow form.
+
+Registered as an aios workflow and fired on a cron. It is a DETERMINISTIC workflow:
+it makes **no model calls and spawns no agents**. Every step is mechanical
+computation — enumerate, join, classify, hash — per the intelligence-vs-computation
+doctrine: reserve intelligence for judgment, not for a join.
+
+Declared surface (the launcher's agent surface must SUPERSET this, or the run is
+silently attenuated — the #1386/#2043 launcher-clamp trap):
+
+    tools:        http_request, list_runs
+    http_servers: github (GET /repos/**)
+
+Input::
+
+    {"repos": ["eumemic/aios", ...],          # optional, defaults below
+     "workflow_ids": ["wf_01KV4YGV4PSGP08TJBAY32J2VK"],
+     "previous_hash": "<the last disagreement_hash>"}   # for change detection
+
+Output: the report dict from ``aios.reconcilers.work_state.ReconcileReport.to_dict``,
+plus ``changed`` / ``wake_seat``.
+
+WRITES NOTHING. Only ``GET`` is ever issued (``_gh`` hard-refuses any other verb),
+and the github http_server this runs under is declared GET-only. No label edit, no
+comment on a reconciled item, no re-dispatch, no close. Phase 2 (demotion) is gated
+on reviewing a week of phase-1 data.
+
+FAIL-LOUD: every read is checked. A failed read produces ``verdict: ALARM`` with
+``counts: null`` — never an empty list rendered as health. That failure (an empty
+result from a broken query reading as health) happened twice on 2026-07-25 and is
+the bug class this whole effort exists to kill.
+
+The classification logic here is a deliberate MIRROR of
+``aios.reconcilers.work_state`` (the script host cannot import ``aios.*``);
+``tests/unit/test_work_state_reconciler.py`` asserts the two agree on the same
+fixtures, so they cannot drift apart silently.
+"""
+
+import hashlib
+import json
+
+DEFAULT_REPOS = [
+    "eumemic/aios",
+    "eumemic/eumemic-ops",
+    "eumemic/eumemic-company",
+    "eumemic/aios-console",
+    "eumemic/autodev",
+]
+DEV_PIPELINE_WORKFLOW_ID = "wf_01KV4YGV4PSGP08TJBAY32J2VK"
+
+LIVE = {"pending", "running"}
+SUSPENDED = {"suspended"}
+TERMINAL = {"completed", "errored", "cancelled"}
+CLASSES = ["ZOMBIE", "DEAD", "MISLABELLED", "LAGGING"]
+
+PIPELINE_LABELS = {
+    "dispatched",
+    "approved",
+    "hold",
+    "paused",
+    "escalated",
+    "blocked",
+    "ci-loop-exhausted",
+    "merge:approved",
+}
+PIPELINE_PREFIXES = ("needs:human/", "autodev:", "pipeline:")
+
+MAX_ISSUE_PAGES = 50
+MAX_RUN_PAGES = 200
+
+
+class ReadFailure(Exception):
+    """A source read failed. NEVER degrades to an empty list."""
+
+
+def is_pipeline_label(label):
+    if label in PIPELINE_LABELS:
+        return True
+    for prefix in PIPELINE_PREFIXES:
+        if label.startswith(prefix):
+            return True
+    return False
+
+
+async def _gh(path, method="GET"):
+    """One GitHub GET through the declared ``github`` http_server.
+
+    Refuses any other verb outright: phase 1 is observe-only and this is the single
+    door to GitHub, so the constraint is enforced at the door rather than by
+    reviewer vigilance over call sites.
+    """
+    if method != "GET":
+        raise ReadFailure("phase-1 reconciler is OBSERVE-ONLY: refusing %s %s" % (method, path))
+    result = await tool(  # noqa: F821 - injected capability
+        "http_request", {"server_ref": "github", "path": path, "method": "GET"}
+    )
+    # tool() returns errors as VALUES. An unchecked error here would parse as an
+    # empty page — the exact silent-degradation this reconciler exists to detect.
+    if not isinstance(result, dict):
+        raise ReadFailure("http_request returned %r for %s" % (type(result), path))
+    if "error" in result:
+        raise ReadFailure("GET %s failed: %s" % (path, result["error"]))
+    if result.get("truncated"):
+        raise ReadFailure("GET %s response was TRUNCATED — a cut body is not a page" % path)
+    status = result.get("status")
+    if not isinstance(status, int) or not (200 <= status < 300):
+        raise ReadFailure("GET %s → HTTP %s" % (path, status))
+    body = result.get("body")
+    try:
+        parsed = json.loads(body) if body else None
+    except Exception as exc:
+        raise ReadFailure("GET %s returned unparseable JSON: %s" % (path, exc))
+    link = ""
+    for pair in result.get("headers") or []:
+        if len(pair) == 2 and pair[0].lower() == "link":
+            link = pair[1]
+    return parsed, link
+
+
+def _next_link(link_header):
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        segments = part.split(";")
+        if len(segments) >= 2 and 'rel="next"' in "".join(segments[1:]):
+            return segments[0].strip().strip("<>")
+    return None
+
+
+def _path_of(url):
+    """Reduce an absolute GitHub URL to the path+query the http_server route expects."""
+    marker = "api.github.com"
+    if marker in url:
+        return url.split(marker, 1)[1]
+    return url
+
+
+async def _read_items(repos):
+    """Open issues/PRs carrying any pipeline state label, across ``repos``.
+
+    Enumerates ALL open items and filters locally: the LAGGING class is defined by
+    the ABSENCE of ``dispatched``, so a server-side ``?labels=dispatched`` filter
+    would be structurally incapable of finding it — the same defect as the stall
+    detectors that could not see the zombies because they trusted the lying label.
+    """
+    items = []
+    exhaustive = True
+    for repo in repos:
+        path = "/repos/%s/issues?state=open&per_page=100&sort=created&direction=desc" % repo
+        pages = 0
+        while path is not None:
+            if pages >= MAX_ISSUE_PAGES:
+                exhaustive = False
+                break
+            body, link = await _gh(path)
+            if not isinstance(body, list):
+                raise ReadFailure("issue list for %s was not a JSON array" % repo)
+            pages += 1
+            for row in body:
+                labels = sorted(
+                    [
+                        x.get("name", "") if isinstance(x, dict) else str(x)
+                        for x in (row.get("labels") or [])
+                    ]
+                )
+                if not any(is_pipeline_label(x) for x in labels):
+                    continue
+                items.append(
+                    {
+                        "repo": repo,
+                        "number": row.get("number"),
+                        "kind": "pull_request" if "pull_request" in row else "issue",
+                        "title": row.get("title", ""),
+                        "labels": labels,
+                        "url": row.get("html_url", ""),
+                        "updated_at": row.get("updated_at", ""),
+                    }
+                )
+            nxt = _next_link(link)
+            path = _path_of(nxt) if nxt else None
+    return items, exhaustive
+
+
+def _normalise_repo(raw, default_owner="eumemic"):
+    """Canonicalise a repo reference from ``run.input``; ``None`` when unreadable.
+
+    Never guesses: a wrong guess manufactures a phantom 'agree', which is exactly
+    the false-health this reconciler exists to prevent.
+    """
+    if isinstance(raw, dict):
+        owner = raw.get("owner")
+        name = raw.get("name") or raw.get("repo")
+        if isinstance(owner, str) and isinstance(name, str) and owner and name:
+            return "%s/%s" % (owner.strip("/"), name.strip("/"))
+        raw = name
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if "github.com" in text:
+        tail = text.split("github.com", 1)[1].lstrip(":/")
+        parts = [p for p in tail.split("/") if p]
+        if len(parts) >= 2:
+            name = parts[1]
+            if name.endswith(".git"):
+                name = name[:-4]
+            return "%s/%s" % (parts[0], name)
+        return None
+    if text.endswith(".git"):
+        text = text[:-4]
+    parts = [p for p in text.strip("/").split("/") if p]
+    if len(parts) == 1:
+        return "%s/%s" % (default_owner, parts[0])
+    if len(parts) == 2:
+        return "%s/%s" % (parts[0], parts[1])
+    return None
+
+
+def _issue_number(raw):
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw if raw > 0 else None
+    if isinstance(raw, str):
+        text = raw.strip().lstrip("#")
+        if text.isdigit() and int(text) > 0:
+            return int(text)
+    return None
+
+
+def _run_key(run):
+    inp = run.get("input")
+    if not isinstance(inp, dict):
+        return (None, None)
+    repo = None
+    for k in ("repo", "repository", "repo_full_name", "full_name"):
+        if k in inp:
+            repo = _normalise_repo(inp[k])
+            break
+    number = None
+    for k in ("issue_number", "issue", "number", "issueNumber"):
+        if k in inp:
+            number = _issue_number(inp[k])
+            break
+    return (repo, number)
+
+
+async def _read_runs(workflow_ids):
+    """Every run of the pipeline workflow(s) — including terminal ones.
+
+    'No run, ever' is only a sound ZOMBIE verdict if this read reaches the whole
+    history, so a truncated read marks the source non-exhaustive and every derived
+    count renders as a floor ('at least N') rather than a total.
+    """
+    runs = []
+    exhaustive = True
+    for workflow_id in workflow_ids:
+        after = None
+        pages = 0
+        while True:
+            if pages >= MAX_RUN_PAGES:
+                exhaustive = False
+                break
+            args = {"workflow_id": workflow_id, "limit": 200, "account_wide": True}
+            if after:
+                args["after"] = after
+            result = await tool("list_runs", args)  # noqa: F821 - injected capability
+            if not isinstance(result, dict):
+                raise ReadFailure("list_runs returned %r" % type(result))
+            if "error" in result:
+                raise ReadFailure("list_runs failed: %s" % result["error"])
+            rows = result.get("runs")
+            if not isinstance(rows, list):
+                # A missing 'runs' key is a CONTRACT failure, not an empty page.
+                raise ReadFailure("list_runs response has no 'runs' list")
+            pages += 1
+            runs.extend(rows)
+            if len(rows) < 200:
+                break
+            after = rows[-1].get("id")
+            if not after:
+                break
+    return runs, exhaustive
+
+
+def classify(item, runs):
+    """Classify one item against its runs. ``None`` == the label agrees.
+
+    Precedence: live > suspended > terminal. One live run means work really is
+    happening. With none live, a SUSPENDED run is parked at a gate — a different
+    condition from running, so MISLABELLED, not 'agree' (folding parked into agree
+    is how a gate-parked item hides behind `dispatched` forever).
+    """
+    dispatched = "dispatched" in item["labels"]
+    live = [r for r in runs if r.get("status") in LIVE]
+    suspended = [r for r in runs if r.get("status") in SUSPENDED]
+    terminal = [r for r in runs if r.get("status") in TERMINAL]
+    unknown = [
+        r
+        for r in runs
+        if r.get("status") not in LIVE
+        and r.get("status") not in SUSPENDED
+        and r.get("status") not in TERMINAL
+    ]
+
+    def mk(classification, detail, subject, caveats=()):
+        return {
+            "classification": classification,
+            "repo": item["repo"],
+            "number": item["number"],
+            "kind": item["kind"],
+            "title": item["title"],
+            "url": item["url"],
+            "labels": [x for x in item["labels"] if is_pipeline_label(x)],
+            "detail": detail,
+            "run_ids": [r.get("id", "") for r in subject],
+            "run_statuses": sorted({r.get("status", "") for r in subject}),
+            "updated_at": item["updated_at"],
+            "caveats": list(caveats),
+        }
+
+    if not dispatched:
+        if live:
+            return mk(
+                "LAGGING",
+                "%d live run(s) but no `dispatched` label" % len(live),
+                live,
+            )
+        return None
+    if live:
+        return None
+    if unknown and not suspended and not terminal:
+        return mk(
+            "MISLABELLED",
+            "run(s) in unrecognised status — cannot prove live; treat as parked pending triage",
+            unknown,
+            ("unrecognised-run-status",),
+        )
+    if suspended:
+        return mk(
+            "MISLABELLED",
+            "%d run(s) suspended at a gate — parked is NOT running" % len(suspended),
+            suspended,
+        )
+    if terminal:
+        return mk("DEAD", "`dispatched` but every run is terminal", terminal)
+    return mk(
+        "ZOMBIE", "`dispatched` but NO run exists for this issue — nothing ever picked it up", []
+    )
+
+
+def build(items, items_exhaustive, runs, runs_exhaustive, failures):
+    """Join + classify. **Any failure ⇒ ALARM with counts:null.**
+
+    The counts key is ``None`` — not ``{}``, not zeros — on ALARM, so a consumer
+    cannot render 'no disagreements' from a broken read. There is no count to render.
+    """
+    if failures:
+        return {
+            "verdict": "ALARM",
+            "counts": None,
+            "total_disagreements": None,
+            "failures": failures,
+            "disagreements": [],
+            "unmatched_runs": [],
+            "exhaustive": False,
+            "items_scanned": 0,
+            "runs_scanned": 0,
+        }
+
+    index = {}
+    for run in runs:
+        repo, number = _run_key(run)
+        if repo is None or number is None:
+            continue
+        index.setdefault((repo, number), []).append(run)
+
+    open_keys = {(i["repo"], i["number"]) for i in items}
+    disagreements = []
+    for item in sorted(items, key=lambda i: (i["repo"], i["number"])):
+        verdict = classify(item, index.get((item["repo"], item["number"]), []))
+        if verdict is not None:
+            disagreements.append(verdict)
+
+    unmatched = []
+    for run in runs:
+        repo, number = _run_key(run)
+        if run.get("status") not in LIVE and run.get("status") not in SUSPENDED:
+            continue
+        if repo is None or number is None:
+            unmatched.append(
+                {
+                    "run_id": run.get("id", ""),
+                    "status": run.get("status", ""),
+                    "repo": repo,
+                    "issue_number": number,
+                    "reason": "run.input carries no usable (repo, issue_number)",
+                }
+            )
+        elif run.get("status") in LIVE and (repo, number) not in open_keys:
+            unmatched.append(
+                {
+                    "run_id": run.get("id", ""),
+                    "status": run.get("status", ""),
+                    "repo": repo,
+                    "issue_number": number,
+                    "reason": "live run against an item that is not open in the scanned repos",
+                }
+            )
+
+    order = {c: n for n, c in enumerate(CLASSES)}
+    disagreements.sort(key=lambda d: (order[d["classification"]], d["repo"], d["number"]))
+    counts = {c: len([d for d in disagreements if d["classification"] == c]) for c in CLASSES}
+    return {
+        "verdict": "OK",
+        "counts": counts,
+        "total_disagreements": len(disagreements),
+        "failures": [],
+        "disagreements": disagreements,
+        "unmatched_runs": unmatched,
+        "exhaustive": bool(items_exhaustive and runs_exhaustive),
+        "items_scanned": len(items),
+        "runs_scanned": len(runs),
+    }
+
+
+def disagreement_hash(report):
+    """Hash of the disagreement SET — the seat-wake change detector.
+
+    Identity = class + item + run statuses (NOT run ids), so a re-dispatch that
+    yields the same verdict for the same reason does not spam the seat, while a
+    real transition (suspended → errored) does. On ALARM the failure reasons are
+    hashed instead, so a NEW outage still wakes the seat.
+    """
+    if report["verdict"] == "ALARM":
+        parts = ["ALARM"] + sorted(
+            ["%s:%s" % (f.get("source", ""), f.get("reason", "")) for f in report["failures"]]
+        )
+    else:
+        parts = sorted(
+            [
+                "%s:%s#%s:%s"
+                % (d["classification"], d["repo"], d["number"], ",".join(sorted(d["run_statuses"])))
+                for d in report["disagreements"]
+            ]
+        )
+    return hashlib.sha256("\n".join(parts).encode()).hexdigest()
+
+
+async def main(input):
+    input = input if isinstance(input, dict) else {}
+    repos = input.get("repos") or DEFAULT_REPOS
+    workflow_ids = input.get("workflow_ids") or [DEV_PIPELINE_WORKFLOW_ID]
+    previous_hash = input.get("previous_hash")
+
+    phase("read-github")  # noqa: F821 - injected capability
+    failures = []
+    items, items_exhaustive = [], True
+    try:
+        items, items_exhaustive = await _read_items(repos)
+    except ReadFailure as exc:
+        # A failed read is recorded as a FAILURE, never swallowed into an empty
+        # list. The report below will ALARM and carry counts:null.
+        failures.append({"source": "github", "reason": str(exc)})
+
+    phase("read-runs")  # noqa: F821
+    runs, runs_exhaustive = [], True
+    try:
+        runs, runs_exhaustive = await _read_runs(workflow_ids)
+    except ReadFailure as exc:
+        failures.append({"source": "aios-runs", "reason": str(exc)})
+
+    phase("join")  # noqa: F821
+    report = build(items, items_exhaustive, runs, runs_exhaustive, failures)
+    current_hash = disagreement_hash(report)
+    report["disagreement_hash"] = current_hash
+    report["changed"] = previous_hash != current_hash
+    # Wake the seat when the disagreement SET changes, and ALWAYS on an ALARM —
+    # silence is not health, so a broken read is never allowed to be quiet.
+    report["wake_seat"] = bool(report["changed"] or report["verdict"] == "ALARM")
+    report["phase"] = "1-observe-only"
+    report["writes_performed"] = 0
+    report["repos_scanned"] = list(repos)
+
+    if report["verdict"] == "ALARM":
+        log("ALARM: work-state reconciler could not read its sources: %s" % json.dumps(failures))  # noqa: F821
+    else:
+        log(  # noqa: F821
+            "work-state: %s (exhaustive=%s, changed=%s)"
+            % (json.dumps(report["counts"]), report["exhaustive"], report["changed"])
+        )
+    return report

--- a/infra/workflows/work-state-reconciler.wf.py
+++ b/infra/workflows/work-state-reconciler.wf.py
@@ -242,10 +242,7 @@ async def _read_items(repos):
             for row in body:
                 raw_labels = _check_issue_row(repo, row)
                 labels = sorted(
-                    [
-                        x.get("name", "") if isinstance(x, dict) else str(x)
-                        for x in raw_labels
-                    ]
+                    [x.get("name", "") if isinstance(x, dict) else str(x) for x in raw_labels]
                 )
                 # C5: unlabelled items are KEPT. LAGGING is defined by the ABSENCE of an
                 # in-flight assertion, so filtering enumeration on presence-of-some-label

--- a/infra/workflows/work-state-reconciler.wf.py
+++ b/infra/workflows/work-state-reconciler.wf.py
@@ -85,6 +85,35 @@ PIPELINE_PREFIXES = ("needs:human/", "autodev:", "pipeline:")
 
 MAX_ISSUE_PAGES = 50
 MAX_RUN_PAGES = 200
+#: Timeline pages read per issue when acquiring the linked-PR evidence (C2). A
+#: TRUNCATED timeline is a FAILED read, not a short one: the page we did not read
+#: is exactly where the PR that disproves a ZOMBIE would be, so stopping quietly
+#: manufactures the false ZOMBIE this reconciler exists to catch.
+MAX_TIMELINE_PAGES = 20
+#: Redirect hops followed on the issue-LIST path (a renamed repo). Mirrors urllib's
+#: silent following in the CLI so the two forms enumerate the same items.
+MAX_REDIRECT_HOPS = 5
+
+#: A GitHub 3xx on an issue read IS the transfer signal (C4). ``http_request`` does
+#: NOT follow redirects (httpx defaults ``follow_redirects=False``), so a
+#: transferred issue comes back as a literal 301 carrying ``Location``; the urllib
+#: CLI sees the same event as a silent hop and reports ``resp.geturl()``. Different
+#: mechanism, SAME note — which is what the reader drift guard pins.
+REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+
+
+def transfer_note(repo, number, dest):
+    """The C4 note. Byte-identical to the library/CLI form — pinned by the drift guard.
+
+    68 issues changed repos on 2026-07-25. A transfer gives the issue a NEW
+    (repo, number) while every ``run.input`` still holds the OLD one, so the join
+    key is stale and the item reads as a FALSE ZOMBIE. Detection only in phase 1:
+    we report the stale key, we do not rewrite it.
+    """
+    return (
+        f"{repo}#{number} was REDIRECTED to {dest} — the issue appears to have been TRANSFERRED, "
+        "so any run keyed to these coordinates cannot join (C4)"
+    )
 
 
 class ReadFailure(Exception):
@@ -100,13 +129,14 @@ def _check_issue_row(repo, row):
     """
     if not isinstance(row, dict):
         raise ReadFailure(
-            "issue list for %s contained a non-object row (%s)" % (repo, type(row).__name__)
+            f"issue list for {repo} contained a non-object row ({type(row).__name__})"
         )
     raw_labels = row.get("labels")
     if raw_labels is not None and not isinstance(raw_labels, list):
         raise ReadFailure(
-            "issue row %s#%s has a non-list 'labels' (%s)"
-            % (repo, row.get("number"), type(raw_labels).__name__)
+            "issue row {}#{} has a non-list 'labels' ({})".format(
+                repo, row.get("number"), type(raw_labels).__name__
+            )
         )
     return raw_labels or []
 
@@ -114,7 +144,7 @@ def _check_issue_row(repo, row):
 def _check_run_row(row):
     """Validate ONE run row. Same contract as :func:`_check_issue_row`."""
     if not isinstance(row, dict):
-        raise ReadFailure("list_runs returned a non-object run row (%s)" % type(row).__name__)
+        raise ReadFailure(f"list_runs returned a non-object run row ({type(row).__name__})")
     return row
 
 
@@ -132,9 +162,9 @@ def _paginate_check(rows):
     after = rows[-1].get("id")
     if not after:
         raise ReadFailure(
-            "list_runs returned a full page (%d rows) whose last row has no 'id' — no "
-            "pagination cursor, so the run history is TRUNCATED. Refusing to report a "
-            "truncated read as exhaustive." % len(rows)
+            f"list_runs returned a full page ({len(rows)} rows) whose last row has no "
+            "'id' — no pagination cursor, so the run history is TRUNCATED. Refusing to "
+            "report a truncated read as exhaustive."
         )
     return after
 
@@ -145,10 +175,7 @@ def is_in_flight_label(label):
         return False
     if label in IN_FLIGHT_LABELS:
         return True
-    for prefix in IN_FLIGHT_PREFIXES:
-        if label.startswith(prefix):
-            return True
-    return False
+    return any(label.startswith(prefix) for prefix in IN_FLIGHT_PREFIXES)
 
 
 def in_flight_assertions(labels):
@@ -159,45 +186,73 @@ def in_flight_assertions(labels):
 def is_pipeline_label(label):
     if label in PIPELINE_LABELS:
         return True
-    for prefix in PIPELINE_PREFIXES:
-        if label.startswith(prefix):
-            return True
-    return False
+    return any(label.startswith(prefix) for prefix in PIPELINE_PREFIXES)
 
 
-async def _gh(path, method="GET"):
+def _header(result, name):
+    """One header value out of http_request's ``[[name, value], ...]`` pair list.
+
+    A pair LIST, not a dict, because HTTP permits repeated header names; we take the
+    last occurrence, which is what a dict would have kept anyway.
+    """
+    found = ""
+    for pair in result.get("headers") or []:
+        if len(pair) == 2 and isinstance(pair[0], str) and pair[0].lower() == name:
+            found = pair[1]
+    return found
+
+
+async def _gh(path, method="GET", allow_redirect=False):
     """One GitHub GET through the declared ``github`` http_server.
+
+    Returns ``(parsed_body, link_header, redirect_location_or_None)``.
 
     Refuses any other verb outright: phase 1 is observe-only and this is the single
     door to GitHub, so the constraint is enforced at the door rather than by
     reviewer vigilance over call sites.
+
+    C4 — ``allow_redirect=True`` turns a 3xx from an ERROR into a SIGNAL. The
+    ``http_request`` tool does not follow redirects, so a TRANSFERRED issue answers
+    with a literal 301 + ``Location``; without this the workflow's only options were
+    "raise" (an ALARM for a routine transfer) or, worse, nothing at all — which is
+    what shipped, so 68 transferred issues would have read as false ZOMBIEs. The
+    urllib CLI observes the same event as a silently-followed hop and reports
+    ``resp.geturl()``; the mechanisms differ, the emitted note does not.
     """
     if method != "GET":
-        raise ReadFailure("phase-1 reconciler is OBSERVE-ONLY: refusing %s %s" % (method, path))
+        raise ReadFailure(f"phase-1 reconciler is OBSERVE-ONLY: refusing {method} {path}")
     result = await tool(  # noqa: F821 - injected capability
         "http_request", {"server_ref": "github", "path": path, "method": "GET"}
     )
     # tool() returns errors as VALUES. An unchecked error here would parse as an
     # empty page — the exact silent-degradation this reconciler exists to detect.
     if not isinstance(result, dict):
-        raise ReadFailure("http_request returned %r for %s" % (type(result), path))
+        raise ReadFailure(f"http_request returned {type(result)!r} for {path}")
     if "error" in result:
-        raise ReadFailure("GET %s failed: %s" % (path, result["error"]))
+        raise ReadFailure("GET {} failed: {}".format(path, result["error"]))
     if result.get("truncated"):
-        raise ReadFailure("GET %s response was TRUNCATED — a cut body is not a page" % path)
+        raise ReadFailure(f"GET {path} response was TRUNCATED — a cut body is not a page")
     status = result.get("status")
+    if isinstance(status, int) and status in REDIRECT_STATUSES:
+        location = _header(result, "location")
+        if not allow_redirect:
+            raise ReadFailure(f"GET {path} → HTTP {status} (redirect to {location!r})")
+        if not location:
+            # A redirect with nowhere to go is a FAILED read, not a transfer we can
+            # name. Refusing beats inventing a destination.
+            raise ReadFailure(
+                f"GET {path} → HTTP {status} with no Location header — cannot tell where this "
+                "issue moved to, and guessing would manufacture a join key"
+            )
+        return None, "", location
     if not isinstance(status, int) or not (200 <= status < 300):
-        raise ReadFailure("GET %s → HTTP %s" % (path, status))
+        raise ReadFailure(f"GET {path} → HTTP {status}")
     body = result.get("body")
     try:
         parsed = json.loads(body) if body else None
     except Exception as exc:
-        raise ReadFailure("GET %s returned unparseable JSON: %s" % (path, exc))
-    link = ""
-    for pair in result.get("headers") or []:
-        if len(pair) == 2 and pair[0].lower() == "link":
-            link = pair[1]
-    return parsed, link
+        raise ReadFailure(f"GET {path} returned unparseable JSON: {exc}") from exc
+    return parsed, _header(result, "link"), None
 
 
 def _next_link(link_header):
@@ -218,26 +273,99 @@ def _path_of(url):
     return url
 
 
-async def _read_items(repos):
-    """Open issues/PRs carrying any pipeline state label, across ``repos``.
+async def _fetch_linked_prs(repo, number):
+    """PRs cross-referencing an issue + any redirect seen — the ACQUIRED evidence (C2/C4).
+
+    Returns ``(linked_pr_numbers, redirect_location_or_None)``.
+
+    This is the half the mirror was missing. Without it ``linked_pr_numbers`` was
+    never populated in the workflow, so AMBIGUOUS was UNREACHABLE with real data and
+    the five known-good items (company#71/#50/#135, ops#337/#331) classified ZOMBIE
+    on the form that actually runs on cron. The classifier was right; the system
+    never handed it the evidence. Read-only: the timeline endpoint under GET.
+
+    A truncated timeline is a FAILED read (:data:`MAX_TIMELINE_PAGES`), because the
+    unread page is exactly where the PR that disproves the ZOMBIE would be.
+    """
+    path = f"/repos/{repo}/issues/{number}/timeline?per_page=100"
+    found = set()
+    redirected_to = None
+    pages = 0
+    while path is not None:
+        if pages >= MAX_TIMELINE_PAGES:
+            raise ReadFailure(
+                f"timeline for {repo}#{number} exceeded {MAX_TIMELINE_PAGES} pages — "
+                "refusing to decide ZOMBIE vs AMBIGUOUS on a TRUNCATED timeline, since "
+                "the unread page is exactly where the PR that disproves a ZOMBIE would be"
+            )
+        body, link, location = await _gh(path, allow_redirect=True)
+        if location:
+            return tuple(sorted(found)), location
+        if not isinstance(body, list):
+            raise ReadFailure(f"timeline for {repo}#{number} was not a JSON array")
+        pages += 1
+        for event in body:
+            if not isinstance(event, dict) or event.get("event") != "cross-referenced":
+                continue
+            source = event.get("source")
+            issue = source.get("issue") if isinstance(source, dict) else None
+            if isinstance(issue, dict) and "pull_request" in issue:
+                num = issue.get("number")
+                if isinstance(num, int) and not isinstance(num, bool):
+                    found.add(num)
+        nxt = _next_link(link)
+        path = _path_of(nxt) if nxt else None
+    return tuple(sorted(found)), redirected_to
+
+
+async def _read_items(repos, enrich_linked_prs=True):
+    """Open issues/PRs across ``repos``, ENRICHED with the linked-PR evidence.
+
+    Returns ``(items, exhaustive, notes)``.
 
     Enumerates ALL open items and filters locally: the LAGGING class is defined by
     the ABSENCE of ``dispatched``, so a server-side ``?labels=dispatched`` filter
     would be structurally incapable of finding it — the same defect as the stall
     detectors that could not see the zombies because they trusted the lying label.
+
+    Two signals are ACQUIRED here rather than assumed, and the reader drift guard
+    fails the build if either goes missing from one form:
+
+    * **C2** — every item that ASSERTS in flight gets its timeline read, so
+      ``linked_pr_numbers`` is evidence the production path actually fetched. A
+      classifier that can only reach AMBIGUOUS when a test hands it the answer is
+      the defect family this PR exists to kill: evidence asserted, not acquired.
+    * **C4** — a 3xx on either read is a TRANSFER, surfaced as an explicit note
+      instead of being allowed to masquerade as a zombie.
     """
     items = []
     exhaustive = True
+    notes = []
+    transferred = {}
     for repo in repos:
-        path = "/repos/%s/issues?state=open&per_page=100&sort=created&direction=desc" % repo
+        path = f"/repos/{repo}/issues?state=open&per_page=100&sort=created&direction=desc"
         pages = 0
+        hops = 0
         while path is not None:
             if pages >= MAX_ISSUE_PAGES:
                 exhaustive = False
                 break
-            body, link = await _gh(path)
+            body, link, location = await _gh(path, allow_redirect=True)
+            if location:
+                # C4 on the LIST path: the repo itself was renamed/moved. Follow it (the
+                # CLI's urllib does so silently) but SAY SO, so the join key that no
+                # longer resolves is visible as data rather than as a shrinking count.
+                hops += 1
+                if hops > MAX_REDIRECT_HOPS:
+                    raise ReadFailure(
+                        f"issue list for {repo} redirected more than "
+                        f"{MAX_REDIRECT_HOPS} times — refusing to chase a redirect loop"
+                    )
+                notes.append(transfer_note(repo, "*", location))
+                path = _path_of(location)
+                continue
             if not isinstance(body, list):
-                raise ReadFailure("issue list for %s was not a JSON array" % repo)
+                raise ReadFailure(f"issue list for {repo} was not a JSON array")
             pages += 1
             for row in body:
                 raw_labels = _check_issue_row(repo, row)
@@ -256,11 +384,28 @@ async def _read_items(repos):
                         "labels": labels,
                         "url": row.get("html_url", ""),
                         "updated_at": row.get("updated_at", ""),
+                        "linked_pr_numbers": [],
                     }
                 )
             nxt = _next_link(link)
             path = _path_of(nxt) if nxt else None
-    return items, exhaustive
+
+    if enrich_linked_prs:
+        for it in items:
+            # C1: enrich on the UNION of in-flight assertions. Keying this on
+            # `dispatched` alone would mean the nine issues that now assert in-flight
+            # via `autodev:in-progress` never had their linked PRs read, so AMBIGUOUS
+            # could never fire for them — the C1 bug wearing a C2 hat.
+            if it["kind"] != "issue" or not in_flight_assertions(it["labels"]):
+                continue
+            linked, redirected = await _fetch_linked_prs(it["repo"], it["number"])
+            it["linked_pr_numbers"] = list(linked)
+            if redirected:
+                transferred[(it["repo"], it["number"])] = redirected
+
+    for key in sorted(transferred):
+        notes.append(transfer_note(key[0], key[1], transferred[key]))
+    return items, exhaustive, notes
 
 
 def _normalise_repo(raw, default_owner="eumemic"):
@@ -273,7 +418,7 @@ def _normalise_repo(raw, default_owner="eumemic"):
         owner = raw.get("owner")
         name = raw.get("name") or raw.get("repo")
         if isinstance(owner, str) and isinstance(name, str) and owner and name:
-            return "%s/%s" % (owner.strip("/"), name.strip("/"))
+            return "{}/{}".format(owner.strip("/"), name.strip("/"))
         raw = name
     if not isinstance(raw, str):
         return None
@@ -287,15 +432,15 @@ def _normalise_repo(raw, default_owner="eumemic"):
             name = parts[1]
             if name.endswith(".git"):
                 name = name[:-4]
-            return "%s/%s" % (parts[0], name)
+            return f"{parts[0]}/{name}"
         return None
     if text.endswith(".git"):
         text = text[:-4]
     parts = [p for p in text.strip("/").split("/") if p]
     if len(parts) == 1:
-        return "%s/%s" % (default_owner, parts[0])
+        return f"{default_owner}/{parts[0]}"
     if len(parts) == 2:
-        return "%s/%s" % (parts[0], parts[1])
+        return f"{parts[0]}/{parts[1]}"
     return None
 
 
@@ -349,9 +494,9 @@ async def _read_runs(workflow_ids):
                 args["after"] = after
             result = await tool("list_runs", args)  # noqa: F821 - injected capability
             if not isinstance(result, dict):
-                raise ReadFailure("list_runs returned %r" % type(result))
+                raise ReadFailure(f"list_runs returned {type(result)!r}")
             if "error" in result:
-                raise ReadFailure("list_runs failed: %s" % result["error"])
+                raise ReadFailure("list_runs failed: {}".format(result["error"]))
             rows = result.get("runs")
             if not isinstance(rows, list):
                 # A missing 'runs' key is a CONTRACT failure, not an empty page.
@@ -414,14 +559,14 @@ def classify(item, runs):
         if live:
             return mk(
                 "LAGGING",
-                "%d live run(s) (%s) but NO in-flight label (no `dispatched`, no "
-                "`autodev:in-progress`, no `needs:human/*`)" % (len(live), _statuses(live)),
+                f"{len(live)} live run(s) ({_statuses(live)}) but NO in-flight label "
+                "(no `dispatched`, no `autodev:in-progress`, no `needs:human/*`)",
                 live,
                 trigger_labels=[],
             )
         return None
 
-    claim = ", ".join(["`%s`" % x for x in triggers])
+    claim = ", ".join([f"`{x}`" for x in triggers])
 
     if live:
         return None
@@ -432,53 +577,51 @@ def classify(item, runs):
         extra = ""
         if others:
             extra = (
-                " (alongside %d run(s) in %s — a terminal sibling does NOT make an "
-                "unknown status dead)" % (len(others), _statuses(others))
+                f" (alongside {len(others)} run(s) in {_statuses(others)} — a terminal "
+                "sibling does NOT make an unknown status dead)"
             )
         return mk(
             "MISLABELLED",
-            "%s and run(s) in unrecognised status (%s) — cannot prove live; treat as "
-            "parked pending triage%s" % (claim, _statuses(unknown), extra),
+            f"{claim} and run(s) in unrecognised status ({_statuses(unknown)}) — cannot prove live; treat as "
+            f"parked pending triage{extra}",
             unknown + others,
             ("unrecognised-run-status",),
         )
     if suspended:
         return mk(
             "MISLABELLED",
-            "%s but %d run(s) suspended at a gate — parked is NOT running"
-            % (claim, len(suspended)),
+            f"{claim} but {len(suspended)} run(s) suspended at a gate — parked is NOT running",
             suspended,
         )
     if terminal:
         return mk(
             "DEAD",
-            "%s but every run is terminal (%s)" % (claim, _statuses(terminal)),
+            f"{claim} but every run is terminal ({_statuses(terminal)})",
             terminal,
         )
     linked = item.get("linked_pr_numbers") or []
     if linked:
         # C2: linked PRs mean work demonstrably happened, so this is NOT a zombie and
         # must not land in counts["ZOMBIE"]. Its own class; phase 2 acts on the class.
-        prs = ", ".join(["#%s" % n for n in linked])
+        prs = ", ".join([f"#{n}" for n in linked])
         return mk(
             "AMBIGUOUS",
-            "%s and no unarchived run — BUT PR(s) %s reference this issue. Work "
+            f"{claim} and no unarchived run — BUT PR(s) {prs} reference this issue. Work "
             "demonstrably happened, so the join key (or the run's archival) is the "
-            "suspect, not the item. NEEDS TRIAGE — deliberately NOT counted as a ZOMBIE."
-            % (claim, prs),
+            "suspect, not the item. NEEDS TRIAGE — deliberately NOT counted as a ZOMBIE.",
             [],
             ("has-linked-prs", "excluded-from-zombie-count"),
         )
     return mk(
         "ZOMBIE",
-        "%s but NO unarchived run exists for this issue — nothing (visible) ever "
-        "picked it up" % claim,
+        f"{claim} but NO unarchived run exists for this issue — nothing (visible) ever "
+        "picked it up",
         [],
         ("zombie-means-no-unarchived-run",),
     )
 
 
-def build(items, items_exhaustive, runs, runs_exhaustive, failures):
+def build(items, items_exhaustive, runs, runs_exhaustive, failures, notes=()):
     """Join + classify. **Any failure ⇒ ALARM with counts:null.**
 
     The counts key is ``None`` — not ``{}``, not zeros — on ALARM, so a consumer
@@ -491,6 +634,7 @@ def build(items, items_exhaustive, runs, runs_exhaustive, failures):
             "zombie_means": ZOMBIE_MEANS,
             "total_disagreements": None,
             "failures": failures,
+            "notes": list(notes),
             "disagreements": [],
             "unmatched_runs": [],
             "exhaustive": False,
@@ -554,6 +698,10 @@ def build(items, items_exhaustive, runs, runs_exhaustive, failures):
         + [x + "*" for x in IN_FLIGHT_PREFIXES],
         "total_disagreements": len(disagreements),
         "failures": [],
+        # C4 — transfer notes ride on the report, never suppressed. A stale join key
+        # is DATA a triager must see; swallowing it is how a transfer masquerades as
+        # a zombie.
+        "notes": list(notes),
         "disagreements": disagreements,
         "unmatched_runs": unmatched,
         "exhaustive": bool(items_exhaustive and runs_exhaustive),
@@ -571,14 +719,19 @@ def disagreement_hash(report):
     hashed instead, so a NEW outage still wakes the seat.
     """
     if report["verdict"] == "ALARM":
-        parts = ["ALARM"] + sorted(
-            ["%s:%s" % (f.get("source", ""), f.get("reason", "")) for f in report["failures"]]
-        )
+        parts = [
+            "ALARM",
+            *sorted(
+                [
+                    "{}:{}".format(f.get("source", ""), f.get("reason", ""))
+                    for f in report["failures"]
+                ]
+            ),
+        ]
     else:
         parts = sorted(
             [
-                "%s:%s#%s:%s:%s"
-                % (
+                "{}:{}#{}:{}:{}".format(
                     d["classification"],
                     d["repo"],
                     d["number"],
@@ -599,9 +752,9 @@ async def main(input):
 
     phase("read-github")  # noqa: F821 - injected capability
     failures = []
-    items, items_exhaustive = [], True
+    items, items_exhaustive, notes = [], True, []
     try:
-        items, items_exhaustive = await _read_items(repos)
+        items, items_exhaustive, notes = await _read_items(repos)
     except ReadFailure as exc:
         # A failed read is recorded as a FAILURE, never swallowed into an empty
         # list. The report below will ALARM and carry counts:null.
@@ -615,7 +768,7 @@ async def main(input):
         failures.append({"source": "aios-runs", "reason": str(exc)})
 
     phase("join")  # noqa: F821
-    report = build(items, items_exhaustive, runs, runs_exhaustive, failures)
+    report = build(items, items_exhaustive, runs, runs_exhaustive, failures, notes)
     current_hash = disagreement_hash(report)
     report["disagreement_hash"] = current_hash
     report["changed"] = previous_hash != current_hash
@@ -627,10 +780,11 @@ async def main(input):
     report["repos_scanned"] = list(repos)
 
     if report["verdict"] == "ALARM":
-        log("ALARM: work-state reconciler could not read its sources: %s" % json.dumps(failures))  # noqa: F821
+        log(f"ALARM: work-state reconciler could not read its sources: {json.dumps(failures)}")  # noqa: F821
     else:
         log(  # noqa: F821
-            "work-state: %s (exhaustive=%s, changed=%s)"
-            % (json.dumps(report["counts"]), report["exhaustive"], report["changed"])
+            "work-state: {} (exhaustive={}, changed={})".format(
+                json.dumps(report["counts"]), report["exhaustive"], report["changed"]
+            )
         )
     return report

--- a/src/aios/reconcilers/__init__.py
+++ b/src/aios/reconcilers/__init__.py
@@ -1,0 +1,10 @@
+"""Reconcilers: loops that re-check an *asserted* state against the world.
+
+A reconciler exists because an assertion nobody re-checks is not state — it is a
+sticker. Each module here reads a declared/asserted projection (a GitHub label, a
+committed manifest) and the authoritative substrate it claims to describe, joins
+them, and REPORTS the disagreement.
+
+``work_state`` is the pure join/classify core for work-state reconciliation
+(labels vs. aios runs); ``work_state_cli`` is its I/O shell.
+"""

--- a/src/aios/reconcilers/work_state.py
+++ b/src/aios/reconcilers/work_state.py
@@ -872,9 +872,7 @@ def classify_item(
         moved_from = f"{transfer.stale_repo}#{transfer.stale_number}"
         ids = ", ".join(transfer.run_ids) or "(none)"
         prs = (
-            " Linked PR(s): "
-            + ", ".join("#" + str(n) for n in item.linked_pr_numbers)
-            + "."
+            " Linked PR(s): " + ", ".join("#" + str(n) for n in item.linked_pr_numbers) + "."
             if item.linked_pr_numbers
             else ""
         )

--- a/src/aios/reconcilers/work_state.py
+++ b/src/aios/reconcilers/work_state.py
@@ -1,0 +1,779 @@
+"""Work-state reconciliation, phase 1 (OBSERVE-ONLY): the pure join + classify core.
+
+The defect this exists to kill (eumemic/aios#2043, design of record:
+``architecture/work-state-reconciliation.md`` in eumemic-company):
+
+    **A GitHub label is an assertion that nothing re-checks against the world.**
+
+``dispatched`` is a sticker. It stays stuck whether or not any machine ever picked
+the work up — measured 2026-07-25, 14 issues across the org carried ``dispatched``
+with no run and no PR, to 12 days old. The stall detectors could not see them
+*because they read labels too*: a detector that consumes the same asserted state it
+is meant to check is not a detector.
+
+The truth already exists. The dev pipeline is a durable aios workflow with ONE RUN
+PER ISSUE: ``run.input`` carries ``{repo, issue_number}`` and ``run.status`` carries
+the live state. Nothing joined the two. **This module is the join.**
+
+Layering
+--------
+This module is PURE: dataclasses, a join, a classifier, a hash. No network, no
+clock, no ``os.environ`` — every input is passed in, so the whole classification
+surface is unit-testable offline and the reconciler is deterministic and
+re-runnable (per #2043: "no dependence on prior in-memory state beyond a
+change-detection hash"). The I/O shell lives in
+:mod:`aios.reconcilers.work_state_cli`; the durable-workflow form lives in
+``infra/workflows/work-state-reconciler.wf.py``.
+
+Fail-loud, structurally (the acceptance criterion that outranks the feature)
+----------------------------------------------------------------------------
+An empty result from a BROKEN query rendering as health happened twice on
+2026-07-25 and is the exact bug class this effort exists to kill. So the report is
+**not** a list of disagreements — it is a :class:`ReconcileReport` whose
+:attr:`~ReconcileReport.verdict` is ``ALARM`` whenever any source read failed, and
+whose per-class counts are ``None`` (not ``0``) in that case. There is no way to
+render "no disagreements" from a failed read, because there is no count to render:
+``counts`` does not exist unless every source is :class:`SourceOk`. "Read failed"
+and "read succeeded and found nothing" are different types here, not different
+values of the same type.
+
+The four classes (#2043)
+------------------------
+=================================  ================================  ==============
+Label says                         Runs say                          Classification
+=================================  ================================  ==============
+``dispatched``                     a live run exists                 agree
+``dispatched``                     no run, ever                      ZOMBIE
+``dispatched``                     run terminal                      DEAD
+``dispatched``                     run suspended at a gate           MISLABELLED
+no ``dispatched``                  a live run exists                 LAGGING
+=================================  ================================  ==============
+
+*Parked is NOT running*: a ``suspended`` run is a **different condition** from a
+running one (it is waiting on a human at a gate), so it gets its own class rather
+than being folded into "agree" — that fold is how a gate-parked item hides inside
+a `dispatched` label forever.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+# ─── run-status vocabulary (mirrors aios.models.workflows.WfRunStatus) ───────
+#
+# Deliberately restated as plain frozensets rather than imported: the workflow-run
+# form of this reconciler executes in the credential-free script host, which may
+# not import ``aios.*``. The drift guard is a unit test that asserts these agree
+# with ``WfRunStatus`` / ``TERMINAL_RUN_STATUSES``, so a new status can never
+# silently fall through the classifier.
+
+#: Statuses that mean "a machine is actually on this, right now".
+LIVE_RUN_STATUSES: frozenset[str] = frozenset({"pending", "running"})
+#: Parked at a durable ``gate()`` — waiting on a human. NOT running.
+SUSPENDED_RUN_STATUSES: frozenset[str] = frozenset({"suspended"})
+#: Terminal: the run is over, whatever the label still claims.
+TERMINAL_RUN_STATUSES: frozenset[str] = frozenset({"completed", "errored", "cancelled"})
+
+#: The label whose truth this reconciler checks.
+DISPATCHED_LABEL = "dispatched"
+
+#: Labels that assert something about pipeline state. An item carrying any of
+#: these is in scope for enumeration (the ``dispatched`` join is the phase-1
+#: check; the rest are carried as evidence for the phase-2 gate work).
+PIPELINE_STATE_LABEL_PREFIXES: tuple[str, ...] = ("needs:human/", "autodev:", "pipeline:")
+PIPELINE_STATE_LABELS: frozenset[str] = frozenset(
+    {
+        DISPATCHED_LABEL,
+        "approved",
+        "hold",
+        "paused",
+        "escalated",
+        "blocked",
+        "ci-loop-exhausted",
+        "merge:approved",
+    }
+)
+
+Classification = Literal["ZOMBIE", "DEAD", "MISLABELLED", "LAGGING"]
+
+#: Stable ordering for rendering + the change-detection hash.
+CLASSES: tuple[Classification, ...] = ("ZOMBIE", "DEAD", "MISLABELLED", "LAGGING")
+
+
+def is_pipeline_state_label(label: str) -> bool:
+    """True iff ``label`` asserts something about pipeline work state."""
+    return label in PIPELINE_STATE_LABELS or label.startswith(PIPELINE_STATE_LABEL_PREFIXES)
+
+
+# ─── inputs ──────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class WorkItem:
+    """One open GitHub issue or PR, as read (never as written — phase 1 writes nothing)."""
+
+    repo: str  # canonical "owner/name"
+    number: int
+    kind: Literal["issue", "pull_request"]
+    title: str
+    labels: tuple[str, ...]
+    html_url: str
+    updated_at: str  # ISO-8601, verbatim from GitHub
+    created_at: str = ""
+    #: PRs cross-referencing this issue. Evidence only — a ZOMBIE that HAS linked
+    #: PRs is flagged (``has_linked_prs``) rather than silently trusted, because
+    #: "no run" plus "a PR exists" means the join key is wrong, not that the work
+    #: never happened. eumemic-company#71 is exactly this shape and is the
+    #: designed-in check on the join logic.
+    linked_pr_numbers: tuple[int, ...] = ()
+
+    @property
+    def key(self) -> tuple[str, int]:
+        return (self.repo, self.number)
+
+    @property
+    def is_dispatched(self) -> bool:
+        return DISPATCHED_LABEL in self.labels
+
+    @property
+    def pipeline_labels(self) -> tuple[str, ...]:
+        return tuple(sorted(x for x in self.labels if is_pipeline_state_label(x)))
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    """One aios run of a pipeline workflow, reduced to what the join needs."""
+
+    run_id: str
+    status: str
+    repo: str | None  # canonical "owner/name" parsed from run.input, None if unparseable
+    issue_number: int | None
+    workflow_id: str | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+    @property
+    def key(self) -> tuple[str, int] | None:
+        if self.repo is None or self.issue_number is None:
+            return None
+        return (self.repo, self.issue_number)
+
+    @property
+    def is_live(self) -> bool:
+        return self.status in LIVE_RUN_STATUSES
+
+    @property
+    def is_suspended(self) -> bool:
+        return self.status in SUSPENDED_RUN_STATUSES
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_RUN_STATUSES
+
+
+# ─── source reads: "failed" and "found nothing" are DIFFERENT TYPES ──────────
+
+
+@dataclass(frozen=True)
+class SourceOk:
+    """A read that SUCCEEDED. ``items`` may legitimately be empty.
+
+    ``exhaustive=False`` means pagination stopped at a safety cap, so every count
+    derived from it is a floor — rendered "at least N", never as a total (#2043:
+    "paginate to exhaustion, or explicitly report 'at least N'").
+    """
+
+    name: str
+    items: tuple[Any, ...]
+    exhaustive: bool = True
+    pages_read: int = 0
+
+    ok: Literal[True] = True
+
+
+@dataclass(frozen=True)
+class SourceFailed:
+    """A read that FAILED. Carries no items — not an empty list, no items *at all*.
+
+    This is the type-level enforcement of fail-loud: a failed read cannot be
+    iterated into "0 disagreements", because it has nothing to iterate.
+    """
+
+    name: str
+    reason: str
+
+    ok: Literal[False] = False
+
+
+SourceRead = SourceOk | SourceFailed
+
+
+# ─── outputs ─────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Disagreement:
+    """One item whose label and whose runs do not agree."""
+
+    classification: Classification
+    repo: str
+    number: int
+    kind: Literal["issue", "pull_request"]
+    title: str
+    html_url: str
+    labels: tuple[str, ...]
+    detail: str
+    run_ids: tuple[str, ...] = ()
+    run_statuses: tuple[str, ...] = ()
+    updated_at: str = ""
+    #: Non-fatal qualifiers a human should see before acting (phase 2 will act).
+    caveats: tuple[str, ...] = ()
+
+    @property
+    def key(self) -> tuple[str, int]:
+        return (self.repo, self.number)
+
+    def identity(self) -> str:
+        """The change-detection identity: class + item + the run statuses behind it.
+
+        Run *ids* are excluded so a re-dispatch that produces the same verdict for
+        the same reason does not spam the seat; statuses are included so a
+        transition (suspended → errored) DOES.
+        """
+        return (
+            f"{self.classification}:{self.repo}#{self.number}:{','.join(sorted(self.run_statuses))}"
+        )
+
+
+@dataclass(frozen=True)
+class UnmatchedRun:
+    """A live run whose ``(repo, issue_number)`` matches no OPEN item we enumerated.
+
+    Not one of the four classes — it is either a run against a closed issue or a
+    join-key mismatch. Reported (never swallowed) so a broken join surfaces as data
+    instead of as a quietly-shrinking LAGGING count.
+    """
+
+    run_id: str
+    status: str
+    repo: str | None
+    issue_number: int | None
+    reason: str
+
+
+@dataclass(frozen=True)
+class ReconcileReport:
+    """The reconciler's output. Read :attr:`verdict` FIRST — always."""
+
+    #: ``OK`` = every source read succeeded (disagreements may be 0 — real health).
+    #: ``ALARM`` = at least one source read FAILED; counts are meaningless and are
+    #: therefore absent. Never collapse these two.
+    verdict: Literal["OK", "ALARM"]
+    disagreements: tuple[Disagreement, ...] = ()
+    unmatched_runs: tuple[UnmatchedRun, ...] = ()
+    failures: tuple[SourceFailed, ...] = ()
+    #: Sources that read OK but stopped short of exhaustion; their counts are floors.
+    truncated_sources: tuple[str, ...] = ()
+    items_scanned: int = 0
+    runs_scanned: int = 0
+    repos_scanned: tuple[str, ...] = ()
+    generated_at: str = ""
+    meta: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def alarmed(self) -> bool:
+        return self.verdict == "ALARM"
+
+    @property
+    def exhaustive(self) -> bool:
+        """False when any source stopped at a cap — every count is then a floor."""
+        return not self.truncated_sources
+
+    @property
+    def counts(self) -> Mapping[Classification, int] | None:
+        """Per-class counts, or **None** when the run alarmed.
+
+        ``None`` — not ``{}``, not zeros. A caller that wants to print "0
+        disagreements" is forced to handle the ALARM case first; there is no
+        count to print otherwise. This is the whole anti-pattern, closed at the
+        type level.
+        """
+        if self.alarmed:
+            return None
+        return {c: sum(1 for d in self.disagreements if d.classification == c) for c in CLASSES}
+
+    def by_class(self, classification: Classification) -> tuple[Disagreement, ...]:
+        return tuple(d for d in self.disagreements if d.classification == classification)
+
+    def disagreement_hash(self) -> str:
+        """Stable hash of the disagreement SET — the seat-wake change detector.
+
+        Sorted, so ordering churn from the API never fires a wake; identity-based
+        (see :meth:`Disagreement.identity`), so the same finding on the same item
+        for the same reason is the same hash tomorrow. On ALARM the hash folds in
+        the failure reasons, so a persistent outage does not read as "unchanged,
+        nothing to say" — a NEW failure wakes the seat.
+        """
+        parts = sorted(d.identity() for d in self.disagreements)
+        if self.alarmed:
+            parts = ["ALARM", *sorted(f"{f.name}:{f.reason}" for f in self.failures)]
+        return hashlib.sha256("\n".join(parts).encode()).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        counts = self.counts
+        return {
+            "verdict": self.verdict,
+            "counts": None if counts is None else {k: counts[k] for k in CLASSES},
+            "total_disagreements": None if self.alarmed else len(self.disagreements),
+            "exhaustive": self.exhaustive,
+            "truncated_sources": list(self.truncated_sources),
+            "items_scanned": self.items_scanned,
+            "runs_scanned": self.runs_scanned,
+            "repos_scanned": list(self.repos_scanned),
+            "generated_at": self.generated_at,
+            "disagreement_hash": self.disagreement_hash(),
+            "failures": [{"source": f.name, "reason": f.reason} for f in self.failures],
+            "disagreements": [
+                {
+                    "classification": d.classification,
+                    "repo": d.repo,
+                    "number": d.number,
+                    "kind": d.kind,
+                    "title": d.title,
+                    "url": d.html_url,
+                    "labels": list(d.labels),
+                    "detail": d.detail,
+                    "run_ids": list(d.run_ids),
+                    "run_statuses": list(d.run_statuses),
+                    "updated_at": d.updated_at,
+                    "caveats": list(d.caveats),
+                }
+                for d in self.disagreements
+            ],
+            "unmatched_runs": [
+                {
+                    "run_id": u.run_id,
+                    "status": u.status,
+                    "repo": u.repo,
+                    "issue_number": u.issue_number,
+                    "reason": u.reason,
+                }
+                for u in self.unmatched_runs
+            ],
+            "meta": dict(self.meta),
+        }
+
+
+# ─── the join key ────────────────────────────────────────────────────────────
+
+
+def normalise_repo(raw: Any, *, default_owner: str = "eumemic") -> str | None:
+    """Canonicalise a repo reference from ``run.input`` to ``owner/name``.
+
+    Accepts ``"eumemic/aios"``, ``"aios"`` (owner defaulted), a full GitHub URL, and
+    a ``{"owner": ..., "name": ...}`` object, because ``run.input`` is arbitrary JSON
+    written by several dispatchers over months. Returns ``None`` when the value
+    cannot be understood — the caller must then report the run as unmatched rather
+    than guess, since a wrong guess manufactures a phantom "agree" and re-creates
+    exactly the bug we are killing.
+    """
+    if isinstance(raw, Mapping):
+        owner = raw.get("owner")
+        name = raw.get("name") or raw.get("repo")
+        if isinstance(owner, str) and isinstance(name, str) and owner and name:
+            return f"{owner.strip('/')}/{name.strip('/')}"
+        raw = name
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if "github.com" in text:
+        tail = text.split("github.com", 1)[1].lstrip(":/")
+        parts = [p for p in tail.split("/") if p]
+        if len(parts) >= 2:
+            return f"{parts[0]}/{parts[1].removesuffix('.git')}"
+        return None
+    text = text.strip("/").removesuffix(".git")
+    parts = [p for p in text.split("/") if p]
+    if len(parts) == 1:
+        return f"{default_owner}/{parts[0]}"
+    if len(parts) == 2:
+        return f"{parts[0]}/{parts[1]}"
+    return None
+
+
+def _coerce_issue_number(raw: Any) -> int | None:
+    """``run.input`` numbers arrive as int, ``"337"``, or ``"#337"``. Never guess."""
+    if isinstance(raw, bool):  # bool is an int subclass; a bool is not an issue number
+        return None
+    if isinstance(raw, int):
+        return raw if raw > 0 else None
+    if isinstance(raw, str):
+        text = raw.strip().lstrip("#")
+        if text.isdigit():
+            n = int(text)
+            return n if n > 0 else None
+    return None
+
+
+#: The keys a dispatcher may have used for the issue number in ``run.input``.
+_ISSUE_NUMBER_KEYS = ("issue_number", "issue", "number", "issueNumber")
+_REPO_KEYS = ("repo", "repository", "repo_full_name", "full_name")
+
+
+def run_record_from_payload(
+    payload: Mapping[str, Any], *, default_owner: str = "eumemic"
+) -> RunRecord:
+    """Build a :class:`RunRecord` from an aios run dict (``list_runs`` / ``GET /v1/runs``).
+
+    A run whose input carries no usable ``(repo, issue_number)`` yields a record with
+    ``repo``/``issue_number`` ``None`` — it joins to nothing and is reported as
+    unmatched. It is never dropped: a silently-dropped run is a missing "agree",
+    which manufactures a false ZOMBIE.
+    """
+    raw_input = payload.get("input")
+    inp: Mapping[str, Any] = raw_input if isinstance(raw_input, Mapping) else {}
+    repo_raw: Any = None
+    for k in _REPO_KEYS:
+        if k in inp:
+            repo_raw = inp[k]
+            break
+    issue_raw: Any = None
+    for k in _ISSUE_NUMBER_KEYS:
+        if k in inp:
+            issue_raw = inp[k]
+            break
+    return RunRecord(
+        run_id=str(payload.get("id", "")),
+        status=str(payload.get("status", "")),
+        repo=normalise_repo(repo_raw, default_owner=default_owner),
+        issue_number=_coerce_issue_number(issue_raw),
+        workflow_id=(
+            payload.get("workflow_id") if isinstance(payload.get("workflow_id"), str) else None
+        ),
+        created_at=str(payload.get("created_at", "")),
+        updated_at=str(payload.get("updated_at", "")),
+    )
+
+
+def index_runs(runs: Iterable[RunRecord]) -> dict[tuple[str, int], list[RunRecord]]:
+    """Group runs by ``(repo, issue_number)``. Unkeyable runs are excluded (and must
+    be reported separately by the caller — see :func:`build_report`)."""
+    index: dict[tuple[str, int], list[RunRecord]] = {}
+    for run in runs:
+        key = run.key
+        if key is None:
+            continue
+        index.setdefault(key, []).append(run)
+    return index
+
+
+# ─── the classifier ──────────────────────────────────────────────────────────
+
+
+def _statuses(runs: Sequence[RunRecord]) -> tuple[str, ...]:
+    return tuple(sorted({r.status for r in runs}))
+
+
+def classify_item(item: WorkItem, runs: Sequence[RunRecord]) -> Disagreement | None:
+    """Classify ONE item against every run keyed to it. ``None`` == the label agrees.
+
+    Precedence is deliberate and is the heart of the design: **live > suspended >
+    terminal**. One live run means work really is happening, whatever the other runs
+    say. With no live run, a *suspended* run means parked-at-a-gate — a different
+    condition from running, hence MISLABELLED rather than "agree" (folding parked
+    into agree is how a gate-parked item hides behind ``dispatched`` forever). Only
+    with no live and no suspended run is the item DEAD/ZOMBIE.
+    """
+    live = [r for r in runs if r.is_live]
+    suspended = [r for r in runs if r.is_suspended]
+    terminal = [r for r in runs if r.is_terminal]
+    unknown = [r for r in runs if not (r.is_live or r.is_suspended or r.is_terminal)]
+
+    def _mk(
+        classification: Classification,
+        detail: str,
+        subject: Sequence[RunRecord],
+        caveats: tuple[str, ...] = (),
+    ) -> Disagreement:
+        return Disagreement(
+            classification=classification,
+            repo=item.repo,
+            number=item.number,
+            kind=item.kind,
+            title=item.title,
+            html_url=item.html_url,
+            labels=item.pipeline_labels,
+            detail=detail,
+            run_ids=tuple(r.run_id for r in subject),
+            run_statuses=_statuses(subject),
+            updated_at=item.updated_at,
+            caveats=caveats,
+        )
+
+    if not item.is_dispatched:
+        # Label says nothing; runs say something. The projection lags reality.
+        if live:
+            return _mk(
+                "LAGGING",
+                f"{len(live)} live run(s) ({', '.join(_statuses(live))}) but no `dispatched` label",
+                live,
+            )
+        return None
+
+    # From here: the item claims `dispatched`.
+    if live:
+        return None  # agree — a machine really is on it
+
+    if unknown and not (suspended or terminal):
+        # An unrecognised status is NOT evidence of death. Refuse to classify rather
+        # than guess a zombie: a wrong DEAD here is a false alarm that trains people
+        # to ignore the report.
+        return _mk(
+            "MISLABELLED",
+            "run(s) in unrecognised status "
+            f"({', '.join(_statuses(unknown))}) — cannot prove live; treat as parked pending triage",
+            unknown,
+            caveats=("unrecognised-run-status",),
+        )
+
+    if suspended:
+        return _mk(
+            "MISLABELLED",
+            f"{len(suspended)} run(s) suspended at a gate — parked is NOT running",
+            suspended,
+        )
+
+    if terminal:
+        by_status = ", ".join(_statuses(terminal))
+        return _mk(
+            "DEAD",
+            f"`dispatched` but every run is terminal ({by_status})",
+            terminal,
+        )
+
+    caveats: tuple[str, ...] = ()
+    if item.linked_pr_numbers:
+        # "No run ever" AND "a PR exists" cannot both be true of healthy work — the
+        # join key is wrong, or the work predates the workflow. Flag it; do not
+        # quietly count it as a zombie.
+        caveats = ("has-linked-prs",)
+    detail = "`dispatched` but NO run exists for this issue — nothing ever picked it up"
+    if item.linked_pr_numbers:
+        detail += (
+            f" (but PR(s) {', '.join('#' + str(n) for n in item.linked_pr_numbers)} reference it —"
+            " verify the join key before believing this)"
+        )
+    return _mk("ZOMBIE", detail, (), caveats=caveats)
+
+
+# ─── the report builder ──────────────────────────────────────────────────────
+
+
+def build_report(
+    *,
+    items_read: SourceRead,
+    runs_read: SourceRead,
+    generated_at: str = "",
+    repos_scanned: Sequence[str] = (),
+    meta: Mapping[str, Any] | None = None,
+) -> ReconcileReport:
+    """Join the two sources and classify. **Any failed source ⇒ ALARM, no counts.**
+
+    This function is the choke point where "empty" could have become "healthy", and
+    it is where that is made impossible: it inspects the SOURCE OBJECTS, not their
+    contents. If either is a :class:`SourceFailed` it returns an ALARM report
+    immediately — no classification is attempted, no zeros are produced, and
+    :attr:`ReconcileReport.counts` is ``None``. A caller cannot accidentally print
+    health, because there is nothing healthy-shaped to print.
+    """
+    failures = tuple(s for s in (items_read, runs_read) if isinstance(s, SourceFailed))
+    if failures:
+        return ReconcileReport(
+            verdict="ALARM",
+            failures=failures,
+            repos_scanned=tuple(repos_scanned),
+            generated_at=generated_at,
+            meta=dict(meta or {}),
+        )
+
+    assert isinstance(items_read, SourceOk) and isinstance(runs_read, SourceOk)
+    items = tuple(i for i in items_read.items if isinstance(i, WorkItem))
+    runs = tuple(r for r in runs_read.items if isinstance(r, RunRecord))
+    if len(items) != len(items_read.items) or len(runs) != len(runs_read.items):
+        # A shape we did not expect is a READ failure, not an empty page.
+        return ReconcileReport(
+            verdict="ALARM",
+            failures=(
+                SourceFailed(
+                    name="join",
+                    reason=(
+                        "source payload contained rows of an unexpected type "
+                        f"(items {len(items)}/{len(items_read.items)}, "
+                        f"runs {len(runs)}/{len(runs_read.items)})"
+                    ),
+                ),
+            ),
+            repos_scanned=tuple(repos_scanned),
+            generated_at=generated_at,
+            meta=dict(meta or {}),
+        )
+
+    run_index = index_runs(runs)
+    items_by_key = {i.key: i for i in items}
+
+    disagreements: list[Disagreement] = []
+    for item in sorted(items, key=lambda i: (i.repo, i.number)):
+        verdict = classify_item(item, run_index.get(item.key, []))
+        if verdict is not None:
+            disagreements.append(verdict)
+
+    unmatched: list[UnmatchedRun] = []
+    for run in runs:
+        key = run.key
+        if key is None:
+            if run.is_live or run.is_suspended:
+                unmatched.append(
+                    UnmatchedRun(
+                        run_id=run.run_id,
+                        status=run.status,
+                        repo=run.repo,
+                        issue_number=run.issue_number,
+                        reason="run.input carries no usable (repo, issue_number) — join key unreadable",
+                    )
+                )
+            continue
+        if run.is_live and key not in items_by_key:
+            unmatched.append(
+                UnmatchedRun(
+                    run_id=run.run_id,
+                    status=run.status,
+                    repo=run.repo,
+                    issue_number=run.issue_number,
+                    reason="live run against an item that is not open (closed, or outside the scanned repos)",
+                )
+            )
+
+    truncated = tuple(s.name for s in (items_read, runs_read) if not s.exhaustive)
+
+    order = {c: n for n, c in enumerate(CLASSES)}
+    disagreements.sort(key=lambda d: (order[d.classification], d.repo, d.number))
+
+    return ReconcileReport(
+        verdict="OK",
+        disagreements=tuple(disagreements),
+        unmatched_runs=tuple(unmatched),
+        failures=(),
+        truncated_sources=truncated,
+        items_scanned=len(items),
+        runs_scanned=len(runs),
+        repos_scanned=tuple(repos_scanned),
+        generated_at=generated_at,
+        meta=dict(meta or {}),
+    )
+
+
+# ─── rendering ───────────────────────────────────────────────────────────────
+
+
+def render_markdown(report: ReconcileReport, *, limit_per_class: int = 50) -> str:
+    """Human-readable summary. An ALARM renders as an ALARM — never as a clean bill.
+
+    Note the ordering rule this encodes: the verdict line comes FIRST and the counts
+    are only printed when there are counts. A reader skimming the top of the report
+    cannot mistake a broken read for a quiet week.
+    """
+    lines: list[str] = []
+    if report.alarmed:
+        lines.append("## 🚨 WORK-STATE RECONCILER: ALARM — THE READ FAILED")
+        lines.append("")
+        lines.append(
+            "**This is NOT a report of zero disagreements.** One or more sources could not be "
+            "read, so nothing was classified and no count exists. Treat the pipeline state as "
+            "UNKNOWN until this is fixed."
+        )
+        lines.append("")
+        for failure in report.failures:
+            lines.append(f"- **{failure.name}** — {failure.reason}")
+        lines.append("")
+        lines.append(f"_generated {report.generated_at or 'n/a'}_")
+        return "\n".join(lines)
+
+    counts = report.counts
+    assert counts is not None
+    total = sum(counts.values())
+    at_least = "" if report.exhaustive else "at least "
+    lines.append("## Work-state reconciler (phase 1, observe-only)")
+    lines.append("")
+    lines.append(
+        f"Read OK. Scanned {at_least}{report.items_scanned} open item(s) across "
+        f"{len(report.repos_scanned)} repo(s) against {at_least}{report.runs_scanned} run(s)."
+    )
+    if not report.exhaustive:
+        lines.append("")
+        lines.append(
+            "> ⚠️ **Counts are FLOORS, not totals** — pagination stopped at a safety cap for: "
+            + ", ".join(report.truncated_sources)
+            + ". Every number below is 'at least N'."
+        )
+    lines.append("")
+    lines.append("| class | count | meaning |")
+    lines.append("|---|---:|---|")
+    meaning = {
+        "ZOMBIE": "`dispatched`, no run ever — nothing picked it up",
+        "DEAD": "`dispatched`, every run terminal",
+        "MISLABELLED": "`dispatched`, run suspended at a gate (parked ≠ running)",
+        "LAGGING": "live run, no `dispatched` label — the projection lags",
+    }
+    for c in CLASSES:
+        lines.append(f"| **{c}** | {at_least}{counts[c]} | {meaning[c]} |")
+    lines.append(f"| _total_ | {at_least}{total} | |")
+    lines.append("")
+    lines.append(f"`disagreement_hash`: `{report.disagreement_hash()[:16]}`")
+    lines.append("")
+
+    for c in CLASSES:
+        rows = report.by_class(c)
+        if not rows:
+            continue
+        lines.append(f"### {c} ({at_least}{len(rows)})")
+        lines.append("")
+        for d in rows[:limit_per_class]:
+            caveat = f" ⚠️ _{', '.join(d.caveats)}_" if d.caveats else ""
+            lines.append(f"- [{d.repo}#{d.number}]({d.html_url}) — {d.title}{caveat}")
+            lines.append(f"  - {d.detail}")
+            if d.run_ids:
+                lines.append(f"  - runs: {', '.join(d.run_ids)} ({', '.join(d.run_statuses)})")
+        if len(rows) > limit_per_class:
+            lines.append(f"- …and {len(rows) - limit_per_class} more")
+        lines.append("")
+
+    if report.unmatched_runs:
+        lines.append(f"### Unmatched live runs ({len(report.unmatched_runs)})")
+        lines.append("")
+        lines.append(
+            "_Not a disagreement class — live runs whose join key matched no open item. "
+            "Reported so a broken join surfaces as data instead of a shrinking count._"
+        )
+        lines.append("")
+        for u in report.unmatched_runs[:limit_per_class]:
+            where = f"{u.repo}#{u.issue_number}" if u.repo else "(unparseable input)"
+            lines.append(f"- `{u.run_id}` [{u.status}] → {where} — {u.reason}")
+        lines.append("")
+
+    lines.append(
+        "_Phase 1 is OBSERVE-ONLY: this reconciler performed **zero** writes against any "
+        "listed item — no label edits, no comments, no re-dispatch, no closes._"
+    )
+    lines.append("")
+    lines.append(f"_generated {report.generated_at or 'n/a'}_")
+    return "\n".join(lines)
+
+
+def render_json(report: ReconcileReport) -> str:
+    return json.dumps(report.to_dict(), indent=2, sort_keys=False)

--- a/src/aios/reconcilers/work_state.py
+++ b/src/aios/reconcilers/work_state.py
@@ -78,8 +78,55 @@ SUSPENDED_RUN_STATUSES: frozenset[str] = frozenset({"suspended"})
 #: Terminal: the run is over, whatever the label still claims.
 TERMINAL_RUN_STATUSES: frozenset[str] = frozenset({"completed", "errored", "cancelled"})
 
-#: The label whose truth this reconciler checks.
+#: The label the FIRST cut of this reconciler checked — kept as a named constant
+#: because it is still the most common assertion, NOT because it is the only one.
 DISPATCHED_LABEL = "dispatched"
+
+#: **Every label that asserts "work is in flight on this item".**
+#:
+#: This is the C1 fix and it is the whole point of the tool. The first cut tested
+#: membership of exactly ONE literal (``dispatched``) — so when the seat STRIPPED
+#: that label from all nine confirmed zombies at 2026-07-26T03:25 as remediation,
+#: the reconciler would have classified all nine as AGREEING and reported
+#: "Read OK. 0 ZOMBIE" while nine issues sat dead. They still carry
+#: ``autodev:in-progress`` + ``needs:human/build``, which assert exactly the same
+#: thing: *a machine has this*.
+#:
+#: A tool built BECAUSE a label is an assertion nothing re-checks must not itself
+#: trust a single label. So the claim "in flight" is the UNION below, and every
+#: finding reports WHICH assertion triggered it (:attr:`Disagreement.trigger_labels`).
+IN_FLIGHT_LABELS: frozenset[str] = frozenset(
+    {
+        DISPATCHED_LABEL,
+        "autodev:in-progress",
+        "design:in-progress",
+    }
+)
+
+#: ``needs:human/<gate>`` asserts "the pipeline reached a gate and is parked there",
+#: which is a claim that a run EXISTS. With no run at all it is exactly as false as
+#: a stuck ``dispatched``, so the whole family counts as an in-flight assertion.
+IN_FLIGHT_LABEL_PREFIXES: tuple[str, ...] = ("needs:human/",)
+
+#: Labels that assert the work is DONE / handed off rather than in flight. Listed
+#: so the union above can never quietly swallow them (``autodev:built`` means a PR
+#: exists — that is not a claim that a machine is on it right now).
+NOT_IN_FLIGHT_LABELS: frozenset[str] = frozenset(
+    {"autodev:built", "autodev:failed", "hold", "paused"}
+)
+
+
+def is_in_flight_label(label: str) -> bool:
+    """True iff ``label`` asserts that work is in flight (a run should exist)."""
+    if label in NOT_IN_FLIGHT_LABELS:
+        return False
+    return label in IN_FLIGHT_LABELS or label.startswith(IN_FLIGHT_LABEL_PREFIXES)
+
+
+def in_flight_assertions(labels: Iterable[str]) -> tuple[str, ...]:
+    """Every in-flight assertion carried by ``labels``, sorted (the trigger set)."""
+    return tuple(sorted({x for x in labels if is_in_flight_label(x)}))
+
 
 #: Labels that assert something about pipeline state. An item carrying any of
 #: these is in scope for enumeration (the ``dispatched`` join is the phase-1
@@ -98,10 +145,27 @@ PIPELINE_STATE_LABELS: frozenset[str] = frozenset(
     }
 )
 
-Classification = Literal["ZOMBIE", "DEAD", "MISLABELLED", "LAGGING"]
+Classification = Literal["ZOMBIE", "DEAD", "MISLABELLED", "LAGGING", "AMBIGUOUS"]
 
 #: Stable ordering for rendering + the change-detection hash.
-CLASSES: tuple[Classification, ...] = ("ZOMBIE", "DEAD", "MISLABELLED", "LAGGING")
+#:
+#: ``AMBIGUOUS`` (C2) is a FIRST-CLASS class, not a footnote: an item asserting
+#: in-flight with no run BUT with linked PRs cannot be a zombie and must not be
+#: counted as one. A caveat does not undo a count — phase 2 will act on the class,
+#: so the class has to be right. ``counts["ZOMBIE"]`` therefore excludes them.
+CLASSES: tuple[Classification, ...] = ("ZOMBIE", "AMBIGUOUS", "DEAD", "MISLABELLED", "LAGGING")
+
+#: What the ZOMBIE class can and cannot prove (B3). ``list_runs`` filters
+#: ``archived_at IS NULL`` (``db/queries/__init__.py``) and archiving requires a
+#: TERMINAL run (``services/workflows.py``), so a run that completed and was
+#: archived reads as "no run, ever". ZOMBIE therefore means **no UNARCHIVED run**,
+#: and every report says so out loud rather than letting a reader infer "nothing
+#: ever picked it up".
+ZOMBIE_MEANS = (
+    "no UNARCHIVED run exists for this item. `list_runs` cannot see archived runs "
+    "(archived_at IS NULL) and archiving requires a TERMINAL run, so ZOMBIE cannot "
+    "distinguish 'never picked up' from 'ran and was tidied away'."
+)
 
 
 def is_pipeline_state_label(label: str) -> bool:
@@ -137,7 +201,25 @@ class WorkItem:
 
     @property
     def is_dispatched(self) -> bool:
+        """Legacy single-label test. **Not** what the classifier keys on — see
+        :attr:`claims_in_flight`. Retained only because the phrase "carries
+        `dispatched`" still appears in triage conversation."""
         return DISPATCHED_LABEL in self.labels
+
+    @property
+    def in_flight_labels(self) -> tuple[str, ...]:
+        """The in-flight assertions this item actually carries (C1).
+
+        This is the trigger set: the reconciler reports WHICH label made the claim,
+        so a reader can see that ``autodev:in-progress`` + ``needs:human/build``
+        asserted "a machine has this" just as loudly as ``dispatched`` did.
+        """
+        return in_flight_assertions(self.labels)
+
+    @property
+    def claims_in_flight(self) -> bool:
+        """True iff ANY label asserts work is in flight. The classifier's predicate."""
+        return bool(self.in_flight_labels)
 
     @property
     def pipeline_labels(self) -> tuple[str, ...]:
@@ -191,6 +273,10 @@ class SourceOk:
     items: tuple[Any, ...]
     exhaustive: bool = True
     pages_read: int = 0
+    #: Non-fatal observations from the read itself — e.g. the C4 transfer signal
+    #: (a GitHub 301 on an issue read). Surfaced in the report so a stale join key
+    #: is visible as DATA rather than silently becoming a false ZOMBIE.
+    notes: tuple[str, ...] = ()
 
     ok: Literal[True] = True
 
@@ -232,6 +318,9 @@ class Disagreement:
     updated_at: str = ""
     #: Non-fatal qualifiers a human should see before acting (phase 2 will act).
     caveats: tuple[str, ...] = ()
+    #: WHICH in-flight assertion(s) triggered this finding (C1). Empty for LAGGING,
+    #: whose trigger is the ABSENCE of any such assertion.
+    trigger_labels: tuple[str, ...] = ()
 
     @property
     def key(self) -> tuple[str, int]:
@@ -245,17 +334,26 @@ class Disagreement:
         transition (suspended → errored) DOES.
         """
         return (
-            f"{self.classification}:{self.repo}#{self.number}:{','.join(sorted(self.run_statuses))}"
+            f"{self.classification}:{self.repo}#{self.number}"
+            f":{','.join(sorted(self.run_statuses))}"
+            f":{','.join(sorted(self.trigger_labels))}"
         )
 
 
 @dataclass(frozen=True)
 class UnmatchedRun:
-    """A live run whose ``(repo, issue_number)`` matches no OPEN item we enumerated.
+    """A run that joined to no OPEN item we enumerated.
 
-    Not one of the four classes — it is either a run against a closed issue or a
-    join-key mismatch. Reported (never swallowed) so a broken join surfaces as data
-    instead of as a quietly-shrinking LAGGING count.
+    Not one of the classes — it is a run against a closed issue, or a join-key
+    mismatch. Reported (never swallowed) so a broken join surfaces as data instead
+    of as a quietly-shrinking LAGGING count.
+
+    B4: this now includes **terminal** runs whose join key is unreadable. The
+    previous cut reported only live/suspended ones, so an ``errored`` run with an
+    unparseable ``run.input`` vanished — and its issue was then classified ZOMBIE
+    with no trace of the run that actually existed. That is a manufactured false
+    ZOMBIE, which is the exact failure the PR body claimed to prevent
+    ("unkeyable runs are never skipped"). The claim is now true.
     """
 
     run_id: str
@@ -278,6 +376,8 @@ class ReconcileReport:
     failures: tuple[SourceFailed, ...] = ()
     #: Sources that read OK but stopped short of exhaustion; their counts are floors.
     truncated_sources: tuple[str, ...] = ()
+    #: Non-fatal read observations (C4 transfers, etc.). Never suppressed.
+    notes: tuple[str, ...] = ()
     items_scanned: int = 0
     runs_scanned: int = 0
     repos_scanned: tuple[str, ...] = ()
@@ -328,9 +428,15 @@ class ReconcileReport:
         return {
             "verdict": self.verdict,
             "counts": None if counts is None else {k: counts[k] for k in CLASSES},
+            # B3: stated in EVERY machine-readable report, not just the markdown, so a
+            # phase-2 consumer cannot read ZOMBIE as "nothing ever picked it up".
+            "zombie_means": ZOMBIE_MEANS,
+            "in_flight_labels_checked": sorted(IN_FLIGHT_LABELS)
+            + [p + "*" for p in IN_FLIGHT_LABEL_PREFIXES],
             "total_disagreements": None if self.alarmed else len(self.disagreements),
             "exhaustive": self.exhaustive,
             "truncated_sources": list(self.truncated_sources),
+            "notes": list(self.notes),
             "items_scanned": self.items_scanned,
             "runs_scanned": self.runs_scanned,
             "repos_scanned": list(self.repos_scanned),
@@ -351,6 +457,7 @@ class ReconcileReport:
                     "run_statuses": list(d.run_statuses),
                     "updated_at": d.updated_at,
                     "caveats": list(d.caveats),
+                    "trigger_labels": list(d.trigger_labels),
                 }
                 for d in self.disagreements
             ],
@@ -481,25 +588,38 @@ def _statuses(runs: Sequence[RunRecord]) -> tuple[str, ...]:
 
 
 def classify_item(item: WorkItem, runs: Sequence[RunRecord]) -> Disagreement | None:
-    """Classify ONE item against every run keyed to it. ``None`` == the label agrees.
+    """Classify ONE item against every run keyed to it. ``None`` == the labels agree.
+
+    **What "the label claims work is in flight" means (C1).** Not ``dispatched``.
+    The UNION in :data:`IN_FLIGHT_LABELS` / :data:`IN_FLIGHT_LABEL_PREFIXES`:
+    ``dispatched``, ``autodev:in-progress``, ``design:in-progress``, and every
+    ``needs:human/<gate>``. Keying on one literal string is how the first cut of
+    this module would have reported "0 ZOMBIE" the morning after the seat stripped
+    ``dispatched`` from nine dead issues that still carried
+    ``autodev:in-progress`` + ``needs:human/build``. The trigger is recorded on the
+    finding so a reader sees which assertion was doing the lying.
 
     Precedence is deliberate and is the heart of the design: **live > suspended >
-    terminal**. One live run means work really is happening, whatever the other runs
-    say. With no live run, a *suspended* run means parked-at-a-gate — a different
-    condition from running, hence MISLABELLED rather than "agree" (folding parked
-    into agree is how a gate-parked item hides behind ``dispatched`` forever). Only
-    with no live and no suspended run is the item DEAD/ZOMBIE.
+    unknown > terminal**. One live run means work really is happening, whatever the
+    other runs say. With no live run, a *suspended* run means parked-at-a-gate — a
+    different condition from running, hence MISLABELLED rather than "agree". With
+    neither, an UNRECOGNISED status outranks a terminal one (C3): an unknown status
+    may well BE live under a new name, so it can never be evidence of death — not
+    even alongside a corpse. Only with no live, no suspended and no unknown run is
+    the item DEAD/ZOMBIE/AMBIGUOUS.
     """
     live = [r for r in runs if r.is_live]
     suspended = [r for r in runs if r.is_suspended]
     terminal = [r for r in runs if r.is_terminal]
     unknown = [r for r in runs if not (r.is_live or r.is_suspended or r.is_terminal)]
+    triggers = item.in_flight_labels
 
     def _mk(
         classification: Classification,
         detail: str,
         subject: Sequence[RunRecord],
         caveats: tuple[str, ...] = (),
+        trigger_labels: tuple[str, ...] = triggers,
     ) -> Disagreement:
         return Disagreement(
             classification=classification,
@@ -514,38 +634,53 @@ def classify_item(item: WorkItem, runs: Sequence[RunRecord]) -> Disagreement | N
             run_statuses=_statuses(subject),
             updated_at=item.updated_at,
             caveats=caveats,
+            trigger_labels=trigger_labels,
         )
 
-    if not item.is_dispatched:
-        # Label says nothing; runs say something. The projection lags reality.
+    if not item.claims_in_flight:
+        # No label asserts work is in flight; the runs say otherwise. The projection
+        # lags reality.
         if live:
             return _mk(
                 "LAGGING",
-                f"{len(live)} live run(s) ({', '.join(_statuses(live))}) but no `dispatched` label",
+                f"{len(live)} live run(s) ({', '.join(_statuses(live))}) but NO in-flight "
+                "label (no `dispatched`, no `autodev:in-progress`, no `needs:human/*`)",
                 live,
+                trigger_labels=(),
             )
         return None
 
-    # From here: the item claims `dispatched`.
+    # From here: the item ASSERTS work is in flight (via `triggers`).
+    claim = ", ".join(f"`{x}`" for x in triggers)
+
     if live:
         return None  # agree — a machine really is on it
 
-    if unknown and not (suspended or terminal):
-        # An unrecognised status is NOT evidence of death. Refuse to classify rather
-        # than guess a zombie: a wrong DEAD here is a false alarm that trains people
-        # to ignore the report.
+    if unknown:
+        # C3: an unrecognised status is NEVER evidence of death — not even when a
+        # terminal sibling exists, because the unknown run may be live under a
+        # status name this vocabulary has not learned yet. Handled BEFORE terminal
+        # for exactly that reason. A false DEAD is a false alarm, and false alarms
+        # train people to ignore the report.
+        others = [r for r in (suspended + terminal) if r]
+        extra = (
+            f" (alongside {len(others)} run(s) in {', '.join(_statuses(others))} — a terminal"
+            " sibling does NOT make an unknown status dead)"
+            if others
+            else ""
+        )
         return _mk(
             "MISLABELLED",
-            "run(s) in unrecognised status "
-            f"({', '.join(_statuses(unknown))}) — cannot prove live; treat as parked pending triage",
-            unknown,
+            f"{claim} and run(s) in unrecognised status ({', '.join(_statuses(unknown))}) — "
+            f"cannot prove live; treat as parked pending triage{extra}",
+            unknown + others,
             caveats=("unrecognised-run-status",),
         )
 
     if suspended:
         return _mk(
             "MISLABELLED",
-            f"{len(suspended)} run(s) suspended at a gate — parked is NOT running",
+            f"{claim} but {len(suspended)} run(s) suspended at a gate — parked is NOT running",
             suspended,
         )
 
@@ -553,23 +688,33 @@ def classify_item(item: WorkItem, runs: Sequence[RunRecord]) -> Disagreement | N
         by_status = ", ".join(_statuses(terminal))
         return _mk(
             "DEAD",
-            f"`dispatched` but every run is terminal ({by_status})",
+            f"{claim} but every run is terminal ({by_status})",
             terminal,
         )
 
-    caveats: tuple[str, ...] = ()
+    # No run at all — subject to the B3 caveat that we can only see UNARCHIVED runs.
     if item.linked_pr_numbers:
-        # "No run ever" AND "a PR exists" cannot both be true of healthy work — the
-        # join key is wrong, or the work predates the workflow. Flag it; do not
-        # quietly count it as a zombie.
-        caveats = ("has-linked-prs",)
-    detail = "`dispatched` but NO run exists for this issue — nothing ever picked it up"
-    if item.linked_pr_numbers:
-        detail += (
-            f" (but PR(s) {', '.join('#' + str(n) for n in item.linked_pr_numbers)} reference it —"
-            " verify the join key before believing this)"
+        # C2: "no run ever" AND "a PR exists" cannot both be true of healthy work, so
+        # this is NOT a zombie — it is a join-key question. It gets its OWN class,
+        # excluded from counts["ZOMBIE"], because a footnote does not undo a count and
+        # phase 2 will act on the class, not the caveat.
+        prs = ", ".join("#" + str(n) for n in item.linked_pr_numbers)
+        return _mk(
+            "AMBIGUOUS",
+            f"{claim} and no unarchived run — BUT PR(s) {prs} reference this issue. "
+            "Work demonstrably happened, so the join key (or the run's archival) is the "
+            "suspect, not the item. NEEDS TRIAGE — deliberately NOT counted as a ZOMBIE.",
+            (),
+            caveats=("has-linked-prs", "excluded-from-zombie-count"),
         )
-    return _mk("ZOMBIE", detail, (), caveats=caveats)
+
+    return _mk(
+        "ZOMBIE",
+        f"{claim} but NO unarchived run exists for this issue — nothing (visible) ever "
+        "picked it up",
+        (),
+        caveats=("zombie-means-no-unarchived-run",),
+    )
 
 
 # ─── the report builder ──────────────────────────────────────────────────────
@@ -637,16 +782,24 @@ def build_report(
     for run in runs:
         key = run.key
         if key is None:
-            if run.is_live or run.is_suspended:
-                unmatched.append(
-                    UnmatchedRun(
-                        run_id=run.run_id,
-                        status=run.status,
-                        repo=run.repo,
-                        issue_number=run.issue_number,
-                        reason="run.input carries no usable (repo, issue_number) — join key unreadable",
-                    )
+            # B4: EVERY unkeyable run is reported, terminal ones included. The old
+            # live/suspended filter silently dropped an `errored` run with an
+            # unparseable input — and its issue was then classified ZOMBIE with no
+            # trace of the run that did exist. A manufactured false ZOMBIE with no
+            # trace in the output is the exact failure this section claims to prevent.
+            unmatched.append(
+                UnmatchedRun(
+                    run_id=run.run_id,
+                    status=run.status,
+                    repo=run.repo,
+                    issue_number=run.issue_number,
+                    reason=(
+                        f"run.input carries no usable (repo, issue_number) — join key "
+                        f"unreadable (status {run.status or 'unknown'}); any item this run "
+                        "belonged to may therefore read as a FALSE ZOMBIE"
+                    ),
                 )
+            )
             continue
         if run.is_live and key not in items_by_key:
             unmatched.append(
@@ -660,6 +813,7 @@ def build_report(
             )
 
     truncated = tuple(s.name for s in (items_read, runs_read) if not s.exhaustive)
+    notes = tuple(n for src in (items_read, runs_read) for n in src.notes)
 
     order = {c: n for n, c in enumerate(CLASSES)}
     disagreements.sort(key=lambda d: (order[d.classification], d.repo, d.number))
@@ -670,6 +824,7 @@ def build_report(
         unmatched_runs=tuple(unmatched),
         failures=(),
         truncated_sources=truncated,
+        notes=notes,
         items_scanned=len(items),
         runs_scanned=len(runs),
         repos_scanned=tuple(repos_scanned),
@@ -722,17 +877,33 @@ def render_markdown(report: ReconcileReport, *, limit_per_class: int = 50) -> st
             + ". Every number below is 'at least N'."
         )
     lines.append("")
+    if report.notes:
+        for note in report.notes:
+            lines.append(f"> ⚠️ {note}")
+        lines.append("")
     lines.append("| class | count | meaning |")
     lines.append("|---|---:|---|")
     meaning = {
-        "ZOMBIE": "`dispatched`, no run ever — nothing picked it up",
-        "DEAD": "`dispatched`, every run terminal",
-        "MISLABELLED": "`dispatched`, run suspended at a gate (parked ≠ running)",
-        "LAGGING": "live run, no `dispatched` label — the projection lags",
+        "ZOMBIE": "claims in-flight, **no UNARCHIVED run** — nothing visible picked it up",
+        "AMBIGUOUS": "claims in-flight, no run, **but linked PRs exist** — NOT a zombie; triage",
+        "DEAD": "claims in-flight, every run terminal",
+        "MISLABELLED": "claims in-flight, run suspended at a gate (parked ≠ running)",
+        "LAGGING": "live run, but NO in-flight label — the projection lags",
     }
     for c in CLASSES:
         lines.append(f"| **{c}** | {at_least}{counts[c]} | {meaning[c]} |")
     lines.append(f"| _total_ | {at_least}{total} | |")
+    lines.append("")
+    # B3, stated LOUDLY and unconditionally — not as a footnote a triager may miss.
+    lines.append(f"> ⚠️ **What ZOMBIE can prove:** {ZOMBIE_MEANS}")
+    lines.append("")
+    lines.append(
+        "> **In-flight assertions checked** (a finding names which one triggered it): "
+        + ", ".join(f"`{x}`" for x in sorted(IN_FLIGHT_LABELS))
+        + ", "
+        + ", ".join(f"`{x}*`" for x in IN_FLIGHT_LABEL_PREFIXES)
+        + ". Keying on `dispatched` alone is how nine dead issues read as healthy."
+    )
     lines.append("")
     lines.append(f"`disagreement_hash`: `{report.disagreement_hash()[:16]}`")
     lines.append("")
@@ -743,9 +914,19 @@ def render_markdown(report: ReconcileReport, *, limit_per_class: int = 50) -> st
             continue
         lines.append(f"### {c} ({at_least}{len(rows)})")
         lines.append("")
+        if c == "AMBIGUOUS":
+            lines.append(
+                "_Deliberately NOT counted as ZOMBIE: each of these has linked PRs, so work "
+                "demonstrably happened and the join key (or run archival) is the suspect._"
+            )
+            lines.append("")
         for d in rows[:limit_per_class]:
             caveat = f" ⚠️ _{', '.join(d.caveats)}_" if d.caveats else ""
             lines.append(f"- [{d.repo}#{d.number}]({d.html_url}) — {d.title}{caveat}")
+            if d.trigger_labels:
+                lines.append(
+                    f"  - triggered by: {', '.join('`' + x + '`' for x in d.trigger_labels)}"
+                )
             lines.append(f"  - {d.detail}")
             if d.run_ids:
                 lines.append(f"  - runs: {', '.join(d.run_ids)} ({', '.join(d.run_statuses)})")
@@ -754,10 +935,11 @@ def render_markdown(report: ReconcileReport, *, limit_per_class: int = 50) -> st
         lines.append("")
 
     if report.unmatched_runs:
-        lines.append(f"### Unmatched live runs ({len(report.unmatched_runs)})")
+        lines.append(f"### Unmatched runs ({len(report.unmatched_runs)})")
         lines.append("")
         lines.append(
-            "_Not a disagreement class — live runs whose join key matched no open item. "
+            "_Not a disagreement class — runs whose join key matched no open item (terminal "
+            "ones included, since a dropped run manufactures a false ZOMBIE). "
             "Reported so a broken join surfaces as data instead of a shrinking count._"
         )
         lines.append("")

--- a/src/aios/reconcilers/work_state.py
+++ b/src/aios/reconcilers/work_state.py
@@ -149,8 +149,9 @@ Classification = Literal["ZOMBIE", "DEAD", "MISLABELLED", "LAGGING", "AMBIGUOUS"
 
 #: Stable ordering for rendering + the change-detection hash.
 #:
-#: ``AMBIGUOUS`` (C2) is a FIRST-CLASS class, not a footnote: an item asserting
-#: in-flight with no run BUT with linked PRs cannot be a zombie and must not be
+#: ``AMBIGUOUS`` (C2/C4) is a FIRST-CLASS class, not a footnote: an item asserting
+#: in-flight with no run BUT with linked PRs — or one whose run is keyed to STALE
+#: coordinates because the issue was TRANSFERRED — cannot be a zombie and must not be
 #: counted as one. A caveat does not undo a count — phase 2 will act on the class,
 #: so the class has to be right. ``counts["ZOMBIE"]`` therefore excludes them.
 CLASSES: tuple[Classification, ...] = ("ZOMBIE", "AMBIGUOUS", "DEAD", "MISLABELLED", "LAGGING")
@@ -171,6 +172,101 @@ ZOMBIE_MEANS = (
 def is_pipeline_state_label(label: str) -> bool:
     """True iff ``label`` asserts something about pipeline work state."""
     return label in PIPELINE_STATE_LABELS or label.startswith(PIPELINE_STATE_LABEL_PREFIXES)
+
+
+# ─── C4: the STALE-JOIN-KEY probe (transferred issues) ───────────────────────
+#
+# A transfer is only ever visible from the OLD coordinates, and the old coordinates
+# are the one place enumeration never looks.
+#
+# The first cut of C4 detected a transfer by starting from an ENUMERATED issue and
+# noticing a redirect on its timeline read. **That world cannot occur.** Once a
+# transfer has completed, GitHub serves the issue at its NEW (repo, number) and
+# enumeration of the new repo returns exactly that — the OLD pair is never
+# enumerated, so nothing ever asks GitHub about it and no redirect is ever seen. The
+# real transferred issue therefore still became a FALSE ZOMBIE: it is enumerated at
+# its new coordinates, no run is keyed there (every ``run.input`` still holds the old
+# pair), and "no run" reads as "nothing ever picked it up".
+#
+# So the probe is INVERTED. The stale coordinates are known — they are exactly the
+# run join keys that matched NO enumerated item (:func:`stale_run_keys`). The I/O
+# shell GETs those coordinates directly (``GET /repos/{repo}/issues/{n}``, still
+# GET-only) and a redirect — or a body that answers from different coordinates than
+# the ones asked for — is authoritative evidence of a transfer. The evidence is fed
+# back in as :class:`TransferEvidence`, which moves the item at the NEW coordinates
+# out of ZOMBIE and into AMBIGUOUS/NEEDS-TRIAGE.
+
+
+def parse_issue_ref(url: Any) -> tuple[str, int] | None:
+    """``(repo, number)`` from a GitHub issue API **or** HTML url; ``None`` if unreadable.
+
+    Used to turn a redirect destination into the issue's NEW coordinates. Returns
+    ``None`` rather than guessing: a guessed join key manufactures a phantom "agree",
+    which is the failure this whole module exists to prevent.
+    """
+    if not isinstance(url, str) or not url:
+        return None
+    parts = [p for p in url.split("?", 1)[0].rstrip("/").split("/") if p]
+    if len(parts) < 4 or parts[-2] not in ("issues", "pull", "pulls"):
+        return None
+    number = _coerce_issue_number(parts[-1])
+    owner, name = parts[-4], parts[-3]
+    if number is None or owner in ("repos", "github.com", "api.github.com"):
+        return None
+    return (f"{owner}/{name}", number)
+
+
+def stale_key_transfer_note(
+    stale_repo: str, stale_number: int, dest: str, run_ids: Sequence[str] = ()
+) -> str:
+    """The C4 note for an INVERTED probe hit, in ONE place.
+
+    Byte-identical to the workflow mirror's ``stale_key_transfer_note`` — the reader
+    drift guard compares the emitted strings, so the two forms cannot describe the
+    same transfer differently.
+    """
+    ids = ", ".join(sorted(run_ids)) or "(none)"
+    return (
+        f"STALE JOIN KEY: {stale_repo}#{stale_number} — held by run(s) {ids} — RESOLVES to "
+        f"{dest}. The issue was TRANSFERRED, so that run can never join, and the issue at "
+        "its NEW coordinates would otherwise read as a FALSE ZOMBIE (C4)"
+    )
+
+
+@dataclass(frozen=True)
+class TransferEvidence:
+    """Authoritative evidence that a run's stored ``(repo, issue_number)`` is STALE.
+
+    Produced by the inverted probe: we asked GitHub about the STALE coordinates and
+    GitHub answered from somewhere else (a 301, or a body whose own coordinates
+    differ). Either way the issue moved.
+    """
+
+    stale_repo: str
+    stale_number: int
+    #: Where the probe actually landed (redirect ``Location`` / final url / body url).
+    destination: str
+    #: The NEW coordinates, when the destination could be parsed. ``None`` means we
+    #: know a transfer happened but not where to — still reported, never guessed.
+    new_repo: str | None = None
+    new_number: int | None = None
+    #: The run(s) whose join key is stale. Named on the finding so a triager can act.
+    run_ids: tuple[str, ...] = ()
+
+    @property
+    def stale_key(self) -> tuple[str, int]:
+        return (self.stale_repo, self.stale_number)
+
+    @property
+    def new_key(self) -> tuple[str, int] | None:
+        if self.new_repo is None or self.new_number is None:
+            return None
+        return (self.new_repo, self.new_number)
+
+    def note(self) -> str:
+        return stale_key_transfer_note(
+            self.stale_repo, self.stale_number, self.destination, self.run_ids
+        )
 
 
 # ─── inputs ──────────────────────────────────────────────────────────────────
@@ -378,6 +474,10 @@ class ReconcileReport:
     truncated_sources: tuple[str, ...] = ()
     #: Non-fatal read observations (C4 transfers, etc.). Never suppressed.
     notes: tuple[str, ...] = ()
+    #: The C4 stale-join-key evidence behind the transfer notes. Kept as structured
+    #: data (not only prose) because the change detector hashes it — see
+    #: :meth:`disagreement_hash`.
+    transfers: tuple[TransferEvidence, ...] = ()
     items_scanned: int = 0
     runs_scanned: int = 0
     repos_scanned: tuple[str, ...] = ()
@@ -409,6 +509,17 @@ class ReconcileReport:
     def by_class(self, classification: Classification) -> tuple[Disagreement, ...]:
         return tuple(d for d in self.disagreements if d.classification == classification)
 
+    @property
+    def transfer_notes(self) -> tuple[str, ...]:
+        """Just the C4 transfer notes, sorted — the part of ``notes`` the hash folds in.
+
+        A transfer note is the ONLY output for a stale key whose destination is
+        outside the scanned repos: there is no item to hang a caveat on, so if the
+        hash ignored these, a newly-discovered stale key would read as "unchanged,
+        nothing to say" and never wake the seat.
+        """
+        return tuple(sorted({e.note() for e in self.transfers}))
+
     def disagreement_hash(self) -> str:
         """Stable hash of the disagreement SET — the seat-wake change detector.
 
@@ -417,10 +528,19 @@ class ReconcileReport:
         for the same reason is the same hash tomorrow. On ALARM the hash folds in
         the failure reasons, so a persistent outage does not read as "unchanged,
         nothing to say" — a NEW failure wakes the seat.
+
+        The C4 transfer notes are folded in for the same reason (ITEM 2): a transfer
+        caveat that appears, moves or disappears is a real change in what a triager
+        must act on, and a hash blind to it would leave the seat asleep. They are
+        hashed as their own SORTED section so that adding transfer detection cannot
+        collide with a disagreement identity.
         """
         parts = sorted(d.identity() for d in self.disagreements)
+        transfer_parts = list(self.transfer_notes)
         if self.alarmed:
             parts = ["ALARM", *sorted(f"{f.name}:{f.reason}" for f in self.failures)]
+        if transfer_parts:
+            parts = [*parts, "TRANSFERS", *transfer_parts]
         return hashlib.sha256("\n".join(parts).encode()).hexdigest()
 
     def to_dict(self) -> dict[str, Any]:
@@ -437,6 +557,19 @@ class ReconcileReport:
             "exhaustive": self.exhaustive,
             "truncated_sources": list(self.truncated_sources),
             "notes": list(self.notes),
+            # C4 — the stale-key evidence as DATA, not only prose, so a phase-2
+            # consumer can act on the transfer without parsing a sentence.
+            "transfers": [
+                {
+                    "stale_repo": e.stale_repo,
+                    "stale_number": e.stale_number,
+                    "destination": e.destination,
+                    "new_repo": e.new_repo,
+                    "new_number": e.new_number,
+                    "run_ids": list(e.run_ids),
+                }
+                for e in self.transfers
+            ],
             "items_scanned": self.items_scanned,
             "runs_scanned": self.runs_scanned,
             "repos_scanned": list(self.repos_scanned),
@@ -580,6 +713,32 @@ def index_runs(runs: Iterable[RunRecord]) -> dict[tuple[str, int], list[RunRecor
     return index
 
 
+def stale_run_keys(
+    items: Iterable[WorkItem], runs: Iterable[RunRecord]
+) -> dict[tuple[str, int], tuple[str, ...]]:
+    """The C4 probe list: every run join key that matched NO enumerated item.
+
+    This is the INVERSION that makes transfer detection possible at all. A completed
+    transfer is invisible from the new coordinates (they resolve normally) and
+    invisible from enumeration (which only ever returns the new pair). It is visible
+    from exactly one place: the OLD pair, which survives only in ``run.input``. Those
+    pairs are precisely the keys below, so these — not the enumerated items — are the
+    coordinates worth probing.
+
+    Returns ``{stale_key: (run_id, ...)}``, sorted for determinism. Unkeyable runs are
+    absent by construction (they have no coordinates to probe) and are reported as
+    :class:`UnmatchedRun` instead.
+    """
+    open_keys = {i.key for i in items}
+    stale: dict[tuple[str, int], list[str]] = {}
+    for run in runs:
+        key = run.key
+        if key is None or key in open_keys:
+            continue
+        stale.setdefault(key, []).append(run.run_id)
+    return {k: tuple(sorted(v)) for k, v in sorted(stale.items())}
+
+
 # ─── the classifier ──────────────────────────────────────────────────────────
 
 
@@ -587,7 +746,12 @@ def _statuses(runs: Sequence[RunRecord]) -> tuple[str, ...]:
     return tuple(sorted({r.status for r in runs}))
 
 
-def classify_item(item: WorkItem, runs: Sequence[RunRecord]) -> Disagreement | None:
+def classify_item(
+    item: WorkItem,
+    runs: Sequence[RunRecord],
+    *,
+    transfer: TransferEvidence | None = None,
+) -> Disagreement | None:
     """Classify ONE item against every run keyed to it. ``None`` == the labels agree.
 
     **What "the label claims work is in flight" means (C1).** Not ``dispatched``.
@@ -607,6 +771,12 @@ def classify_item(item: WorkItem, runs: Sequence[RunRecord]) -> Disagreement | N
     may well BE live under a new name, so it can never be evidence of death — not
     even alongside a corpse. Only with no live, no suspended and no unknown run is
     the item DEAD/ZOMBIE/AMBIGUOUS.
+
+    ``transfer`` (C4) is evidence from the INVERTED probe that this item is the
+    destination of a transfer: a run exists, but keyed to the issue's OLD
+    coordinates, so it cannot join here. That is a join-key fact, not a dead issue,
+    so the item becomes AMBIGUOUS/NEEDS-TRIAGE and is kept OUT of
+    ``counts["ZOMBIE"]``.
     """
     live = [r for r in runs if r.is_live]
     suspended = [r for r in runs if r.is_suspended]
@@ -693,6 +863,31 @@ def classify_item(item: WorkItem, runs: Sequence[RunRecord]) -> Disagreement | N
         )
 
     # No run at all — subject to the B3 caveat that we can only see UNARCHIVED runs.
+    if transfer is not None:
+        # C4: a run DOES exist for this work; it is keyed to the coordinates this issue
+        # had BEFORE it was transferred, so it cannot join here. "No run" is therefore
+        # false, and calling this a ZOMBIE would be a manufactured verdict about a
+        # stale join key. Its own class, excluded from counts["ZOMBIE"], exactly as
+        # the linked-PR case below — phase 2 acts on the class, not on a footnote.
+        moved_from = f"{transfer.stale_repo}#{transfer.stale_number}"
+        ids = ", ".join(transfer.run_ids) or "(none)"
+        prs = (
+            " Linked PR(s): "
+            + ", ".join("#" + str(n) for n in item.linked_pr_numbers)
+            + "."
+            if item.linked_pr_numbers
+            else ""
+        )
+        return _mk(
+            "AMBIGUOUS",
+            f"{claim} and no unarchived run at THESE coordinates — BUT {moved_from} "
+            f"RESOLVES here, i.e. this issue was TRANSFERRED and run(s) {ids} still hold "
+            f"the OLD join key. The key is stale, not the work missing.{prs} "
+            "NEEDS TRIAGE — deliberately NOT counted as a ZOMBIE.",
+            (),
+            caveats=("transferred-stale-join-key", "excluded-from-zombie-count"),
+        )
+
     if item.linked_pr_numbers:
         # C2: "no run ever" AND "a PR exists" cannot both be true of healthy work, so
         # this is NOT a zombie — it is a join-key question. It gets its OWN class,
@@ -727,6 +922,7 @@ def build_report(
     generated_at: str = "",
     repos_scanned: Sequence[str] = (),
     meta: Mapping[str, Any] | None = None,
+    transfers: Sequence[TransferEvidence] = (),
 ) -> ReconcileReport:
     """Join the two sources and classify. **Any failed source ⇒ ALARM, no counts.**
 
@@ -736,12 +932,19 @@ def build_report(
     immediately — no classification is attempted, no zeros are produced, and
     :attr:`ReconcileReport.counts` is ``None``. A caller cannot accidentally print
     health, because there is nothing healthy-shaped to print.
+
+    ``transfers`` (C4) carries the result of the INVERTED stale-key probe run by the
+    I/O shell (see :func:`stale_run_keys`). Each piece of evidence is matched to the
+    item at the transfer's NEW coordinates, which then classifies AMBIGUOUS rather
+    than ZOMBIE, and every piece of evidence emits a note — including ones whose
+    destination is outside the scanned repos, where there is no item to attach to.
     """
     failures = tuple(s for s in (items_read, runs_read) if isinstance(s, SourceFailed))
     if failures:
         return ReconcileReport(
             verdict="ALARM",
             failures=failures,
+            transfers=tuple(transfers),
             repos_scanned=tuple(repos_scanned),
             generated_at=generated_at,
             meta=dict(meta or {}),
@@ -772,9 +975,21 @@ def build_report(
     run_index = index_runs(runs)
     items_by_key = {i.key: i for i in items}
 
+    # C4: index the transfer evidence by the item it lands ON (the NEW coordinates),
+    # since that is the item facing a false ZOMBIE verdict.
+    transfers_by_new_key: dict[tuple[str, int], TransferEvidence] = {}
+    for evidence in transfers:
+        new_key = evidence.new_key
+        if new_key is not None:
+            transfers_by_new_key.setdefault(new_key, evidence)
+
     disagreements: list[Disagreement] = []
     for item in sorted(items, key=lambda i: (i.repo, i.number)):
-        verdict = classify_item(item, run_index.get(item.key, []))
+        verdict = classify_item(
+            item,
+            run_index.get(item.key, []),
+            transfer=transfers_by_new_key.get(item.key),
+        )
         if verdict is not None:
             disagreements.append(verdict)
 
@@ -813,7 +1028,12 @@ def build_report(
             )
 
     truncated = tuple(s.name for s in (items_read, runs_read) if not s.exhaustive)
-    notes = tuple(n for src in (items_read, runs_read) for n in src.notes)
+    # C4 notes come LAST and are never suppressed — including for a transfer whose
+    # destination lies outside the scanned repos, where no item exists to carry the
+    # caveat and the note is the only trace the stale key leaves.
+    notes = tuple(n for src in (items_read, runs_read) for n in src.notes) + tuple(
+        e.note() for e in transfers
+    )
 
     order = {c: n for n, c in enumerate(CLASSES)}
     disagreements.sort(key=lambda d: (order[d.classification], d.repo, d.number))
@@ -825,6 +1045,7 @@ def build_report(
         failures=(),
         truncated_sources=truncated,
         notes=notes,
+        transfers=tuple(transfers),
         items_scanned=len(items),
         runs_scanned=len(runs),
         repos_scanned=tuple(repos_scanned),
@@ -885,7 +1106,10 @@ def render_markdown(report: ReconcileReport, *, limit_per_class: int = 50) -> st
     lines.append("|---|---:|---|")
     meaning = {
         "ZOMBIE": "claims in-flight, **no UNARCHIVED run** — nothing visible picked it up",
-        "AMBIGUOUS": "claims in-flight, no run, **but linked PRs exist** — NOT a zombie; triage",
+        "AMBIGUOUS": (
+            "claims in-flight, no run, **but linked PRs exist or the issue was "
+            "TRANSFERRED** — NOT a zombie; triage"
+        ),
         "DEAD": "claims in-flight, every run terminal",
         "MISLABELLED": "claims in-flight, run suspended at a gate (parked ≠ running)",
         "LAGGING": "live run, but NO in-flight label — the projection lags",
@@ -916,7 +1140,8 @@ def render_markdown(report: ReconcileReport, *, limit_per_class: int = 50) -> st
         lines.append("")
         if c == "AMBIGUOUS":
             lines.append(
-                "_Deliberately NOT counted as ZOMBIE: each of these has linked PRs, so work "
+                "_Deliberately NOT counted as ZOMBIE: each of these has linked PRs, or is the "
+                "destination of a TRANSFER whose run still holds the old coordinates. Work "
                 "demonstrably happened and the join key (or run archival) is the suspect._"
             )
             lines.append("")

--- a/src/aios/reconcilers/work_state_cli.py
+++ b/src/aios/reconcilers/work_state_cli.py
@@ -180,6 +180,16 @@ def _item_from_payload(
     )
 
 
+def transfer_note(repo: str, number: Any, dest: str) -> str:
+    """The C4 note, in ONE place. Byte-identical to the workflow mirror's
+    ``transfer_note`` — the reader drift guard compares the emitted strings, so the
+    two forms cannot describe the same transfer differently."""
+    return (
+        f"{repo}#{number} was REDIRECTED to {dest} — the issue appears to have been "
+        "TRANSFERRED, so any run keyed to these coordinates cannot join (C4)"
+    )
+
+
 def fetch_repo_items(
     repo: str,
     *,
@@ -187,6 +197,7 @@ def fetch_repo_items(
     getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
     max_pages: int = _MAX_ISSUE_PAGES,
     keep_unlabelled: bool = True,
+    notes: list[str] | None = None,
 ) -> tuple[list[WorkItem], bool]:
     """Every OPEN issue/PR in ``repo``.
 
@@ -223,6 +234,11 @@ def fetch_repo_items(
         if pages >= max_pages:
             return items, False  # cap hit — caller must render "at least N"
         body, resp_headers = getter(url, headers)
+        if resp_headers.get(_FINAL_URL_HEADER) and notes is not None:
+            # C4 on the LIST path: the repo itself was renamed/moved and urllib followed
+            # the 301 silently. Say so — the workflow mirror emits the same note for the
+            # same event, and the reader drift guard compares them.
+            notes.append(transfer_note(repo, "*", str(resp_headers[_FINAL_URL_HEADER])))
         if not isinstance(body, list):
             raise ReadFailure(f"GET {url} did not return a JSON array (got {type(body).__name__})")
         pages += 1
@@ -306,9 +322,10 @@ def read_github_items(
     """
     all_items: list[WorkItem] = []
     exhaustive = True
+    notes: list[str] = []
     try:
         for repo in repos:
-            items, repo_exhaustive = fetch_repo_items(repo, token=token, getter=getter)
+            items, repo_exhaustive = fetch_repo_items(repo, token=token, getter=getter, notes=notes)
             exhaustive = exhaustive and repo_exhaustive
             all_items.extend(items)
     except ReadFailure as exc:
@@ -355,15 +372,14 @@ def read_github_items(
         except ReadFailure as exc:
             return SourceFailed(name="github-timeline", reason=str(exc))
 
+    for (repo_name, number), dest in sorted(transferred.items()):
+        notes.append(transfer_note(repo_name, number, dest))
+
     return SourceOk(
         name="github",
         items=tuple(all_items),
         exhaustive=exhaustive,
-        notes=tuple(
-            f"{repo}#{number} was REDIRECTED to {dest} — the issue appears to have been "
-            "TRANSFERRED, so any run keyed to these coordinates cannot join (C4)"
-            for (repo, number), dest in sorted(transferred.items())
-        ),
+        notes=tuple(notes),
     )
 
 

--- a/src/aios/reconcilers/work_state_cli.py
+++ b/src/aios/reconcilers/work_state_cli.py
@@ -68,6 +68,9 @@ DEFAULT_REPOS: tuple[str, ...] = (
 DEV_PIPELINE_WORKFLOW_ID = "wf_01KV4YGV4PSGP08TJBAY32J2VK"
 
 _GITHUB_API = "https://api.github.com"
+#: Synthetic response header carrying the post-redirect URL (see :func:`_get`).
+#: Not a wire header — the transport's own report of where it actually landed.
+_FINAL_URL_HEADER = "X-Reconciler-Final-Url"
 _REQUEST_TIMEOUT_S = 30
 #: Hard page ceilings. Hitting one is NOT silently ignored: the source is marked
 #: non-exhaustive and every derived count renders as "at least N".
@@ -102,13 +105,29 @@ def _get(
             "Mutating a reconciled item is a failed build, not a feature."
         )
     req = urllib.request.Request(url, method="GET")
+    # Belt-and-braces for the reviewer's `data=` hole: urllib infers POST from a
+    # non-None body, so a future `Request(url, data=...)` would mutate while
+    # containing none of the literals a source grep looks for. Assert the TRANSPORT.
+    if req.get_method() != "GET" or req.data is not None:
+        raise ObserveOnlyViolation(
+            f"phase-1 reconciler is OBSERVE-ONLY: transport resolved to "
+            f"{req.get_method()} (data={'set' if req.data is not None else 'None'}) for {url}"
+        )
     for k, v in headers.items():
         req.add_header(k, v)
     try:
         with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
             raw = resp.read().decode()
             body = json.loads(raw) if raw else None
-            return body, dict(resp.headers)
+            out = dict(resp.headers)
+            # urllib follows a 301 SILENTLY. GitHub 301s a TRANSFERRED issue to its
+            # new (repo, number) — the single signal that a run's stored join key is
+            # stale (C4). Surface the final URL so the caller can SEE the redirect
+            # instead of the transfer vanishing into a false ZOMBIE.
+            final = resp.geturl()
+            if final and final != url:
+                out[_FINAL_URL_HEADER] = final
+            return body, out
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode(errors="replace")[:400]
         raise ReadFailure(f"GET {url} → HTTP {exc.code}: {detail}") from exc
@@ -167,8 +186,18 @@ def fetch_repo_items(
     token: str,
     getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
     max_pages: int = _MAX_ISSUE_PAGES,
+    keep_unlabelled: bool = True,
 ) -> tuple[list[WorkItem], bool]:
-    """Every OPEN issue/PR in ``repo`` carrying at least one pipeline state label.
+    """Every OPEN issue/PR in ``repo``.
+
+    C5 — ``keep_unlabelled=True`` (the default) keeps items carrying NO pipeline
+    label at all. The previous cut dropped them, which made LAGGING structurally
+    under-detectable: a live run against an unlabelled issue could never be LAGGING;
+    it was demoted to an ``unmatched_run`` reason-stringed "not open", which is
+    false — the item IS open, it just has no label. Since LAGGING is defined by the
+    ABSENCE of an in-flight assertion, the enumeration cannot pre-filter on
+    presence-of-*some*-label either. Unlabelled items with no run classify to
+    ``None`` and cost nothing.
 
     Enumerates all open items and filters locally rather than asking GitHub for
     ``?labels=dispatched``: the LAGGING class is defined by the ABSENCE of
@@ -201,7 +230,7 @@ def fetch_repo_items(
             if not isinstance(payload, Mapping):
                 raise ReadFailure(f"GET {url} returned a non-object row")
             item = _item_from_payload(repo, payload)
-            if any(is_pipeline_state_label(x) for x in item.labels):
+            if keep_unlabelled or any(is_pipeline_state_label(x) for x in item.labels):
                 items.append(item)
         url = _next_link(resp_headers)
     return items, True
@@ -213,8 +242,12 @@ def fetch_linked_prs(
     *,
     token: str,
     getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
-) -> tuple[int, ...]:
-    """PRs cross-referencing an issue, from its timeline (READ-ONLY).
+) -> tuple[tuple[int, ...], str | None]:
+    """PRs cross-referencing an issue + any redirect seen, from its timeline (READ-ONLY).
+
+    Returns ``(linked_pr_numbers, redirected_to_url_or_None)``. The second element is
+    the C4 transfer signal: a non-None value means GitHub 301'd this (repo, number),
+    i.e. the issue MOVED and every run keyed to the old coordinates is now unjoinable.
 
     Used only to qualify a ZOMBIE verdict: "no run ever" + "a PR exists" means the
     join key is suspect, and the report says so instead of asserting a zombie.
@@ -228,9 +261,18 @@ def fetch_linked_prs(
         "User-Agent": "aios-work-state-reconciler",
     }
     found: set[int] = set()
+    redirected_to: str | None = None
     next_url: str | None = url
     while next_url is not None:
         body, resp_headers = getter(next_url, headers)
+        if resp_headers.get(_FINAL_URL_HEADER):
+            # C4 — 68 issues were transferred between repos on 2026-07-25. A transfer
+            # gives the issue a NEW (repo, number) while every run.input still holds
+            # the OLD one, so the join key is stale and the item reads as a false
+            # ZOMBIE (or its run as unmatched). The 301 is the only signal, and urllib
+            # follows it silently. Detection only in phase 1 — we report it, we do not
+            # rewrite the key.
+            redirected_to = str(resp_headers[_FINAL_URL_HEADER])
         if not isinstance(body, list):
             raise ReadFailure(f"GET {next_url} did not return a JSON array")
         for event in body:
@@ -245,7 +287,7 @@ def fetch_linked_prs(
                 if isinstance(num, int):
                     found.add(num)
         next_url = _next_link(resp_headers)
-    return tuple(sorted(found))
+    return tuple(sorted(found)), redirected_to
 
 
 def read_github_items(
@@ -279,12 +321,21 @@ def read_github_items(
             name="github", reason=f"unexpected read error: {type(exc).__name__}: {exc}"
         )
 
+    transferred: dict[tuple[str, int], str] = {}
     if enrich_linked_prs:
         try:
             enriched: list[WorkItem] = []
             for item in all_items:
-                if item.is_dispatched and item.kind == "issue":
-                    linked = fetch_linked_prs(item.repo, item.number, token=token, getter=getter)
+                # C1: enrich on the UNION of in-flight assertions. Keying this on
+                # `dispatched` alone meant the nine issues that now assert in-flight
+                # via `autodev:in-progress` never had their linked PRs read, so the
+                # AMBIGUOUS class (C2) could never fire for them.
+                if item.claims_in_flight and item.kind == "issue":
+                    linked, redirected = fetch_linked_prs(
+                        item.repo, item.number, token=token, getter=getter
+                    )
+                    if redirected:
+                        transferred[item.key] = redirected
                     enriched.append(
                         WorkItem(
                             repo=item.repo,
@@ -304,7 +355,16 @@ def read_github_items(
         except ReadFailure as exc:
             return SourceFailed(name="github-timeline", reason=str(exc))
 
-    return SourceOk(name="github", items=tuple(all_items), exhaustive=exhaustive)
+    return SourceOk(
+        name="github",
+        items=tuple(all_items),
+        exhaustive=exhaustive,
+        notes=tuple(
+            f"{repo}#{number} was REDIRECTED to {dest} — the issue appears to have been "
+            "TRANSFERRED, so any run keyed to these coordinates cannot join (C4)"
+            for (repo, number), dest in sorted(transferred.items())
+        ),
+    )
 
 
 # ─── aios: runs of the pipeline workflows ────────────────────────────────────
@@ -360,7 +420,22 @@ def read_aios_runs(
                     records.append(run_record_from_payload(row))
                 cursor = body.get("next_cursor")
                 has_more = body.get("has_more")
-                if has_more and isinstance(cursor, str) and cursor:
+                if has_more and not (isinstance(cursor, str) and cursor):
+                    # B1 — THE fail-loud break. The server said THERE IS MORE and handed
+                    # us no usable cursor. The old code fell into the `else` branch,
+                    # ended pagination, and reported exhaustive=True: a truncated read
+                    # rendered as exhaustive, which is the 2026-07-25 failure mode with
+                    # extra steps. Every ZOMBIE verdict is derived from "no run exists in
+                    # the list I read", so an unread page of runs manufactures false
+                    # ZOMBIEs and hides live runs from LAGGING. This is a FAILED read.
+                    raise ReadFailure(
+                        f"GET {url} returned has_more={has_more!r} with an unusable "
+                        f"next_cursor ({cursor!r}) — the server says there is MORE run "
+                        "history and gave no way to fetch it. Refusing to report a "
+                        "truncated read as exhaustive."
+                    )
+                if has_more:
+                    assert isinstance(cursor, str)
                     url = f"{base_url.rstrip('/')}/v1/runs?cursor={urllib.parse.quote(cursor)}"
                 else:
                     url = None

--- a/src/aios/reconcilers/work_state_cli.py
+++ b/src/aios/reconcilers/work_state_cli.py
@@ -1,0 +1,479 @@
+"""Work-state reconciler, phase 1 (OBSERVE-ONLY): the I/O shell around the pure core.
+
+Reads GitHub (open items carrying pipeline state labels) and the aios API (runs of
+the pipeline workflows), hands both to :func:`aios.reconcilers.work_state.build_report`,
+and prints the result. Every read is wrapped so a failure becomes a
+:class:`~aios.reconcilers.work_state.SourceFailed` — which forces the report to
+ALARM — and NEVER an empty list.
+
+**This module makes no write of any kind against a reconciled issue or PR.** The
+only HTTP verb it issues is ``GET``; :func:`_get` refuses anything else at the
+transport level (:class:`ObserveOnlyViolation`), so a future edit that tries to
+"just also fix the label" fails loudly instead of shipping. Phase 2 (demotion) is
+gated on reviewing a week of phase-1 data, per the design of record.
+
+Usage::
+
+    GITHUB_TOKEN=... AIOS_URL=... AIOS_API_KEY=... \\
+      python -m aios.reconcilers.work_state_cli --format markdown
+
+Exit codes — chosen so a broken cron cannot look healthy:
+
+* ``0`` — read OK (disagreements may exist; they are DATA, not an error).
+* ``2`` — ALARM: a source could not be read. Never exits 0 on a failed read.
+* ``3`` — read OK and ``--fail-on-disagreement`` was passed and some exist.
+
+Credentials come from the ENVIRONMENT only, never argv (an argv-borne secret leaks
+via ``ps`` / ``/proc/<pid>/cmdline``) — the rule ``scripts/reconcile_agents.py``
+already follows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+from aios.reconcilers.work_state import (
+    ReconcileReport,
+    RunRecord,
+    SourceFailed,
+    SourceOk,
+    SourceRead,
+    WorkItem,
+    build_report,
+    is_pipeline_state_label,
+    render_json,
+    render_markdown,
+    run_record_from_payload,
+)
+
+#: The repos whose pipeline labels are in scope (#2043).
+DEFAULT_REPOS: tuple[str, ...] = (
+    "eumemic/aios",
+    "eumemic/eumemic-ops",
+    "eumemic/eumemic-company",
+    "eumemic/aios-console",
+    "eumemic/autodev",
+)
+
+#: The durable dev pipeline: one run per issue, ``run.input`` = ``{repo, issue_number}``.
+DEV_PIPELINE_WORKFLOW_ID = "wf_01KV4YGV4PSGP08TJBAY32J2VK"
+
+_GITHUB_API = "https://api.github.com"
+_REQUEST_TIMEOUT_S = 30
+#: Hard page ceilings. Hitting one is NOT silently ignored: the source is marked
+#: non-exhaustive and every derived count renders as "at least N".
+_MAX_ISSUE_PAGES = 50
+_MAX_RUN_PAGES = 200
+_PER_PAGE = 100
+
+
+class ObserveOnlyViolation(RuntimeError):
+    """A non-GET was attempted. Phase 1 writes NOTHING; this is the enforcement."""
+
+
+class ReadFailure(RuntimeError):
+    """A source read failed. Always becomes a ``SourceFailed`` — never an empty list."""
+
+
+# ─── HTTP (GET-only, by construction) ────────────────────────────────────────
+
+
+def _get(
+    url: str, headers: Mapping[str, str], *, method: str = "GET"
+) -> tuple[Any, Mapping[str, str]]:
+    """Issue one **GET**. Any other verb raises :class:`ObserveOnlyViolation`.
+
+    Phase 1's hard constraint ("zero mutations of the reconciled issues/PRs") is
+    enforced HERE, at the only door to the network, rather than by reviewer
+    vigilance over call sites. A PATCH/POST cannot be smuggled through this module.
+    """
+    if method != "GET":
+        raise ObserveOnlyViolation(
+            f"phase-1 reconciler is OBSERVE-ONLY: refusing {method} {url}. "
+            "Mutating a reconciled item is a failed build, not a feature."
+        )
+    req = urllib.request.Request(url, method="GET")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
+            raw = resp.read().decode()
+            body = json.loads(raw) if raw else None
+            return body, dict(resp.headers)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:400]
+        raise ReadFailure(f"GET {url} → HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise ReadFailure(f"GET {url} failed: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        # A 200 with an unparseable body is a FAILED read, not an empty one.
+        raise ReadFailure(f"GET {url} returned unparseable JSON: {exc}") from exc
+    except TimeoutError as exc:
+        raise ReadFailure(f"GET {url} timed out after {_REQUEST_TIMEOUT_S}s") from exc
+
+
+def _next_link(headers: Mapping[str, str]) -> str | None:
+    """Parse GitHub's ``Link: <...>; rel="next"`` header (the exhaustion driver)."""
+    link = headers.get("Link") or headers.get("link")
+    if not link:
+        return None
+    for part in link.split(","):
+        segments = part.split(";")
+        if len(segments) < 2:
+            continue
+        if 'rel="next"' in "".join(segments[1:]):
+            return segments[0].strip().strip("<>")
+    return None
+
+
+# ─── GitHub: open items carrying pipeline state labels ───────────────────────
+
+
+def _item_from_payload(
+    repo: str, payload: Mapping[str, Any], linked: tuple[int, ...] = ()
+) -> WorkItem:
+    raw_labels = payload.get("labels")
+    labels = tuple(
+        sorted(
+            str(x["name"]) if isinstance(x, Mapping) else str(x)
+            for x in (raw_labels if isinstance(raw_labels, list) else [])
+        )
+    )
+    return WorkItem(
+        repo=repo,
+        number=int(payload["number"]),
+        kind="pull_request" if "pull_request" in payload else "issue",
+        title=str(payload.get("title", "")),
+        labels=labels,
+        html_url=str(payload.get("html_url", "")),
+        updated_at=str(payload.get("updated_at", "")),
+        created_at=str(payload.get("created_at", "")),
+        linked_pr_numbers=linked,
+    )
+
+
+def fetch_repo_items(
+    repo: str,
+    *,
+    token: str,
+    getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
+    max_pages: int = _MAX_ISSUE_PAGES,
+) -> tuple[list[WorkItem], bool]:
+    """Every OPEN issue/PR in ``repo`` carrying at least one pipeline state label.
+
+    Enumerates all open items and filters locally rather than asking GitHub for
+    ``?labels=dispatched``: the LAGGING class is defined by the ABSENCE of
+    ``dispatched``, so a query narrowed to that label is structurally incapable of
+    finding it. (This is the same shape as the stall detectors that could not see
+    the zombies because they filtered on the very label that was lying.)
+
+    Returns ``(items, exhaustive)``. Raises :class:`ReadFailure` on any read error —
+    the caller turns that into a ``SourceFailed``. Never returns a short list quietly.
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "aios-work-state-reconciler",
+    }
+    url: str | None = (
+        f"{_GITHUB_API}/repos/{repo}/issues?state=open&per_page={_PER_PAGE}&sort=created&direction=desc"
+    )
+    items: list[WorkItem] = []
+    pages = 0
+    while url is not None:
+        if pages >= max_pages:
+            return items, False  # cap hit — caller must render "at least N"
+        body, resp_headers = getter(url, headers)
+        if not isinstance(body, list):
+            raise ReadFailure(f"GET {url} did not return a JSON array (got {type(body).__name__})")
+        pages += 1
+        for payload in body:
+            if not isinstance(payload, Mapping):
+                raise ReadFailure(f"GET {url} returned a non-object row")
+            item = _item_from_payload(repo, payload)
+            if any(is_pipeline_state_label(x) for x in item.labels):
+                items.append(item)
+        url = _next_link(resp_headers)
+    return items, True
+
+
+def fetch_linked_prs(
+    repo: str,
+    number: int,
+    *,
+    token: str,
+    getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
+) -> tuple[int, ...]:
+    """PRs cross-referencing an issue, from its timeline (READ-ONLY).
+
+    Used only to qualify a ZOMBIE verdict: "no run ever" + "a PR exists" means the
+    join key is suspect, and the report says so instead of asserting a zombie.
+    eumemic-company#71 is the live instance of this shape.
+    """
+    url = f"{_GITHUB_API}/repos/{repo}/issues/{number}/timeline?per_page={_PER_PAGE}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "aios-work-state-reconciler",
+    }
+    found: set[int] = set()
+    next_url: str | None = url
+    while next_url is not None:
+        body, resp_headers = getter(next_url, headers)
+        if not isinstance(body, list):
+            raise ReadFailure(f"GET {next_url} did not return a JSON array")
+        for event in body:
+            if not isinstance(event, Mapping):
+                continue
+            if event.get("event") != "cross-referenced":
+                continue
+            source = event.get("source")
+            issue = source.get("issue") if isinstance(source, Mapping) else None
+            if isinstance(issue, Mapping) and "pull_request" in issue:
+                num = issue.get("number")
+                if isinstance(num, int):
+                    found.add(num)
+        next_url = _next_link(resp_headers)
+    return tuple(sorted(found))
+
+
+def read_github_items(
+    repos: Sequence[str],
+    *,
+    token: str,
+    getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
+    enrich_linked_prs: bool = True,
+) -> SourceRead:
+    """Read every repo. **One repo failing fails the whole source.**
+
+    A partial read is a LIE with the shape of a health report: the repo that could
+    not be read is exactly where the disagreements might be. So there is no
+    per-repo ``continue`` here — the first failure aborts into ``SourceFailed`` and
+    the report ALARMs.
+    """
+    all_items: list[WorkItem] = []
+    exhaustive = True
+    try:
+        for repo in repos:
+            items, repo_exhaustive = fetch_repo_items(repo, token=token, getter=getter)
+            exhaustive = exhaustive and repo_exhaustive
+            all_items.extend(items)
+    except ReadFailure as exc:
+        return SourceFailed(name="github", reason=str(exc))
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        # Never a bare except, and never a swallow: any unexpected read-path error
+        # is still reported as a FAILED read rather than crashing into a traceback
+        # a cron would report as "no output, probably fine".
+        return SourceFailed(
+            name="github", reason=f"unexpected read error: {type(exc).__name__}: {exc}"
+        )
+
+    if enrich_linked_prs:
+        try:
+            enriched: list[WorkItem] = []
+            for item in all_items:
+                if item.is_dispatched and item.kind == "issue":
+                    linked = fetch_linked_prs(item.repo, item.number, token=token, getter=getter)
+                    enriched.append(
+                        WorkItem(
+                            repo=item.repo,
+                            number=item.number,
+                            kind=item.kind,
+                            title=item.title,
+                            labels=item.labels,
+                            html_url=item.html_url,
+                            updated_at=item.updated_at,
+                            created_at=item.created_at,
+                            linked_pr_numbers=linked,
+                        )
+                    )
+                else:
+                    enriched.append(item)
+            all_items = enriched
+        except ReadFailure as exc:
+            return SourceFailed(name="github-timeline", reason=str(exc))
+
+    return SourceOk(name="github", items=tuple(all_items), exhaustive=exhaustive)
+
+
+# ─── aios: runs of the pipeline workflows ────────────────────────────────────
+
+
+def read_aios_runs(
+    *,
+    base_url: str,
+    api_key: str,
+    workflow_ids: Sequence[str] = (DEV_PIPELINE_WORKFLOW_ID,),
+    getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
+    max_pages: int = _MAX_RUN_PAGES,
+) -> SourceRead:
+    """Every run of the pipeline workflow(s), keyed ``(repo, issue_number)`` from ``run.input``.
+
+    Pagination follows ``next_cursor`` to exhaustion; hitting the page cap marks the
+    source non-exhaustive so counts render as floors instead of being quietly wrong.
+
+    NOTE on the ZOMBIE class: "no run, ever" is only sound if this read reaches the
+    WHOLE history, which is why terminal runs are enumerated too and why a truncated
+    read can never be presented as a total.
+    """
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "User-Agent": "aios-work-state-reconciler",
+    }
+    records: list[RunRecord] = []
+    exhaustive = True
+    try:
+        for workflow_id in workflow_ids:
+            url: str | None = (
+                f"{base_url.rstrip('/')}/v1/runs?workflow_id={urllib.parse.quote(workflow_id)}"
+                f"&limit={_PER_PAGE}"
+            )
+            pages = 0
+            while url is not None:
+                if pages >= max_pages:
+                    exhaustive = False
+                    break
+                body, _ = getter(url, headers)
+                if not isinstance(body, Mapping):
+                    raise ReadFailure(f"GET {url} did not return the ListResponse envelope")
+                rows = body.get("data")
+                if not isinstance(rows, list):
+                    # The envelope's rows live under 'data'; a missing key is a
+                    # CONTRACT failure, not an empty page.
+                    raise ReadFailure(f"GET {url} response has no list 'data' key")
+                pages += 1
+                for row in rows:
+                    if not isinstance(row, Mapping):
+                        raise ReadFailure(f"GET {url} returned a non-object run row")
+                    records.append(run_record_from_payload(row))
+                cursor = body.get("next_cursor")
+                has_more = body.get("has_more")
+                if has_more and isinstance(cursor, str) and cursor:
+                    url = f"{base_url.rstrip('/')}/v1/runs?cursor={urllib.parse.quote(cursor)}"
+                else:
+                    url = None
+    except ReadFailure as exc:
+        return SourceFailed(name="aios-runs", reason=str(exc))
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        return SourceFailed(
+            name="aios-runs", reason=f"unexpected read error: {type(exc).__name__}: {exc}"
+        )
+
+    return SourceOk(name="aios-runs", items=tuple(records), exhaustive=exhaustive)
+
+
+# ─── orchestration ───────────────────────────────────────────────────────────
+
+
+def reconcile(
+    *,
+    repos: Sequence[str],
+    github_token: str | None,
+    aios_url: str | None,
+    aios_api_key: str | None,
+    workflow_ids: Sequence[str] = (DEV_PIPELINE_WORKFLOW_ID,),
+    getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
+    now: str | None = None,
+    enrich_linked_prs: bool = True,
+) -> ReconcileReport:
+    """Read both sources and build the report. Missing credentials ⇒ ALARM.
+
+    A missing token is a READ FAILURE, not a reason to skip a source: the sandbox
+    sweep that "returned zero held PRs" on 2026-07-25 did so because its credential
+    was rejected and the empty result read as health. That path does not exist here.
+    """
+    generated_at = now or datetime.now(UTC).isoformat()
+    items_read: SourceRead
+    if not github_token:
+        items_read = SourceFailed(
+            name="github",
+            reason="GITHUB_TOKEN is unset — cannot read GitHub (NOT 'no disagreements')",
+        )
+    else:
+        items_read = read_github_items(
+            repos, token=github_token, getter=getter, enrich_linked_prs=enrich_linked_prs
+        )
+
+    runs_read: SourceRead
+    if not aios_url or not aios_api_key:
+        runs_read = SourceFailed(
+            name="aios-runs",
+            reason="AIOS_URL / AIOS_API_KEY unset — cannot read run state (NOT 'no disagreements')",
+        )
+    else:
+        runs_read = read_aios_runs(
+            base_url=aios_url, api_key=aios_api_key, workflow_ids=workflow_ids, getter=getter
+        )
+
+    return build_report(
+        items_read=items_read,
+        runs_read=runs_read,
+        generated_at=generated_at,
+        repos_scanned=repos,
+        meta={"workflow_ids": list(workflow_ids), "phase": "1-observe-only", "writes_performed": 0},
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="work-state-reconciler",
+        description=(
+            "Phase-1 OBSERVE-ONLY work-state reconciler: joins GitHub pipeline labels "
+            "against live aios run state and reports the disagreements. Writes nothing."
+        ),
+    )
+    parser.add_argument(
+        "--repo", action="append", dest="repos", help="repeatable; defaults to the org set"
+    )
+    parser.add_argument("--workflow-id", action="append", dest="workflow_ids")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    parser.add_argument(
+        "--fail-on-disagreement",
+        action="store_true",
+        help="exit 3 when disagreements exist (distinct from exit 2 = ALARM/read failed)",
+    )
+    parser.add_argument(
+        "--no-linked-prs",
+        action="store_true",
+        help="skip the per-issue timeline read used to qualify ZOMBIE verdicts",
+    )
+    args = parser.parse_args(argv)
+
+    report = reconcile(
+        repos=tuple(args.repos or DEFAULT_REPOS),
+        github_token=os.environ.get("GITHUB_TOKEN"),
+        aios_url=os.environ.get("AIOS_URL"),
+        aios_api_key=os.environ.get("AIOS_API_KEY"),
+        workflow_ids=tuple(args.workflow_ids or (DEV_PIPELINE_WORKFLOW_ID,)),
+        enrich_linked_prs=not args.no_linked_prs,
+    )
+
+    out = render_json(report) if args.format == "json" else render_markdown(report)
+    print(out)
+
+    if report.alarmed:
+        print(
+            "\nFATAL: work-state reconciler could not read its sources — this is an ALARM, "
+            "not a clean run.",
+            file=sys.stderr,
+        )
+        return 2
+    if args.fail_on_disagreement and report.disagreements:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin entry point
+    raise SystemExit(main())

--- a/src/aios/reconcilers/work_state_cli.py
+++ b/src/aios/reconcilers/work_state_cli.py
@@ -642,9 +642,12 @@ def reconcile(
                 items, runs, token=github_token, getter=getter
             )
         except (OSError, ValueError, KeyError, TypeError) as exc:
-            transfers, probe_notes = (), (
-                f"C4 stale-key probe failed: {type(exc).__name__}: {exc} — a transferred "
-                "issue among the stale join keys would be unreported",
+            transfers, probe_notes = (
+                (),
+                (
+                    f"C4 stale-key probe failed: {type(exc).__name__}: {exc} — a transferred "
+                    "issue among the stale join keys would be unreported",
+                ),
             )
         if probe_notes:
             items_read = SourceOk(

--- a/src/aios/reconcilers/work_state_cli.py
+++ b/src/aios/reconcilers/work_state_cli.py
@@ -47,12 +47,15 @@ from aios.reconcilers.work_state import (
     SourceFailed,
     SourceOk,
     SourceRead,
+    TransferEvidence,
     WorkItem,
     build_report,
     is_pipeline_state_label,
+    parse_issue_ref,
     render_json,
     render_markdown,
     run_record_from_payload,
+    stale_run_keys,
 )
 
 #: The repos whose pipeline labels are in scope (#2043).
@@ -77,6 +80,10 @@ _REQUEST_TIMEOUT_S = 30
 _MAX_ISSUE_PAGES = 50
 _MAX_RUN_PAGES = 200
 _PER_PAGE = 100
+#: Ceiling on the C4 stale-key probes issued per reconcile. Hitting it is NOT
+#: silently ignored: an explicit note says how many keys went UNPROBED, so a
+#: transfer that we did not look for is visible as a gap rather than as a zombie.
+_MAX_TRANSFER_PROBES = 400
 
 
 class ObserveOnlyViolation(RuntimeError):
@@ -383,6 +390,113 @@ def read_github_items(
     )
 
 
+# ─── C4: the INVERTED stale-join-key probe ───────────────────────────────────
+
+
+def probe_transfer(
+    repo: str,
+    number: int,
+    *,
+    token: str,
+    getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
+) -> tuple[str, str | None]:
+    """GET the STALE coordinates directly. Returns ``(destination, unparseable_reason)``.
+
+    ``destination`` is ``""`` when the coordinates still resolve to themselves (no
+    transfer). GET-only, like every other read here.
+
+    Why this direction. A transfer is invisible from the new coordinates (they answer
+    200 as themselves) and invisible from enumeration (which only ever returns the new
+    pair). It is visible from exactly one place — the OLD pair, which survives only in
+    ``run.input``. The first cut of C4 probed an ENUMERATED issue and waited for a
+    redirect, a world production cannot present, so every one of the 68 issues that
+    moved repos on 2026-07-25 still became a FALSE ZOMBIE. Hence: ask about the stale
+    coordinates.
+
+    Two forms of authoritative evidence, because urllib follows the 301 silently:
+
+    * the transport reports a FINAL URL different from the one we asked for; or
+    * the body answers with different coordinates than the ones requested
+      (``url``/``html_url``/``repository_url`` + ``number``) — which is what a
+      followed redirect looks like once the hop itself is invisible.
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "aios-work-state-reconciler",
+    }
+    url = f"{_GITHUB_API}/repos/{repo}/issues/{number}"
+    body, resp_headers = getter(url, headers)
+    final = resp_headers.get(_FINAL_URL_HEADER)
+    if final and parse_issue_ref(final) not in (None, (repo, number)):
+        return str(final), None
+    if isinstance(body, Mapping):
+        for field in ("url", "html_url"):
+            ref = parse_issue_ref(body.get(field))
+            if ref is not None and ref != (repo, number):
+                return str(body[field]), None
+    if final and final != url:
+        # A hop we cannot name is still a hop; report it verbatim rather than guess.
+        return str(final), None
+    return "", None
+
+
+def probe_stale_keys(
+    items: Sequence[WorkItem],
+    runs: Sequence[RunRecord],
+    *,
+    token: str,
+    getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
+    max_probes: int = _MAX_TRANSFER_PROBES,
+) -> tuple[tuple[TransferEvidence, ...], tuple[str, ...]]:
+    """Probe every run join key that matched NO enumerated item (C4). GET-only.
+
+    Returns ``(evidence, notes)``. A key that still resolves to itself yields nothing
+    — most stale keys are simply runs against CLOSED issues, which is normal.
+
+    A 404/410 is NOT a failure here and must not ALARM the whole reconcile: a run
+    against a deleted or invisible issue is an expected shape of history, and the run
+    is already reported as unmatched. Only the transfer signal is extracted.
+    """
+    stale = stale_run_keys(items, runs)
+    notes: list[str] = []
+    evidence: list[TransferEvidence] = []
+    keys = list(stale.items())
+    if len(keys) > max_probes:
+        notes.append(
+            f"C4 stale-key probe capped at {max_probes} of {len(keys)} stale join key(s) — "
+            f"{len(keys) - max_probes} were NOT probed, so a transfer among them would be "
+            "unreported. Counts involving ZOMBIE are therefore floors for those items."
+        )
+        keys = keys[:max_probes]
+    for (repo, number), run_ids in keys:
+        try:
+            destination, _ = probe_transfer(repo, number, token=token, getter=getter)
+        except ReadFailure as exc:
+            # 404/410/403 on a stale coordinate is history, not a broken source.
+            notes.append(
+                f"C4 stale-key probe could not read {repo}#{number} ({exc}) — a transfer "
+                "there would be unreported; the run(s) holding this key remain listed as "
+                f"unmatched ({', '.join(run_ids)})"
+            )
+            continue
+        if not destination:
+            continue
+        ref = parse_issue_ref(destination)
+        evidence.append(
+            TransferEvidence(
+                stale_repo=repo,
+                stale_number=number,
+                destination=destination,
+                new_repo=None if ref is None else ref[0],
+                new_number=None if ref is None else ref[1],
+                run_ids=run_ids,
+            )
+        )
+    return tuple(evidence), tuple(notes)
+
+
 # ─── aios: runs of the pipeline workflows ────────────────────────────────────
 
 
@@ -478,6 +592,7 @@ def reconcile(
     getter: Callable[[str, Mapping[str, str]], tuple[Any, Mapping[str, str]]] = _get,
     now: str | None = None,
     enrich_linked_prs: bool = True,
+    probe_transfers: bool = True,
 ) -> ReconcileReport:
     """Read both sources and build the report. Missing credentials ⇒ ALARM.
 
@@ -508,12 +623,45 @@ def reconcile(
             base_url=aios_url, api_key=aios_api_key, workflow_ids=workflow_ids, getter=getter
         )
 
+    # C4 — the INVERTED probe. It needs BOTH sources (the join keys that matched no
+    # enumerated item are only knowable once both are read), so it runs here rather
+    # than inside either reader. Skipped when either read failed: the report already
+    # ALARMs, and probing coordinates derived from a partial read would attach
+    # confident transfer evidence to an unreliable join.
+    transfers: tuple[TransferEvidence, ...] = ()
+    if (
+        probe_transfers
+        and github_token
+        and isinstance(items_read, SourceOk)
+        and isinstance(runs_read, SourceOk)
+    ):
+        items = tuple(i for i in items_read.items if isinstance(i, WorkItem))
+        runs = tuple(r for r in runs_read.items if isinstance(r, RunRecord))
+        try:
+            transfers, probe_notes = probe_stale_keys(
+                items, runs, token=github_token, getter=getter
+            )
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            transfers, probe_notes = (), (
+                f"C4 stale-key probe failed: {type(exc).__name__}: {exc} — a transferred "
+                "issue among the stale join keys would be unreported",
+            )
+        if probe_notes:
+            items_read = SourceOk(
+                name=items_read.name,
+                items=items_read.items,
+                exhaustive=items_read.exhaustive,
+                pages_read=items_read.pages_read,
+                notes=items_read.notes + probe_notes,
+            )
+
     return build_report(
         items_read=items_read,
         runs_read=runs_read,
         generated_at=generated_at,
         repos_scanned=repos,
         meta={"workflow_ids": list(workflow_ids), "phase": "1-observe-only", "writes_performed": 0},
+        transfers=transfers,
     )
 
 
@@ -540,6 +688,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="skip the per-issue timeline read used to qualify ZOMBIE verdicts",
     )
+    parser.add_argument(
+        "--no-transfer-probe",
+        action="store_true",
+        help=(
+            "skip the C4 stale-join-key probe (GET of the coordinates no enumerated item "
+            "matched); a transferred issue then reads as a ZOMBIE"
+        ),
+    )
     args = parser.parse_args(argv)
 
     report = reconcile(
@@ -549,6 +705,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         aios_api_key=os.environ.get("AIOS_API_KEY"),
         workflow_ids=tuple(args.workflow_ids or (DEV_PIPELINE_WORKFLOW_ID,)),
         enrich_linked_prs=not args.no_linked_prs,
+        probe_transfers=not args.no_transfer_probe,
     )
 
     out = render_json(report) if args.format == "json" else render_markdown(report)

--- a/tests/unit/test_work_state_reconciler.py
+++ b/tests/unit/test_work_state_reconciler.py
@@ -107,7 +107,11 @@ def test_zombie_dispatched_with_no_run_ever() -> None:
     (d,) = report.disagreements
     assert d.classification == "ZOMBIE"
     assert d.run_ids == ()
-    assert "NO run exists" in d.detail
+    # B3: the wording must say UNARCHIVED — `list_runs` cannot see archived runs, so
+    # ZOMBIE cannot distinguish "never picked up" from "ran and was tidied away".
+    assert "NO unarchived run exists" in d.detail
+    assert "zombie-means-no-unarchived-run" in d.caveats
+    assert d.trigger_labels == ("dispatched",)
 
 
 def test_dead_dispatched_but_run_terminal() -> None:
@@ -411,8 +415,11 @@ def test_next_link_parsing() -> None:
     assert _next_link({"Link": '<https://x>; rel="last"'}) is None
 
 
-def test_items_without_pipeline_labels_are_filtered_but_all_open_items_are_enumerated() -> None:
-    """LAGGING is defined by the ABSENCE of `dispatched`, so we must not query by it."""
+def test_unlabelled_open_items_are_KEPT_so_lagging_is_detectable() -> None:
+    """C5. LAGGING is defined by the ABSENCE of an in-flight assertion, so enumeration
+    can neither query by label NOR drop items that carry none. Dropping them made a
+    live run against an unlabelled issue structurally impossible to classify LAGGING —
+    it was demoted to an ``unmatched_run`` stamped "not open", which is simply false."""
     seen: list[str] = []
 
     def getter(url: str, headers: Any) -> Any:
@@ -435,8 +442,19 @@ def test_items_without_pipeline_labels_are_filtered_but_all_open_items_are_enume
         ], {}
 
     items, _ = fetch_repo_items("eumemic/aios", token="t", getter=getter)
-    assert [i.number for i in items] == [2]
+    assert [i.number for i in items] == [1, 2]
     assert all("labels=" not in url for url in seen)
+    # And the payoff: a live run against the UNLABELLED issue #1 is now LAGGING.
+    report = ok_report(list(items), [run("running", number=1)])
+    (lagging,) = report.by_class("LAGGING")
+    assert lagging.number == 1
+    assert lagging.trigger_labels == ()  # its trigger is the ABSENCE of an assertion
+
+    # Opting out still works for callers that only want labelled items.
+    only_labelled, _ = fetch_repo_items(
+        "eumemic/aios", token="t", getter=getter, keep_unlabelled=False
+    )
+    assert [i.number for i in only_labelled] == [2]
 
 
 # ─── (6) change detection ────────────────────────────────────────────────────
@@ -474,13 +492,44 @@ def test_alarm_hash_is_driven_by_failure_reasons_so_a_new_outage_wakes_the_seat(
 # ─── (7) the eumemic-company#71 shape: a ZOMBIE with linked PRs ──────────────
 
 
-def test_zombie_with_linked_prs_is_flagged_as_suspect_join_key() -> None:
-    """'No run ever' + 'a PR exists' cannot both be true of healthy work."""
-    (d,) = ok_report([item(71, repo="eumemic/eumemic-company", linked=(72, 73))], []).disagreements
-    assert d.classification == "ZOMBIE"
+def test_linked_prs_make_it_AMBIGUOUS_and_EXCLUDED_from_the_zombie_count() -> None:
+    """C2. 'No run ever' + 'a PR exists' cannot both be true of healthy work, so these
+    are NOT zombies. The first cut attached a caveat and returned ZOMBIE anyway, which
+    inflated the headline ~36% (5 of 14) and — the part that matters — left phase 2
+    acting on the CLASS while the disclaimer sat in a footnote. A caveat does not undo
+    a count."""
+    report = ok_report([item(71, repo="eumemic/eumemic-company", linked=(72, 73))], [])
+    (d,) = report.disagreements
+    assert d.classification == "AMBIGUOUS"
     assert "has-linked-prs" in d.caveats
-    assert "#72" in d.detail and "verify the join key" in d.detail
-    assert "⚠️" in render_markdown(ok_report([item(71, linked=(72,))], []))
+    assert "excluded-from-zombie-count" in d.caveats
+    assert "#72" in d.detail and "NOT counted as a ZOMBIE" in d.detail
+    counts = report.counts
+    assert counts is not None
+    assert counts["ZOMBIE"] == 0
+    assert counts["AMBIGUOUS"] == 1
+    md = render_markdown(report)
+    assert "⚠️" in md
+    assert "AMBIGUOUS (1)" in md
+    assert "ZOMBIE (" not in md  # empty classes are not rendered at all
+
+
+def test_the_five_known_good_items_are_not_counted_as_zombies() -> None:
+    """The exact five the reviewer named, with their real linked PRs."""
+    known_good = {
+        ("eumemic/eumemic-company", 71): (67, 68, 69, 100, 101),
+        ("eumemic/eumemic-company", 50): (96, 204, 206),
+        ("eumemic/eumemic-company", 135): (212,),
+        ("eumemic/eumemic-ops", 337): (1977, 1979, 2016),
+        ("eumemic/eumemic-ops", 331): (1995, 2041),
+    }
+    items = [item(n, repo=r, linked=prs) for (r, n), prs in known_good.items()]
+    report = ok_report(items, [])
+    counts = report.counts
+    assert counts is not None
+    assert counts["ZOMBIE"] == 0, "known-good items must never inflate the ZOMBIE count"
+    assert counts["AMBIGUOUS"] == 5
+    assert {(d.repo, d.number) for d in report.by_class("AMBIGUOUS")} == set(known_good)
 
 
 # ─── (8) OBSERVE-ONLY: the phase-1 hard constraint ──────────────────────────
@@ -566,6 +615,15 @@ _SCENARIOS: list[tuple[str, tuple[str, ...], list[str]]] = [
     ("", ("dispatched",), ["running"]),
     ("", ("dispatched",), ["errored", "running"]),
     ("", ("approved",), ["completed"]),
+    # FIX ROUND — the mirror must agree on every NEW rule too, or the two forms drift.
+    ("ZOMBIE", ("autodev:in-progress",), []),  # C1
+    ("ZOMBIE", ("needs:human/build",), []),  # C1
+    ("ZOMBIE", ("approved", "autodev:in-progress", "needs:human/build"), []),  # the nine
+    ("", ("autodev:built",), []),  # C1: done is not in-flight
+    ("MISLABELLED", ("dispatched",), ["errored", "quiesced"]),  # C3
+    ("MISLABELLED", ("dispatched",), ["suspended", "quiesced"]),  # C3
+    ("", ("dispatched",), ["quiesced", "running"]),  # C3: live still wins
+    ("LAGGING", (), ["running"]),  # C5: no labels at all
 ]
 
 
@@ -591,6 +649,33 @@ def test_workflow_script_mirror_classifies_identically(
     )
     assert (lib_verdict.classification if lib_verdict else "") == expected
     assert (wf_verdict["classification"] if wf_verdict else "") == expected
+    # The trigger set is part of the contract now, so it must not drift either.
+    assert list(lib_verdict.trigger_labels if lib_verdict else []) == (
+        wf_verdict["trigger_labels"] if wf_verdict else []
+    )
+
+
+def test_workflow_script_mirror_agrees_on_AMBIGUOUS() -> None:
+    """C2 in both forms: linked PRs mean NOT a zombie, in the library and the mirror."""
+    wf = _load_wf_module()
+    lib = classify_item(item(71, repo="eumemic/eumemic-company", linked=(67, 68)), [])
+    wf_verdict = wf.classify(
+        {
+            "repo": "eumemic/eumemic-company",
+            "number": 71,
+            "kind": "issue",
+            "title": "item 71",
+            "labels": ["dispatched"],
+            "url": "",
+            "updated_at": "",
+            "linked_pr_numbers": [67, 68],
+        },
+        [],
+    )
+    assert lib is not None
+    assert lib.classification == "AMBIGUOUS"
+    assert wf_verdict["classification"] == "AMBIGUOUS"
+    assert "excluded-from-zombie-count" in wf_verdict["caveats"]
 
 
 def test_workflow_script_alarms_with_null_counts_on_failure() -> None:
@@ -680,15 +765,20 @@ def test_end_to_end_on_the_known_2043_zombie_set() -> None:
     report = ok_report(items, [run("running", repo="eumemic/aios", number=1)])
     counts = report.counts
     assert counts is not None
-    assert counts["ZOMBIE"] == 14
-    assert {(d.repo, d.number) for d in report.by_class("ZOMBIE")} == set(known)
+    # 13, not 14: #71 has a linked PR, so it is AMBIGUOUS (C2) and must NOT inflate
+    # the headline. The set of FINDINGS is still all 14 — nothing is dropped.
+    assert counts["ZOMBIE"] == 13
+    assert counts["AMBIGUOUS"] == 1
+    assert {(d.repo, d.number) for d in report.disagreements} == set(known)
     # #71 is the designed-in check on the join logic, not a silent pass.
     (suspect,) = [d for d in report.disagreements if d.number == 71]
-    assert suspect.caveats == ("has-linked-prs",)
+    assert suspect.classification == "AMBIGUOUS"
+    assert suspect.caveats == ("has-linked-prs", "excluded-from-zombie-count")
     payload = json.loads(render_json(report))
     assert payload["verdict"] == "OK"
-    assert payload["counts"]["ZOMBIE"] == 14
-    assert "ZOMBIE (14)" in render_markdown(report)
+    assert payload["counts"]["ZOMBIE"] == 13
+    assert "ZOMBIE (13)" in render_markdown(report)
+    assert "no UNARCHIVED run exists" in payload["zombie_means"]
 
 
 def test_disagreements_are_sorted_by_class_then_repo_then_number() -> None:
@@ -731,3 +821,280 @@ def test_disagreement_identity_excludes_run_ids() -> None:
     )
     b = a.__class__(**{**a.__dict__, "run_ids": ("r2",)})
     assert a.identity() == b.identity()
+
+
+# ─── (11) FIX ROUND for the second review ───────────────────────────────────
+#
+# Each test below names the finding it locks down. These are the regressions the
+# reviewer reproduced, so they get explicit tests rather than incidental coverage.
+
+
+# ---- C1: the headline. In-flight is a UNION of assertions, not one literal. ----
+
+#: The NINE confirmed zombies with the labels they ACTUALLY carry as of
+#: 2026-07-26T03:25, after the seat stripped `dispatched` from every one of them as
+#: remediation. If the classifier keys on `dispatched`, this set reports "0 ZOMBIE"
+#: while nine issues sit dead — the exact failure the reviewer reproduced.
+_NINE_AFTER_THE_STRIP: list[tuple[str, int]] = [
+    ("eumemic/aios", 2000),
+    ("eumemic/eumemic-ops", 337),
+    ("eumemic/eumemic-ops", 331),
+    ("eumemic/eumemic-company", 210),
+    ("eumemic/eumemic-company", 199),
+    ("eumemic/eumemic-company", 192),
+    ("eumemic/eumemic-company", 166),
+    ("eumemic/eumemic-company", 151),
+    ("eumemic/eumemic-company", 147),
+]
+_LABELS_AFTER_THE_STRIP = ("approved", "autodev:in-progress", "needs:human/build")
+
+
+def test_C1_the_nine_zombies_are_still_found_after_dispatched_was_stripped() -> None:
+    """THE headline regression. `dispatched` is gone from all nine; they still assert
+    'a machine has this' via `autodev:in-progress` + `needs:human/build`. A tool built
+    BECAUSE a label is an assertion nothing re-checks must not itself trust one label."""
+    items = [item(n, repo=r, labels=_LABELS_AFTER_THE_STRIP) for r, n in _NINE_AFTER_THE_STRIP]
+    report = ok_report(items, [])
+    counts = report.counts
+    assert counts is not None
+    assert counts["ZOMBIE"] == 9, "keying on `dispatched` alone would report 0 here"
+    assert {(d.repo, d.number) for d in report.by_class("ZOMBIE")} == set(_NINE_AFTER_THE_STRIP)
+    # And the report must say WHICH assertion lied, not just that something did.
+    for d in report.by_class("ZOMBIE"):
+        assert d.trigger_labels == ("autodev:in-progress", "needs:human/build")
+        assert "`autodev:in-progress`" in d.detail
+    assert "triggered by:" in render_markdown(report)
+
+
+@pytest.mark.parametrize(
+    ("labels", "expect_in_flight"),
+    [
+        (("dispatched",), True),
+        (("autodev:in-progress",), True),
+        (("design:in-progress",), True),
+        (("needs:human/build",), True),
+        (("needs:human/review",), True),
+        (("needs:human/anything-at-all",), True),
+        (("approved",), False),
+        (("autodev:built",), False),  # a PR exists — done, not in flight
+        (("autodev:failed",), False),
+        (("hold",), False),
+        ((), False),
+    ],
+)
+def test_C1_in_flight_vocabulary(labels: tuple[str, ...], expect_in_flight: bool) -> None:
+    assert item(1, labels=labels).claims_in_flight is expect_in_flight
+    verdict = classify_item(item(1, labels=labels), [])
+    assert (verdict is not None and verdict.classification == "ZOMBIE") is expect_in_flight
+
+
+def test_C1_a_done_label_alone_is_not_an_in_flight_claim() -> None:
+    """`autodev:built` means a PR exists. That is not a claim a machine is on it now,
+    so a built item with no live run is NOT a zombie."""
+    assert classify_item(item(1, labels=("autodev:built",)), []) is None
+
+
+# ---- C3: unknown status outranks terminal; never evidence of death. ----
+
+
+def test_C3_unknown_status_beside_a_terminal_run_is_not_DEAD() -> None:
+    """`if unknown and not (suspended or terminal)` made [unknown, errored] return DEAD,
+    contradicting the documented contract that an unrecognised status is never evidence
+    of death. The unknown run may well BE live under a status name we have not learned."""
+    d = classify_item(item(1), [run("errored", run_id="r1"), run("quiesced", run_id="r2")])
+    assert d is not None
+    assert d.classification == "MISLABELLED"
+    assert "unrecognised-run-status" in d.caveats
+    assert "quiesced" in d.detail
+    assert "terminal sibling does NOT make an unknown status dead" in d.detail
+
+
+def test_C3_unknown_status_beside_a_suspended_run_is_still_not_DEAD() -> None:
+    d = classify_item(item(1), [run("suspended", run_id="r1"), run("quiesced", run_id="r2")])
+    assert d is not None
+    assert d.classification == "MISLABELLED"
+    assert "unrecognised-run-status" in d.caveats
+
+
+def test_C3_a_live_run_still_outranks_everything() -> None:
+    assert (
+        classify_item(item(1), [run("quiesced", run_id="r1"), run("running", run_id="r2")]) is None
+    )
+
+
+# ---- B1 / B2: a truncated read must NEVER render as exhaustive. ----
+
+
+def test_B1_has_more_with_an_unusable_cursor_is_a_READ_FAILURE() -> None:
+    """The server said THERE IS MORE and gave no cursor. The old code ended pagination
+    and reported exhaustive=True — a truncated read rendered as exhaustive, which is the
+    2026-07-25 failure mode this PR exists to kill. Every ZOMBIE rests on 'no run in the
+    list I read', so an unread page manufactures false ZOMBIEs."""
+    for bad_cursor in (None, "", 0, {}):
+
+        def getter(url: str, headers: Any, _c: Any = bad_cursor) -> Any:
+            return (
+                {
+                    "data": [{"id": "r1", "status": "completed"}],
+                    "has_more": True,
+                    "next_cursor": _c,
+                },
+                {},
+            )
+
+        source = read_aios_runs(base_url="http://x", api_key="k", getter=getter)
+        assert isinstance(source, SourceFailed), f"cursor={bad_cursor!r} must FAIL the read"
+        assert "has_more" in source.reason and "unusable" in source.reason
+        # ...and it must surface as ALARM with counts None, never as a clean report.
+        report = build_report(items_read=SourceOk(name="github", items=()), runs_read=source)
+        assert report.verdict == "ALARM"
+        assert report.counts is None
+
+
+def test_B2_workflow_full_page_without_an_id_cursor_is_a_READ_FAILURE() -> None:
+    """The mirror of B1 in the workflow form: a full page whose last row carries no `id`
+    leaves no keyset cursor, so the history is truncated. Breaking the loop with
+    exhaustive=True is the same lie in a different file."""
+    wf = _load_wf_module()
+    rows = [{"id": f"r{n}", "status": "completed"} for n in range(199)]
+    rows.append({"status": "completed"})
+    assert len(rows) == 200
+    with pytest.raises(wf.ReadFailure) as excinfo:
+        wf._paginate_check(rows)
+    assert "TRUNCATED" in str(excinfo.value)
+
+
+# ---- B3: ZOMBIE means "no UNARCHIVED run", and every report says so. ----
+
+
+def test_B3_every_report_states_what_zombie_can_actually_prove() -> None:
+    """`list_runs` filters archived_at IS NULL and archiving requires a TERMINAL run, so
+    a completed-then-archived run reads as 'no run, ever'. The class cannot distinguish
+    'never picked up' from 'tidied away', so it must not imply the former."""
+    report = ok_report([item(2000)], [])
+    payload = json.loads(render_json(report))
+    assert "no UNARCHIVED run exists" in payload["zombie_means"]
+    assert "archived" in payload["zombie_means"]
+    md = render_markdown(report)
+    assert "What ZOMBIE can prove" in md
+    assert "no UNARCHIVED run exists" in md
+    # The per-finding text must not overclaim either.
+    (d,) = report.disagreements
+    assert "NO unarchived run exists" in d.detail
+    assert "zombie-means-no-unarchived-run" in d.caveats
+
+
+def test_B3_workflow_form_states_it_too() -> None:
+    wf = _load_wf_module()
+    report = wf.build([], True, [], True, [])
+    assert "no UNARCHIVED run exists" in report["zombie_means"]
+
+
+# ---- B4: unkeyable runs are NEVER skipped — the PR body's claim, made true. ----
+
+
+def test_B4_terminal_runs_with_an_unreadable_join_key_are_reported() -> None:
+    """Only live/suspended unkeyable runs reached unmatched_runs, so an `errored` run
+    with an unparseable input vanished — and its issue was then classified ZOMBIE with no
+    trace of the run that existed. A manufactured false ZOMBIE, silently."""
+    for status in ("completed", "errored", "cancelled"):
+        report = ok_report([item(2000)], [run(status, repo=None, number=None, run_id="r_lost")])
+        assert [u.run_id for u in report.unmatched_runs] == ["r_lost"], status
+        (u,) = report.unmatched_runs
+        assert "FALSE ZOMBIE" in u.reason
+        assert status in u.reason
+        assert "Unmatched runs" in render_markdown(report)
+
+
+def test_B4_workflow_form_reports_terminal_unkeyable_runs_too() -> None:
+    wf = _load_wf_module()
+    report = wf.build([], True, [{"id": "r_lost", "status": "errored", "input": {}}], True, [])
+    assert [u["run_id"] for u in report["unmatched_runs"]] == ["r_lost"]
+    assert "FALSE ZOMBIE" in report["unmatched_runs"][0]["reason"]
+
+
+# ---- malformed rows ALARM instead of killing the workflow (first review) ----
+
+
+def test_malformed_issue_row_is_a_read_failure_not_an_AttributeError() -> None:
+    """A 2xx carrying a non-object row reached row.get() and raised AttributeError
+    OUTSIDE the ReadFailure handlers, killing the workflow instead of returning
+    verdict:ALARM. A malformed row is a FAILED READ."""
+    wf = _load_wf_module()
+    for bad in ("a string", 42, None, ["nested"]):
+        with pytest.raises(wf.ReadFailure):
+            wf._check_issue_row("eumemic/aios", bad)
+
+
+def test_malformed_labels_field_is_a_read_failure() -> None:
+    wf = _load_wf_module()
+    with pytest.raises(wf.ReadFailure):
+        wf._check_issue_row("eumemic/aios", {"number": 1, "labels": "dispatched"})
+
+
+def test_malformed_run_row_is_a_read_failure() -> None:
+    wf = _load_wf_module()
+    for bad in ("a string", 42, None):
+        with pytest.raises(wf.ReadFailure):
+            wf._check_run_row(bad)
+
+
+# ---- C4: a transferred issue is DETECTED, not silently turned into a zombie. ----
+
+
+def test_C4_a_redirect_on_the_issue_read_is_surfaced_as_a_transfer() -> None:
+    """68 issues were transferred between repos on 2026-07-25. A transfer gives the issue
+    a NEW (repo, number) while every run.input still holds the OLD one, so the join key
+    is stale and the item reads as a false ZOMBIE. urllib follows the 301 silently, so the
+    transport reports where it actually landed and the report says so."""
+    from aios.reconcilers.work_state_cli import _FINAL_URL_HEADER
+
+    def getter(url: str, headers: Any) -> Any:
+        if "/issues?" in url or url.endswith("/issues"):
+            return [
+                {
+                    "number": 71,
+                    "title": "moved",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ], {}
+        return [], {
+            _FINAL_URL_HEADER: "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
+        }
+
+    source = read_github_items(
+        repos=["eumemic/eumemic-company"], token="t", getter=getter, enrich_linked_prs=True
+    )
+    assert isinstance(source, SourceOk)
+    assert any("TRANSFERRED" in n for n in source.notes)
+    assert any("eumemic-ops/issues/900" in n for n in source.notes)
+    report = build_report(items_read=source, runs_read=SourceOk(name="aios-runs", items=()))
+    assert any("TRANSFERRED" in n for n in report.notes)
+    assert "TRANSFERRED" in render_markdown(report)
+    assert any("TRANSFERRED" in n for n in json.loads(render_json(report))["notes"])
+
+
+# ---- the drift guard now asserts the TRANSPORT, not source text. ----
+
+
+def test_drift_guard_catches_a_data_kwarg_that_would_silently_become_a_POST() -> None:
+    """`urllib.request.Request(url, data=...)` infers POST from a non-None body and
+    contains none of the literals a source grep looks for. Assert the TRANSPORT."""
+    import urllib.request
+
+    real_request = urllib.request.Request
+
+    class SneakyRequest(real_request):  # type: ignore[misc,valid-type]
+        def __init__(self, url: str, **kw: Any) -> None:
+            super().__init__(url, data=b"{}", **{k: v for k, v in kw.items() if k != "method"})
+
+    monkey = pytest.MonkeyPatch()
+    try:
+        monkey.setattr(urllib.request, "Request", SneakyRequest)
+        with pytest.raises(ObserveOnlyViolation) as excinfo:
+            _get("https://api.github.com/repos/eumemic/aios/issues/1", {})
+        assert "OBSERVE-ONLY" in str(excinfo.value)
+    finally:
+        monkey.undo()

--- a/tests/unit/test_work_state_reconciler.py
+++ b/tests/unit/test_work_state_reconciler.py
@@ -36,15 +36,18 @@ from aios.reconcilers.work_state import (
     RunRecord,
     SourceFailed,
     SourceOk,
+    TransferEvidence,
     WorkItem,
     build_report,
     classify_item,
     index_runs,
     is_pipeline_state_label,
     normalise_repo,
+    parse_issue_ref,
     render_json,
     render_markdown,
     run_record_from_payload,
+    stale_run_keys,
 )
 from aios.reconcilers.work_state import (
     TERMINAL_RUN_STATUSES as RECON_TERMINAL,
@@ -56,6 +59,7 @@ from aios.reconcilers.work_state_cli import (
     _get,
     _next_link,
     fetch_repo_items,
+    probe_stale_keys,
     read_aios_runs,
     read_github_items,
     reconcile,
@@ -1044,38 +1048,381 @@ def test_malformed_run_row_is_a_read_failure() -> None:
 # ---- C4: a transferred issue is DETECTED, not silently turned into a zombie. ----
 
 
-def test_C4_a_redirect_on_the_issue_read_is_surfaced_as_a_transfer() -> None:
-    """68 issues were transferred between repos on 2026-07-25. A transfer gives the issue
-    a NEW (repo, number) while every run.input still holds the OLD one, so the join key
-    is stale and the item reads as a false ZOMBIE. urllib follows the 301 silently, so the
-    transport reports where it actually landed and the report says so."""
-    from aios.reconcilers.work_state_cli import _FINAL_URL_HEADER
+def test_C4_the_INVERTED_probe_finds_a_transfer_from_a_REALIZABLE_world() -> None:
+    """THE C4 fixture, rebuilt so it describes a world production can actually present.
 
-    def getter(url: str, headers: Any) -> Any:
-        if "/issues?" in url or url.endswith("/issues"):
-            return [
+    The world, exactly as GitHub serves it after a completed transfer:
+
+    * a RUN whose ``input`` names the OLD coordinates (company#71) — 68 issues moved
+      repos on 2026-07-25, so every one of their runs carries a stale key right now;
+    * enumeration that returns ONLY the NEW coordinates (ops#900). The OLD pair is
+      *never enumerated* — that is the whole point, and it is why the previous fixture
+      (start from an enumerated issue, follow a redirect on its timeline) asserted a
+      world that cannot occur. Agreement on an impossible fixture is not evidence.
+
+    So the probe is INVERTED: the reconciler takes the run join keys that matched NO
+    enumerated item and GETs those STALE coordinates. company#71 redirects to ops#900,
+    which is authoritative evidence of the transfer — and ops#900, which would
+    otherwise be a textbook false ZOMBIE (in-flight label, no run keyed to it), is
+    kept OUT of counts['ZOMBIE'].
+    """
+    world = _github_world(
+        # Enumeration NEVER returns the old pair. Only the new coordinates exist.
+        issues={
+            "eumemic/eumemic-ops": [
                 {
-                    "number": 71,
+                    "number": 900,
+                    "title": "moved here from company#71",
+                    "labels": [{"name": "autodev:in-progress"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ],
+            "eumemic/eumemic-company": [],
+        },
+        timelines={"eumemic/eumemic-ops/issues/900": []},
+        moved={
+            "eumemic/eumemic-company/issues/71": (
+                "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
+            )
+        },
+    )
+    # The run still holds the OLD coordinates. This is the stale join key.
+    runs = [
+        {
+            "id": "run_stale",
+            "status": "completed",
+            "input": {"repo": "eumemic/eumemic-company", "issue_number": 71},
+        }
+    ]
+    source, transfers, paths = _cli_reader(
+        world, ["eumemic/eumemic-ops", "eumemic/eumemic-company"], runs
+    )
+
+    # 1. The probe actually asked about the STALE coordinates — the one place a
+    #    completed transfer is visible.
+    assert "/repos/eumemic/eumemic-company/issues/71" in paths, (
+        "the reconciler never probed the stale join key, so a real transfer is invisible"
+    )
+
+    # 2. The redirect is read as authoritative evidence, resolved to NEW coordinates.
+    (evidence,) = transfers
+    assert (evidence.stale_repo, evidence.stale_number) == ("eumemic/eumemic-company", 71)
+    assert (evidence.new_repo, evidence.new_number) == ("eumemic/eumemic-ops", 900)
+    assert evidence.run_ids == ("run_stale",)
+
+    report = build_report(
+        items_read=source,
+        runs_read=SourceOk(
+            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
+        ),
+        transfers=transfers,
+    )
+
+    # 3. THE payoff: the issue at the new coordinates is NOT a zombie.
+    counts = report.counts or {}
+    assert counts["ZOMBIE"] == 0, "a transferred issue STILL became a false ZOMBIE"
+    assert counts["AMBIGUOUS"] == 1
+    (d,) = report.disagreements
+    assert d.classification == "AMBIGUOUS"
+    assert (d.repo, d.number) == ("eumemic/eumemic-ops", 900)
+    assert "transferred-stale-join-key" in d.caveats
+    assert "excluded-from-zombie-count" in d.caveats
+    assert "eumemic/eumemic-company#71" in d.detail
+    assert "run_stale" in d.detail
+
+    # 4. And the stale key is visible as DATA and as prose.
+    assert any("STALE JOIN KEY" in n for n in report.notes)
+    payload = json.loads(render_json(report))
+    assert payload["transfers"][0]["stale_number"] == 71
+    assert payload["transfers"][0]["new_number"] == 900
+    assert "TRANSFERRED" in render_markdown(report)
+
+
+def test_C4_the_OLD_probe_direction_could_not_have_seen_this_world() -> None:
+    """Why the inversion was necessary, pinned as a test rather than left as a claim.
+
+    In the realizable world the OLD coordinates are never enumerated, so a
+    detector that only inspects ENUMERATED items — the previous design — issues no
+    request that could ever observe the transfer. Here: enumeration touches only
+    ops#900 and its timeline, and neither answers with a redirect. Without the probe
+    of the stale key, ops#900 is a ZOMBIE.
+    """
+    world = _github_world(
+        issues={
+            "eumemic/eumemic-ops": [
+                {
+                    "number": 900,
                     "title": "moved",
                     "labels": [{"name": "dispatched"}],
                     "html_url": "",
                     "updated_at": "",
                 }
-            ], {}
-        return [], {
-            _FINAL_URL_HEADER: "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
+            ]
+        },
+        timelines={"eumemic/eumemic-ops/issues/900": []},
+        moved={
+            "eumemic/eumemic-company/issues/71": (
+                "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
+            )
+        },
+    )
+    runs = [
+        {
+            "id": "run_stale",
+            "status": "completed",
+            "input": {"repo": "eumemic/eumemic-company", "issue_number": 71},
         }
+    ]
+    # Enumeration-only (no stale-key probe): NOTHING redirects, so no transfer is seen.
+    source, _transfers, enum_paths = _cli_reader(world, ["eumemic/eumemic-ops"], [])
+    assert not any("issues/71" in p for p in enum_paths)
+    blind = build_report(
+        items_read=source,
+        runs_read=SourceOk(
+            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
+        ),
+    )
+    assert (blind.counts or {})["ZOMBIE"] == 1, (
+        "this fixture must reproduce the FALSE ZOMBIE, or it is not testing the defect"
+    )
+
+    # With the inverted probe, the same world yields AMBIGUOUS instead.
+    _s, transfers, _p = _cli_reader(world, ["eumemic/eumemic-ops"], runs)
+    fixed = build_report(
+        items_read=_s,
+        runs_read=SourceOk(
+            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
+        ),
+        transfers=transfers,
+    )
+    assert (fixed.counts or {})["ZOMBIE"] == 0
+    assert (fixed.counts or {})["AMBIGUOUS"] == 1
+
+
+def test_C4_stale_run_keys_is_exactly_the_probe_list() -> None:
+    """The probe list is the runs that joined to nothing — not the enumerated items."""
+    items = [item(900, repo="eumemic/eumemic-ops")]
+    runs = [
+        run("completed", repo="eumemic/eumemic-company", number=71, run_id="r_a"),
+        run("errored", repo="eumemic/eumemic-company", number=71, run_id="r_b"),
+        run("running", repo="eumemic/eumemic-ops", number=900, run_id="r_joined"),
+        run("errored", repo=None, number=None, run_id="r_unkeyable"),
+    ]
+    assert stale_run_keys(items, runs) == {("eumemic/eumemic-company", 71): ("r_a", "r_b")}
+
+
+def test_C4_a_stale_key_that_resolves_to_ITSELF_is_not_a_transfer() -> None:
+    """Most stale keys are runs against CLOSED issues. That must NOT read as a transfer.
+
+    Without this, "probe the stale keys" could be satisfied by something that reports a
+    transfer for every closed issue — which would move real zombies out of the count
+    and bury the defect the tool exists to surface.
+    """
+    world = _github_world(
+        issues={
+            "eumemic/aios": [
+                {
+                    "number": 2000,
+                    "title": "z",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ]
+        },
+        timelines={"eumemic/aios/issues/2000": []},
+    )
+    runs = [
+        {"id": "r_closed", "status": "completed", "input": {"repo": "eumemic/aios", "issue": 111}}
+    ]
+    source, transfers, paths = _cli_reader(world, ["eumemic/aios"], runs)
+    assert "/repos/eumemic/aios/issues/111" in paths
+    assert transfers == ()
+    report = build_report(
+        items_read=source,
+        runs_read=SourceOk(
+            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
+        ),
+        transfers=transfers,
+    )
+    assert (report.counts or {})["ZOMBIE"] == 1, "a real zombie must stay a zombie"
+    assert (report.counts or {})["AMBIGUOUS"] == 0
+
+
+def test_C4_probe_read_error_is_a_NOTE_not_an_ALARM() -> None:
+    """A 404 on a stale coordinate is HISTORY (deleted/invisible issue), not an outage.
+
+    It must not ALARM the whole reconcile — but it must not be silent either, since an
+    unprobed key is a transfer we did not look for.
+    """
+    def getter(url: str, headers: Any) -> Any:
+        raise ReadFailure(f"GET {url} → HTTP 404: gone")
+
+    transfers, notes = probe_stale_keys(
+        [item(1)],
+        [run("completed", repo="eumemic/aios", number=4242, run_id="r_x")],
+        token="t",
+        getter=getter,
+    )
+    assert transfers == ()
+    assert any("404" in n and "eumemic/aios#4242" in n for n in notes)
+
+
+def test_C4_probe_cap_is_reported_as_a_gap_not_ignored() -> None:
+    """Hitting the probe ceiling says so. An unprobed key is an unseen transfer."""
+    def getter(url: str, headers: Any) -> Any:
+        return {"number": 1, "url": url}, {}
+
+    runs = [
+        run("completed", repo="eumemic/aios", number=n, run_id=f"r{n}") for n in range(10, 20)
+    ]
+    transfers, notes = probe_stale_keys([], runs, token="t", getter=getter, max_probes=3)
+    assert transfers == ()
+    assert any("capped at 3 of 10" in n and "NOT probed" in n for n in notes)
+
+
+def test_C4_a_transfer_OUTSIDE_the_scanned_repos_still_emits_its_note() -> None:
+    """The destination may be a repo we do not scan. There is then no item to caveat, so
+    the note is the ONLY trace the stale key leaves — and it must survive."""
+    evidence = TransferEvidence(
+        stale_repo="eumemic/eumemic-company",
+        stale_number=71,
+        destination="https://api.github.com/repos/other-org/private/issues/5",
+        new_repo="other-org/private",
+        new_number=5,
+        run_ids=("run_stale",),
+    )
+    report = build_report(
+        items_read=SourceOk(name="github", items=()),
+        runs_read=SourceOk(name="aios-runs", items=()),
+        transfers=(evidence,),
+    )
+    assert report.verdict == "OK"
+    assert any("STALE JOIN KEY" in n for n in report.notes)
+    assert "other-org/private" in "\n".join(report.notes)
+
+
+# ---- ITEM 2: the change detector must SEE a transfer-caveat change. ----
+
+
+def _transfer(dest_number: int = 900, run_id: str = "run_stale") -> TransferEvidence:
+    return TransferEvidence(
+        stale_repo="eumemic/eumemic-company",
+        stale_number=71,
+        destination=f"https://api.github.com/repos/eumemic/eumemic-ops/issues/{dest_number}",
+        new_repo="eumemic/eumemic-ops",
+        new_number=dest_number,
+        run_ids=(run_id,),
+    )
+
+
+def test_ITEM2_transfer_notes_are_folded_into_the_disagreement_hash() -> None:
+    """A transfer caveat appearing must WAKE the seat.
+
+    A stale key whose destination lies outside the scanned repos produces no
+    disagreement at all, so a hash computed only over disagreements would read a
+    newly-discovered transfer as "unchanged, nothing to say" and stay silent about the
+    exact fact a triager needs.
+    """
+    def report(transfers: tuple[TransferEvidence, ...]) -> ReconcileReport:
+        return build_report(
+            items_read=SourceOk(name="github", items=()),
+            runs_read=SourceOk(name="aios-runs", items=()),
+            transfers=transfers,
+        )
+
+    none_seen = report(())
+    one_seen = report((_transfer(),))
+    moved_elsewhere = report((_transfer(dest_number=901),))
+    other_run = report((_transfer(run_id="run_other"),))
+
+    assert none_seen.disagreement_hash() != one_seen.disagreement_hash(), (
+        "a NEW transfer caveat did not change the hash — the seat would never be woken"
+    )
+    assert one_seen.disagreement_hash() != moved_elsewhere.disagreement_hash()
+    assert one_seen.disagreement_hash() != other_run.disagreement_hash()
+    # Stable for the same evidence: it must not spam the seat every cron tick.
+    assert one_seen.disagreement_hash() == report((_transfer(),)).disagreement_hash()
+    # Order of evidence is not a change.
+    a = report((_transfer(), _transfer(dest_number=901)))
+    b = report((_transfer(dest_number=901), _transfer()))
+    assert a.disagreement_hash() == b.disagreement_hash()
+
+
+def test_ITEM2_transfer_notes_change_the_hash_on_the_ALARM_path_too() -> None:
+    """An outage must not mask a newly-discovered stale key."""
+    def alarm(transfers: tuple[TransferEvidence, ...]) -> ReconcileReport:
+        return build_report(
+            items_read=SourceFailed(name="github", reason="HTTP 500"),
+            runs_read=SourceOk(name="aios-runs", items=()),
+            transfers=transfers,
+        )
+
+    assert alarm(()).verdict == "ALARM"
+    assert alarm(()).disagreement_hash() != alarm((_transfer(),)).disagreement_hash()
+
+
+def test_ITEM2_both_forms_agree_on_the_hash_WITH_transfers() -> None:
+    """The mirror must fold transfer notes in identically, or the two wake differently."""
+    wf = _load_wf_module()
+    evidence = _transfer()
+    lib = build_report(
+        items_read=SourceOk(name="github", items=()),
+        runs_read=SourceOk(name="aios-runs", items=()),
+        transfers=(evidence,),
+    )
+    wf_report = wf.build(
+        [],
+        True,
+        [],
+        True,
+        [],
+        [],
+        [
+            {
+                "stale_repo": evidence.stale_repo,
+                "stale_number": evidence.stale_number,
+                "destination": evidence.destination,
+                "new_repo": evidence.new_repo,
+                "new_number": evidence.new_number,
+                "run_ids": list(evidence.run_ids),
+            }
+        ],
+    )
+    assert wf.disagreement_hash(wf_report) == lib.disagreement_hash()
+    # And the mirror's hash moves when the evidence does.
+    bare = wf.build([], True, [], True, [], [], [])
+    assert wf.disagreement_hash(bare) != wf.disagreement_hash(wf_report)
+
+
+def test_C4_parse_issue_ref_never_guesses() -> None:
+    assert parse_issue_ref("https://api.github.com/repos/eumemic/aios/issues/12") == (
+        "eumemic/aios",
+        12,
+    )
+    assert parse_issue_ref("https://github.com/eumemic/aios/issues/12") == ("eumemic/aios", 12)
+    for bad in (None, "", "https://api.github.com/repos/eumemic/aios", "nonsense", 7):
+        assert parse_issue_ref(bad) is None
+
+
+def test_C4_a_repo_RENAME_on_the_list_path_is_still_surfaced() -> None:
+    """The list-path redirect IS realizable (a repo rename/move) and is retained.
+
+    Distinct from the issue-transfer case: here the redirect happens on a request we
+    genuinely make, so following it silently while saying nothing would hide that the
+    enumerated coordinates are not the ones we asked for.
+    """
+    from aios.reconcilers.work_state_cli import _FINAL_URL_HEADER
+
+    def getter(url: str, headers: Any) -> Any:
+        return [], {_FINAL_URL_HEADER: "https://api.github.com/repos/eumemic/renamed/issues"}
 
     source = read_github_items(
-        repos=["eumemic/eumemic-company"], token="t", getter=getter, enrich_linked_prs=True
+        repos=["eumemic/oldname"], token="t", getter=getter, enrich_linked_prs=False
     )
     assert isinstance(source, SourceOk)
-    assert any("TRANSFERRED" in n for n in source.notes)
-    assert any("eumemic-ops/issues/900" in n for n in source.notes)
-    report = build_report(items_read=source, runs_read=SourceOk(name="aios-runs", items=()))
-    assert any("TRANSFERRED" in n for n in report.notes)
-    assert "TRANSFERRED" in render_markdown(report)
-    assert any("TRANSFERRED" in n for n in json.loads(render_json(report))["notes"])
+    assert any("TRANSFERRED" in n and "renamed" in n for n in source.notes)
 
 
 # ---- the drift guard now asserts the TRANSPORT, not source text. ----
@@ -1124,6 +1471,7 @@ def _github_world(
     issues: dict[str, list[dict[str, Any]]],
     timelines: dict[str, list[dict[str, Any]]] | None = None,
     redirects: dict[str, str] | None = None,
+    moved: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """One recorded GitHub, replayable through EITHER transport.
 
@@ -1137,6 +1485,11 @@ def _github_world(
         "issues": issues,
         "timelines": timelines or {},
         "redirects": redirects or {},
+        # C4 — ``moved`` records TRANSFERS as GitHub actually presents them:
+        # ``{"owner/name/issues/N": "<url of the NEW coordinates>"}``. The OLD pair
+        # answers with a redirect; the NEW pair is what enumeration returns. This is
+        # the realizable world — see ``_resolve``.
+        "moved": moved or {},
     }
 
 
@@ -1159,11 +1512,33 @@ def _resolve(world: dict[str, Any], path: str) -> tuple[str, Any]:
     if "/issues?" in path:
         repo = path.split("/repos/", 1)[1].split("/issues?")[0]
         return "ok", world["issues"].get(repo, [])
+    if "/issues/" in path:
+        # A single-issue read — the C4 stale-key PROBE. ``moved`` entries redirect (a
+        # transfer); anything else answers as ITSELF, which is what a stale key
+        # belonging to a merely-closed issue does.
+        key = path.split("/repos/", 1)[1]  # "owner/name/issues/N"
+        if key in world["moved"]:
+            return "redirect", world["moved"][key]
+        repo, number = key.split("/issues/")
+        return "ok", {
+            "number": int(number),
+            "url": f"https://api.github.com/repos/{repo}/issues/{number}",
+            "html_url": f"https://github.com/{repo}/issues/{number}",
+            "state": "closed",
+            "labels": [],
+        }
     raise AssertionError(f"the recorded world has no entry for {path!r}")
 
 
-def _cli_reader(world: dict[str, Any], repos: list[str]) -> tuple[SourceOk, list[str]]:
-    """Drive the LIBRARY/CLI read path over ``world``. Returns (source, paths_requested)."""
+def _cli_reader(
+    world: dict[str, Any], repos: list[str], runs: list[dict[str, Any]] | None = None
+) -> tuple[SourceOk, tuple[TransferEvidence, ...], list[str]]:
+    """Drive the LIBRARY/CLI read path over ``world``, INCLUDING the C4 stale-key probe.
+
+    Returns ``(source, transfers, paths_requested)``. ``runs`` are raw run payloads, so
+    the probe list is derived exactly as production derives it — from join keys that
+    matched no enumerated item — rather than being handed to the test.
+    """
     from aios.reconcilers.work_state_cli import _FINAL_URL_HEADER
 
     seen: list[str] = []
@@ -1180,11 +1555,26 @@ def _cli_reader(world: dict[str, Any], repos: list[str]) -> tuple[SourceOk, list
 
     source = read_github_items(repos, token="t", getter=getter, enrich_linked_prs=True)
     assert isinstance(source, SourceOk), getattr(source, "reason", source)
-    return source, seen
+    records = [run_record_from_payload(r) for r in (runs or [])]
+    items = [i for i in source.items if isinstance(i, WorkItem)]
+    transfers, probe_notes = probe_stale_keys(items, records, token="t", getter=getter)
+    if probe_notes:
+        source = SourceOk(
+            name=source.name,
+            items=source.items,
+            exhaustive=source.exhaustive,
+            notes=source.notes + probe_notes,
+        )
+    return source, transfers, seen
 
 
-def _wf_reader(world: dict[str, Any], repos: list[str]) -> tuple[Any, list[str]]:
-    """Drive the WORKFLOW read path over the SAME ``world``. Returns (result, paths)."""
+def _wf_reader(
+    world: dict[str, Any], repos: list[str], runs: list[dict[str, Any]] | None = None
+) -> tuple[Any, list[str]]:
+    """Drive the WORKFLOW read path over the SAME ``world``, INCLUDING the C4 probe.
+
+    Returns ``((wf, items, exhaustive, notes, transfers), paths)``.
+    """
     wf = _load_wf_module()
     seen: list[str] = []
 
@@ -1203,20 +1593,35 @@ def _wf_reader(world: dict[str, Any], repos: list[str]) -> tuple[Any, list[str]]
 
     wf.tool = fake_tool
     items, exhaustive, notes = asyncio.run(wf._read_items(repos))
-    return (wf, items, exhaustive, notes), seen
+    transfers, probe_notes = asyncio.run(wf._probe_stale_keys(items, runs or []))
+    notes = list(notes) + list(probe_notes)
+    return (wf, items, exhaustive, notes, transfers), seen
 
 
-def _assert_forms_agree(world: dict[str, Any], repos: list[str]) -> tuple[Any, Any]:
+def _assert_forms_agree(
+    world: dict[str, Any], repos: list[str], runs: list[dict[str, Any]] | None = None
+) -> tuple[Any, Any]:
     """THE guard. Both forms read the same world; every observable must match.
 
     Compares the ACQUIRED evidence, the classifications, the notes and the hash. A
-    capability that exists in only one form cannot survive this.
+    capability that exists in only one form cannot survive this. ``runs`` are raw run
+    payloads fed to BOTH forms, so the C4 stale-key probe list is derived by each form
+    from the same join, never handed to it.
     """
-    source, cli_paths = _cli_reader(world, repos)
-    (wf, wf_items, wf_exhaustive, wf_notes), wf_paths = _wf_reader(world, repos)
+    runs = runs or []
+    source, cli_transfers, cli_paths = _cli_reader(world, repos, runs)
+    (wf, wf_items, wf_exhaustive, wf_notes, wf_transfers), wf_paths = _wf_reader(
+        world, repos, runs
+    )
 
-    lib_report = build_report(items_read=source, runs_read=SourceOk(name="aios-runs", items=()))
-    wf_report = wf.build(wf_items, wf_exhaustive, [], True, [], wf_notes)
+    lib_report = build_report(
+        items_read=source,
+        runs_read=SourceOk(
+            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
+        ),
+        transfers=cli_transfers,
+    )
+    wf_report = wf.build(wf_items, wf_exhaustive, runs, True, [], wf_notes, wf_transfers)
 
     # 1. The same ITEMS, with the same ACQUIRED linked-PR evidence.
     assert [(i.repo, i.number) for i in source.items] == [
@@ -1234,6 +1639,16 @@ def _assert_forms_agree(world: dict[str, Any], repos: list[str]) -> tuple[Any, A
 
     # 3. The same NOTES (C4 transfers) — byte for byte.
     assert sorted(lib_report.notes) == sorted(wf_report["notes"])
+
+    # 3b. The same C4 stale-key EVIDENCE, as structured data. Notes are prose; this is
+    #     what phase 2 will act on, so it must match field for field.
+    assert [
+        (e.stale_repo, e.stale_number, e.new_repo, e.new_number, list(e.run_ids))
+        for e in cli_transfers
+    ] == [
+        (t["stale_repo"], t["stale_number"], t["new_repo"], t["new_number"], t["run_ids"])
+        for t in wf_transfers
+    ], "the two forms disagree about which join keys are STALE"
 
     # 4. The same change-detection HASH.
     assert wf.disagreement_hash(wf_report) == lib_report.disagreement_hash()
@@ -1336,7 +1751,7 @@ def test_C2_workflow_read_path_actually_requests_the_timeline() -> None:
             ]
         },
     )
-    (wf, items, _, _), paths = _wf_reader(world, ["eumemic/eumemic-company"])
+    (wf, items, _, _, _), paths = _wf_reader(world, ["eumemic/eumemic-company"])
     assert any("/issues/135/timeline" in p for p in paths), (
         "the workflow read path did not FETCH the linked-PR evidence"
     )
@@ -1421,69 +1836,183 @@ def test_C2_a_truncated_timeline_is_a_READ_FAILURE_not_a_quiet_zombie() -> None:
 # ---- C4 in the WORKFLOW form. ----
 
 
-def test_C4_workflow_form_detects_a_transfer_and_does_not_call_it_a_zombie() -> None:
-    """C4 in the mirror. A 3xx on the issue read is a TRANSFER, surfaced as a note.
+def test_C4_workflow_form_finds_a_transfer_from_the_SAME_REALIZABLE_world() -> None:
+    """C4 in the mirror, on the world production can actually present.
 
-    68 issues changed repos on 2026-07-25, so a stale (repo, number) join key is live
-    reality. The signal existed only in the urllib CLI; the workflow's `_gh` had no
-    equivalent, so on the form that runs on cron a transfer silently became a false
-    ZOMBIE.
+    Same fixture shape as the library test: a run naming the OLD coordinates
+    (company#71) and an enumeration that returns ONLY the new ones (ops#900). The old
+    mirror fixture put a redirect on the TIMELINE of an ENUMERATED issue — a world that
+    cannot occur, because after a transfer the old pair is never enumerated and the new
+    pair resolves normally. The mirror must invert the probe exactly as the library does
+    or the form that actually runs on cron keeps manufacturing false ZOMBIEs.
     """
     world = _github_world(
         issues={
-            "eumemic/eumemic-company": [
+            "eumemic/eumemic-ops": [
                 {
-                    "number": 71,
-                    "title": "moved",
-                    "labels": [{"name": "dispatched"}],
+                    "number": 900,
+                    "title": "moved here from company#71",
+                    "labels": [{"name": "autodev:in-progress"}],
                     "html_url": "",
                     "updated_at": "",
                 }
             ]
         },
-        redirects={
-            "/repos/eumemic/eumemic-company/issues/71/timeline": (
+        timelines={"eumemic/eumemic-ops/issues/900": []},
+        moved={
+            "eumemic/eumemic-company/issues/71": (
                 "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
             )
         },
     )
-    (wf, items, _, notes), _paths = _wf_reader(world, ["eumemic/eumemic-company"])
-    assert any("TRANSFERRED" in n for n in notes), "the mirror missed the transfer entirely"
-    assert any("eumemic-ops/issues/900" in n for n in notes)
-    report = wf.build(items, True, [], True, [], notes)
-    assert any("TRANSFERRED" in n for n in report["notes"])
-    # And it is not silently swallowed into the ALARM path either.
+    runs = [
+        {
+            "id": "run_stale",
+            "status": "completed",
+            "input": {"repo": "eumemic/eumemic-company", "issue_number": 71},
+        }
+    ]
+    (wf, items, _, notes, transfers), paths = _wf_reader(world, ["eumemic/eumemic-ops"], runs)
+
+    # The mirror asked about the STALE coordinates — the inverted probe, in the form
+    # that runs on cron.
+    assert "/repos/eumemic/eumemic-company/issues/71" in paths, (
+        "the mirror never probed the stale join key, so a real transfer is invisible to it"
+    )
+    assert transfers == [
+        {
+            "stale_repo": "eumemic/eumemic-company",
+            "stale_number": 71,
+            "destination": "https://api.github.com/repos/eumemic/eumemic-ops/issues/900",
+            "new_repo": "eumemic/eumemic-ops",
+            "new_number": 900,
+            "run_ids": ["run_stale"],
+        }
+    ]
+
+    report = wf.build(items, True, runs, True, [], notes, transfers)
     assert report["verdict"] == "OK"
+    assert report["counts"]["ZOMBIE"] == 0, "the mirror STILL turned a transfer into a zombie"
+    assert report["counts"]["AMBIGUOUS"] == 1
+    (d,) = report["disagreements"]
+    assert d["classification"] == "AMBIGUOUS"
+    assert (d["repo"], d["number"]) == ("eumemic/eumemic-ops", 900)
+    assert "transferred-stale-join-key" in d["caveats"]
+    assert "excluded-from-zombie-count" in d["caveats"]
+    assert "eumemic/eumemic-company#71" in d["detail"]
+    assert any("STALE JOIN KEY" in n for n in report["notes"])
 
 
-def test_C4_both_forms_emit_the_SAME_transfer_note() -> None:
-    """Parity on the C4 signal: same world, same note, from two different mechanisms.
+def test_C4_both_forms_agree_on_the_REALIZABLE_transfer_world() -> None:
+    """Parity on the C4 signal from two different transports, on the realizable world.
 
-    urllib follows the 301 and reports `geturl()`; `http_request` does not follow and
-    returns a literal 301 + Location. The transports differ by construction — the
-    OBSERVATION must not.
+    urllib follows the 301 silently and reports `geturl()`; `http_request` does not
+    follow and returns a literal 301 + Location. The transports differ by construction —
+    the stale-key EVIDENCE, the notes, the classifications and the HASH must not.
     """
     world = _github_world(
         issues={
-            "eumemic/eumemic-company": [
+            "eumemic/eumemic-ops": [
                 {
-                    "number": 71,
+                    "number": 900,
                     "title": "moved",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ],
+            "eumemic/eumemic-company": [],
+        },
+        timelines={"eumemic/eumemic-ops/issues/900": []},
+        moved={
+            "eumemic/eumemic-company/issues/71": (
+                "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
+            )
+        },
+    )
+    runs = [
+        {
+            "id": "run_stale",
+            "status": "completed",
+            "input": {"repo": "eumemic/eumemic-company", "issue_number": 71},
+        }
+    ]
+    lib_report, wf_report = _assert_forms_agree(
+        world, ["eumemic/eumemic-ops", "eumemic/eumemic-company"], runs
+    )
+    assert any("STALE JOIN KEY" in n for n in wf_report["notes"])
+    assert wf_report["counts"]["ZOMBIE"] == 0
+    assert wf_report["counts"]["AMBIGUOUS"] == 1
+    assert (lib_report.counts or {})["AMBIGUOUS"] == 1
+
+
+def test_C4_mirror_stale_key_that_resolves_to_itself_is_not_a_transfer() -> None:
+    """A stale key belonging to a merely-CLOSED issue must not read as a transfer."""
+    world = _github_world(
+        issues={
+            "eumemic/aios": [
+                {
+                    "number": 2000,
+                    "title": "z",
                     "labels": [{"name": "dispatched"}],
                     "html_url": "",
                     "updated_at": "",
                 }
             ]
         },
-        redirects={
-            "/repos/eumemic/eumemic-company/issues/71/timeline": (
-                "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
-            )
-        },
+        timelines={"eumemic/aios/issues/2000": []},
     )
-    lib_report, wf_report = _assert_forms_agree(world, ["eumemic/eumemic-company"])
-    assert any("TRANSFERRED" in n for n in wf_report["notes"])
-    assert sorted(lib_report.notes) == sorted(wf_report["notes"])
+    runs = [
+        {"id": "r_closed", "status": "errored", "input": {"repo": "eumemic/aios", "issue": 111}}
+    ]
+    _lib_report, wf_report = _assert_forms_agree(world, ["eumemic/aios"], runs)
+    assert wf_report["counts"]["ZOMBIE"] == 1, "a real zombie must stay a zombie in the mirror"
+    assert wf_report["counts"]["AMBIGUOUS"] == 0
+
+
+def test_C4_mirror_probe_read_error_is_a_NOTE_not_an_ALARM() -> None:
+    """A 404 on a stale coordinate is history, not an outage — but it is never silent."""
+    wf = _load_wf_module()
+
+    async def fake_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"status": 404, "headers": [], "body": "{}"}
+
+    wf.tool = fake_tool
+    transfers, notes = asyncio.run(
+        wf._probe_stale_keys(
+            [],
+            [{"id": "r_x", "status": "completed", "input": {"repo": "eumemic/aios", "issue": 4242}}],
+        )
+    )
+    assert transfers == []
+    assert any("404" in n and "eumemic/aios#4242" in n for n in notes)
+
+
+def test_C4_mirror_probe_cap_is_reported_as_a_gap() -> None:
+    """Hitting the ceiling says how many keys went UNPROBED, in the mirror too."""
+    wf = _load_wf_module()
+
+    async def fake_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        path = args["path"]
+        return {
+            "status": 200,
+            "headers": [],
+            "body": json.dumps({"number": 1, "url": f"https://api.github.com{path}"}),
+        }
+
+    wf.tool = fake_tool
+    monkey = pytest.MonkeyPatch()
+    try:
+        monkey.setattr(wf, "MAX_TRANSFER_PROBES", 3)
+        runs = [
+            {"id": f"r{n}", "status": "completed", "input": {"repo": "eumemic/aios", "issue": n}}
+            for n in range(10, 20)
+        ]
+        transfers, notes = asyncio.run(wf._probe_stale_keys([], runs))
+    finally:
+        monkey.undo()
+    assert transfers == []
+    assert any("capped at 3 of 10" in n and "NOT probed" in n for n in notes)
 
 
 def test_C4_a_redirect_without_a_location_is_a_read_failure_not_a_guess() -> None:
@@ -1600,7 +2129,7 @@ def test_the_workflow_mirror_can_REACH_every_class_from_fetched_data() -> None:
             "eumemic/aios/issues/4": [],
         },
     )
-    (wf, items, _, notes), _ = _wf_reader(world, ["eumemic/aios"])
+    (wf, items, _, notes, _t), _ = _wf_reader(world, ["eumemic/aios"])
     runs = [
         {"id": "r3", "status": "errored", "input": {"repo": "eumemic/aios", "issue_number": 3}},
         {"id": "r4", "status": "suspended", "input": {"repo": "eumemic/aios", "issue_number": 4}},

--- a/tests/unit/test_work_state_reconciler.py
+++ b/tests/unit/test_work_state_reconciler.py
@@ -18,6 +18,7 @@ tested against the SAME fixtures as the library core, so the two cannot drift.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import json
 from pathlib import Path
@@ -1099,3 +1100,554 @@ def test_drift_guard_catches_a_data_kwarg_that_would_silently_become_a_POST() ->
         assert "OBSERVE-ONLY" in str(excinfo.value)
     finally:
         monkey.undo()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# (13) READER PARITY — the drift guard that would have CAUGHT C2 and C4.
+#
+# The previous guard only ever called `classify()` / `build()`, so it compared
+# the two forms' arithmetic while never comparing what they can ACQUIRE. That is
+# precisely how C2 and C4 shipped: the library could fetch linked PRs and detect a
+# transfer, the workflow could not, and every classifier-level assertion still
+# passed because the test HANDED the workflow the evidence its production path
+# could never obtain.
+#
+# So the guard now drives BOTH READ PATHS over ONE recorded GitHub world and
+# requires: identical items, identical classifications, identical hashes, identical
+# notes — AND that each form actually issued the request that acquires the evidence.
+# A capability present in one form and absent in the other now FAILS THE BUILD.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _github_world(
+    *,
+    issues: dict[str, list[dict[str, Any]]],
+    timelines: dict[str, list[dict[str, Any]]] | None = None,
+    redirects: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """One recorded GitHub, replayable through EITHER transport.
+
+    Keyed by the API path (never the full URL) because the two forms address the
+    same endpoint differently: the CLI builds absolute ``https://api.github.com/...``
+    URLs for urllib, the workflow passes a bare path to the ``github`` http_server.
+    Same bytes, same endpoints, two transports — which is the only way a comparison
+    between them means anything.
+    """
+    return {
+        "issues": issues,
+        "timelines": timelines or {},
+        "redirects": redirects or {},
+    }
+
+
+def _path_of(url: str) -> str:
+    return url.split("api.github.com", 1)[1] if "api.github.com" in url else url
+
+
+def _resolve(world: dict[str, Any], path: str) -> tuple[str, Any]:
+    """Resolve one recorded request. Returns ``(kind, payload)``.
+
+    ``kind`` is ``"redirect"`` (payload = destination URL) or ``"ok"`` (payload = the
+    JSON body). Shared by both adapters so neither form can be fed a different world.
+    """
+    for prefix, dest in world["redirects"].items():
+        if path.startswith(prefix):
+            return "redirect", dest
+    if "/timeline" in path:
+        key = path.split("/repos/", 1)[1].split("/timeline")[0]  # "owner/name/issues/N"
+        return "ok", world["timelines"].get(key, [])
+    if "/issues?" in path:
+        repo = path.split("/repos/", 1)[1].split("/issues?")[0]
+        return "ok", world["issues"].get(repo, [])
+    raise AssertionError(f"the recorded world has no entry for {path!r}")
+
+
+def _cli_reader(world: dict[str, Any], repos: list[str]) -> tuple[SourceOk, list[str]]:
+    """Drive the LIBRARY/CLI read path over ``world``. Returns (source, paths_requested)."""
+    from aios.reconcilers.work_state_cli import _FINAL_URL_HEADER
+
+    seen: list[str] = []
+
+    def getter(url: str, headers: Any) -> Any:
+        path = _path_of(url)
+        seen.append(path)
+        kind, payload = _resolve(world, path)
+        if kind == "redirect":
+            # urllib FOLLOWS the 301 silently and reports where it landed; that
+            # synthetic header is the CLI's transfer signal.
+            return [], {_FINAL_URL_HEADER: payload}
+        return payload, {}
+
+    source = read_github_items(repos, token="t", getter=getter, enrich_linked_prs=True)
+    assert isinstance(source, SourceOk), getattr(source, "reason", source)
+    return source, seen
+
+
+def _wf_reader(world: dict[str, Any], repos: list[str]) -> tuple[Any, list[str]]:
+    """Drive the WORKFLOW read path over the SAME ``world``. Returns (result, paths)."""
+    wf = _load_wf_module()
+    seen: list[str] = []
+
+    async def fake_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        assert name == "http_request"
+        assert args["method"] == "GET", "OBSERVE-ONLY: the mirror may only ever GET"
+        assert "body" not in args, "OBSERVE-ONLY: a GET carries no request body"
+        path = args["path"]
+        seen.append(path)
+        kind, payload = _resolve(world, path)
+        if kind == "redirect":
+            # http_request does NOT follow redirects, so the transfer arrives as a
+            # literal 301 + Location. Different mechanism from urllib, same event.
+            return {"status": 301, "headers": [["Location", payload]], "body": ""}
+        return {"status": 200, "headers": [], "body": json.dumps(payload)}
+
+    wf.tool = fake_tool
+    items, exhaustive, notes = asyncio.run(wf._read_items(repos))
+    return (wf, items, exhaustive, notes), seen
+
+
+def _assert_forms_agree(world: dict[str, Any], repos: list[str]) -> tuple[Any, Any]:
+    """THE guard. Both forms read the same world; every observable must match.
+
+    Compares the ACQUIRED evidence, the classifications, the notes and the hash. A
+    capability that exists in only one form cannot survive this.
+    """
+    source, cli_paths = _cli_reader(world, repos)
+    (wf, wf_items, wf_exhaustive, wf_notes), wf_paths = _wf_reader(world, repos)
+
+    lib_report = build_report(items_read=source, runs_read=SourceOk(name="aios-runs", items=()))
+    wf_report = wf.build(wf_items, wf_exhaustive, [], True, [], wf_notes)
+
+    # 1. The same ITEMS, with the same ACQUIRED linked-PR evidence.
+    assert [(i.repo, i.number) for i in source.items] == [
+        (i["repo"], i["number"]) for i in wf_items
+    ]
+    assert [list(i.linked_pr_numbers) for i in source.items] == [
+        list(i["linked_pr_numbers"]) for i in wf_items
+    ], "linked-PR evidence differs between the two forms"
+
+    # 2. The same CLASSIFICATIONS and the same COUNTS.
+    assert dict(lib_report.counts or {}) == wf_report["counts"]
+    assert [(d.classification, d.repo, d.number) for d in lib_report.disagreements] == [
+        (d["classification"], d["repo"], d["number"]) for d in wf_report["disagreements"]
+    ]
+
+    # 3. The same NOTES (C4 transfers) — byte for byte.
+    assert sorted(lib_report.notes) == sorted(wf_report["notes"])
+
+    # 4. The same change-detection HASH.
+    assert wf.disagreement_hash(wf_report) == lib_report.disagreement_hash()
+
+    # 5. Both forms actually WENT AND GOT IT. Equal outputs from unequal effort is
+    #    exactly the shape C2 shipped in: one form fetched the evidence, the other
+    #    was handed it by a test.
+    assert sorted(cli_paths) == sorted(wf_paths), (
+        "the two forms issued DIFFERENT requests for the same world — one of them is "
+        f"not acquiring evidence it appears to have.\nCLI: {sorted(cli_paths)}\n"
+        f"WF : {sorted(wf_paths)}"
+    )
+    return lib_report, wf_report
+
+
+def test_drift_guard_C2_both_forms_FETCH_the_linked_pr_evidence() -> None:
+    """C2, as a SYSTEM test: nothing is injected. Both forms must go and get it.
+
+    The five known-good items with their real linked PRs. The workflow used never to
+    fetch a timeline at all, so `linked_pr_numbers` stayed empty and AMBIGUOUS was
+    UNREACHABLE with real data — all five classified ZOMBIE on the form that runs on
+    cron. The old test passed anyway because it INJECTED `linked_pr_numbers` into
+    `classify()`. Here the only source of that evidence is the recorded timeline, so
+    a form that does not fetch it CANNOT reach AMBIGUOUS.
+    """
+    known_good = {
+        ("eumemic/eumemic-company", 71): [67, 68, 69, 100, 101],
+        ("eumemic/eumemic-company", 50): [96, 204, 206],
+        ("eumemic/eumemic-company", 135): [212],
+        ("eumemic/eumemic-ops", 337): [1977, 1979, 2016],
+        ("eumemic/eumemic-ops", 331): [1995, 2041],
+    }
+    issues: dict[str, list[dict[str, Any]]] = {}
+    timelines: dict[str, list[dict[str, Any]]] = {}
+    for (repo, number), prs in known_good.items():
+        issues.setdefault(repo, []).append(
+            {
+                "number": number,
+                "title": f"item {number}",
+                # The REAL current labels: `dispatched` was stripped on 2026-07-26.
+                "labels": [{"name": "approved"}, {"name": "autodev:in-progress"}],
+                "html_url": "",
+                "updated_at": "",
+            }
+        )
+        timelines[f"{repo}/issues/{number}"] = [
+            {"event": "cross-referenced", "source": {"issue": {"number": n, "pull_request": {}}}}
+            for n in prs
+        ] + [
+            {"event": "labeled"},
+            {"event": "cross-referenced", "source": {"issue": {"number": 9}}},
+        ]
+
+    world = _github_world(issues=issues, timelines=timelines)
+    repos = ["eumemic/eumemic-company", "eumemic/eumemic-ops"]
+    lib_report, wf_report = _assert_forms_agree(world, repos)
+
+    # The payoff, in BOTH forms, from FETCHED evidence only.
+    assert wf_report["counts"]["ZOMBIE"] == 0, (
+        "the five known-good items must not be zombies in the WORKFLOW form — this is "
+        "the assertion the injected-input test could never make"
+    )
+    assert wf_report["counts"]["AMBIGUOUS"] == 5
+    assert (lib_report.counts or {})["ZOMBIE"] == 0
+    assert (lib_report.counts or {})["AMBIGUOUS"] == 5
+    assert {(d["repo"], d["number"]) for d in wf_report["disagreements"]} == set(known_good)
+    for d in wf_report["disagreements"]:
+        assert d["classification"] == "AMBIGUOUS"
+        assert "excluded-from-zombie-count" in d["caveats"]
+        # The ACQUIRED PR numbers are named in the finding, not merely counted.
+        for n in known_good[(d["repo"], d["number"])]:
+            assert f"#{n}" in d["detail"]
+
+
+def test_C2_workflow_read_path_actually_requests_the_timeline() -> None:
+    """The fetch itself, pinned. `_read_items` must issue the timeline GET.
+
+    Stated separately from the parity guard because this is the exact regression:
+    the mirror's read path never asked for a timeline, so no amount of classifier
+    correctness could produce an AMBIGUOUS from real workflow data.
+    """
+    world = _github_world(
+        issues={
+            "eumemic/eumemic-company": [
+                {
+                    "number": 135,
+                    "title": "t",
+                    "labels": [{"name": "autodev:in-progress"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ]
+        },
+        timelines={
+            "eumemic/eumemic-company/issues/135": [
+                {
+                    "event": "cross-referenced",
+                    "source": {"issue": {"number": 212, "pull_request": {}}},
+                }
+            ]
+        },
+    )
+    (wf, items, _, _), paths = _wf_reader(world, ["eumemic/eumemic-company"])
+    assert any("/issues/135/timeline" in p for p in paths), (
+        "the workflow read path did not FETCH the linked-PR evidence"
+    )
+    assert items[0]["linked_pr_numbers"] == [212]
+    assert wf.classify(items[0], [])["classification"] == "AMBIGUOUS"
+
+
+def test_C2_a_zombie_stays_a_zombie_when_the_fetch_finds_no_linked_pr() -> None:
+    """The enrichment must not turn everything AMBIGUOUS. An empty timeline ⇒ ZOMBIE.
+
+    Without this, 'fetch the timeline' could be satisfied by a call that always
+    reports linkage, which would bury the nine real zombies instead of the five
+    known-good items. Both forms, same world.
+    """
+    world = _github_world(
+        issues={
+            "eumemic/aios": [
+                {
+                    "number": 2000,
+                    "title": "t",
+                    "labels": [{"name": "autodev:in-progress"}, {"name": "needs:human/build"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ]
+        },
+        timelines={"eumemic/aios/issues/2000": [{"event": "labeled"}]},
+    )
+    lib_report, wf_report = _assert_forms_agree(world, ["eumemic/aios"])
+    assert wf_report["counts"]["ZOMBIE"] == 1
+    assert wf_report["counts"]["AMBIGUOUS"] == 0
+    assert (lib_report.counts or {})["ZOMBIE"] == 1
+    (d,) = wf_report["disagreements"]
+    assert d["trigger_labels"] == ["autodev:in-progress", "needs:human/build"]
+
+
+def test_C2_a_truncated_timeline_is_a_READ_FAILURE_not_a_quiet_zombie() -> None:
+    """A timeline we could not read to the end cannot decide ZOMBIE vs AMBIGUOUS.
+
+    The unread page is exactly where the PR that disproves the ZOMBIE would be, so
+    stopping quietly manufactures the false ZOMBIE this whole reconciler exists to
+    catch. Fail loud instead.
+    """
+    wf = _load_wf_module()
+
+    async def fake_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        path = args["path"]
+        if "/timeline" in path:
+            return {
+                "status": 200,
+                "headers": [
+                    [
+                        "Link",
+                        "<https://api.github.com/repos/eumemic/aios/issues/1/timeline"
+                        '?page=2>; rel="next"',
+                    ]
+                ],
+                "body": "[]",
+            }
+        return {
+            "status": 200,
+            "headers": [],
+            "body": json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "title": "t",
+                        "labels": [{"name": "dispatched"}],
+                        "html_url": "",
+                        "updated_at": "",
+                    }
+                ]
+            ),
+        }
+
+    wf.tool = fake_tool
+    with pytest.raises(wf.ReadFailure) as excinfo:
+        asyncio.run(wf._read_items(["eumemic/aios"]))
+    assert "TRUNCATED" in str(excinfo.value)
+
+
+# ---- C4 in the WORKFLOW form. ----
+
+
+def test_C4_workflow_form_detects_a_transfer_and_does_not_call_it_a_zombie() -> None:
+    """C4 in the mirror. A 3xx on the issue read is a TRANSFER, surfaced as a note.
+
+    68 issues changed repos on 2026-07-25, so a stale (repo, number) join key is live
+    reality. The signal existed only in the urllib CLI; the workflow's `_gh` had no
+    equivalent, so on the form that runs on cron a transfer silently became a false
+    ZOMBIE.
+    """
+    world = _github_world(
+        issues={
+            "eumemic/eumemic-company": [
+                {
+                    "number": 71,
+                    "title": "moved",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ]
+        },
+        redirects={
+            "/repos/eumemic/eumemic-company/issues/71/timeline": (
+                "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
+            )
+        },
+    )
+    (wf, items, _, notes), _paths = _wf_reader(world, ["eumemic/eumemic-company"])
+    assert any("TRANSFERRED" in n for n in notes), "the mirror missed the transfer entirely"
+    assert any("eumemic-ops/issues/900" in n for n in notes)
+    report = wf.build(items, True, [], True, [], notes)
+    assert any("TRANSFERRED" in n for n in report["notes"])
+    # And it is not silently swallowed into the ALARM path either.
+    assert report["verdict"] == "OK"
+
+
+def test_C4_both_forms_emit_the_SAME_transfer_note() -> None:
+    """Parity on the C4 signal: same world, same note, from two different mechanisms.
+
+    urllib follows the 301 and reports `geturl()`; `http_request` does not follow and
+    returns a literal 301 + Location. The transports differ by construction — the
+    OBSERVATION must not.
+    """
+    world = _github_world(
+        issues={
+            "eumemic/eumemic-company": [
+                {
+                    "number": 71,
+                    "title": "moved",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ]
+        },
+        redirects={
+            "/repos/eumemic/eumemic-company/issues/71/timeline": (
+                "https://api.github.com/repos/eumemic/eumemic-ops/issues/900"
+            )
+        },
+    )
+    lib_report, wf_report = _assert_forms_agree(world, ["eumemic/eumemic-company"])
+    assert any("TRANSFERRED" in n for n in wf_report["notes"])
+    assert sorted(lib_report.notes) == sorted(wf_report["notes"])
+
+
+def test_C4_a_redirect_without_a_location_is_a_read_failure_not_a_guess() -> None:
+    """A redirect with nowhere to go cannot be named. Refuse rather than invent."""
+    wf = _load_wf_module()
+
+    async def fake_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"status": 301, "headers": [], "body": ""}
+
+    wf.tool = fake_tool
+    with pytest.raises(wf.ReadFailure) as excinfo:
+        asyncio.run(wf._read_items(["eumemic/aios"]))
+    assert "no Location" in str(excinfo.value)
+
+
+def test_C4_a_non_redirect_error_status_still_ALARMS() -> None:
+    """Making 3xx a signal must not make 4xx/5xx one. A 404 is still a FAILED read."""
+    wf = _load_wf_module()
+
+    async def fake_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"status": 404, "headers": [], "body": "{}"}
+
+    wf.tool = fake_tool
+    with pytest.raises(wf.ReadFailure) as excinfo:
+        asyncio.run(wf._read_items(["eumemic/aios"]))
+    assert "404" in str(excinfo.value)
+
+
+# ---- the CAPABILITY guard: present in one form, absent in the other ⇒ FAIL. ----
+
+
+#: Every read-path capability that must exist in BOTH forms, with the probe that
+#: proves it. The previous drift guard compared only `classify()`/`build()`, so a
+#: capability could live in the library alone and every test still passed — which is
+#: exactly how C2 and C4 shipped. Adding a capability to one form now requires
+#: adding it to the other, or this table fails the build.
+_READ_CAPABILITIES: list[tuple[str, str]] = [
+    ("linked-PR enrichment (C2)", "linked_pr_numbers"),
+    ("transfer/redirect detection (C4)", "transfer_note"),
+]
+
+
+@pytest.mark.parametrize(("capability", "marker"), _READ_CAPABILITIES)
+def test_every_read_capability_exists_in_BOTH_forms(capability: str, marker: str) -> None:
+    """Structural backstop to the behavioural parity guard above.
+
+    Behaviour is the real test; this catches the case where someone deletes a
+    capability from the mirror and also deletes the fixture that exercised it — a
+    green build for a mirror that can no longer see what the library sees.
+    """
+    wf_source = Path("infra/workflows/work-state-reconciler.wf.py").read_text()
+    cli_source = Path("src/aios/reconcilers/work_state_cli.py").read_text()
+    lib_source = Path("src/aios/reconcilers/work_state.py").read_text()
+    assert marker in wf_source, f"{capability} is MISSING from the durable workflow mirror"
+    assert marker in cli_source or marker in lib_source, (
+        f"{capability} is MISSING from the library core"
+    )
+
+
+def test_the_workflow_mirror_can_REACH_every_class_from_fetched_data() -> None:
+    """Reachability, not just correctness: every class must be producible by the
+    workflow's own READ PATH.
+
+    AMBIGUOUS was unreachable in the mirror — the classifier had a branch for it that
+    no production input could ever satisfy. A class that only a test can reach is a
+    class that does not ship, so reachability is asserted from the reader outward.
+    """
+    world = _github_world(
+        issues={
+            "eumemic/aios": [
+                # ZOMBIE: asserts in flight, no run, timeline shows no PR.
+                {
+                    "number": 1,
+                    "title": "z",
+                    "labels": [{"name": "autodev:in-progress"}],
+                    "html_url": "",
+                    "updated_at": "",
+                },
+                # AMBIGUOUS: same, but the timeline HAS a PR.
+                {
+                    "number": 2,
+                    "title": "a",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                },
+                # DEAD / MISLABELLED / LAGGING come from the run side.
+                {
+                    "number": 3,
+                    "title": "d",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                },
+                {
+                    "number": 4,
+                    "title": "m",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                },
+                {"number": 5, "title": "l", "labels": [], "html_url": "", "updated_at": ""},
+            ]
+        },
+        timelines={
+            "eumemic/aios/issues/1": [],
+            "eumemic/aios/issues/2": [
+                {
+                    "event": "cross-referenced",
+                    "source": {"issue": {"number": 99, "pull_request": {}}},
+                }
+            ],
+            "eumemic/aios/issues/3": [],
+            "eumemic/aios/issues/4": [],
+        },
+    )
+    (wf, items, _, notes), _ = _wf_reader(world, ["eumemic/aios"])
+    runs = [
+        {"id": "r3", "status": "errored", "input": {"repo": "eumemic/aios", "issue_number": 3}},
+        {"id": "r4", "status": "suspended", "input": {"repo": "eumemic/aios", "issue_number": 4}},
+        {"id": "r5", "status": "running", "input": {"repo": "eumemic/aios", "issue_number": 5}},
+    ]
+    report = wf.build(items, True, runs, True, [], notes)
+    assert report["counts"] == {
+        "ZOMBIE": 1,
+        "AMBIGUOUS": 1,
+        "DEAD": 1,
+        "MISLABELLED": 1,
+        "LAGGING": 1,
+    }, "a class the workflow's own read path cannot reach is a class that does not ship"
+
+
+def test_workflow_read_path_is_OBSERVE_ONLY_end_to_end() -> None:
+    """Gate 1, asserted on the READ PATH rather than by grepping the source.
+
+    Every request the mirror issues while reading a full world — issue pages AND the
+    new timeline fetches — must be a GET with no body.
+    """
+    wf = _load_wf_module()
+    verbs: list[str] = []
+
+    async def fake_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        verbs.append(args.get("method", ""))
+        assert "body" not in args
+        if "/timeline" in args["path"]:
+            return {"status": 200, "headers": [], "body": "[]"}
+        return {
+            "status": 200,
+            "headers": [],
+            "body": json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "title": "t",
+                        "labels": [{"name": "dispatched"}],
+                        "html_url": "",
+                        "updated_at": "",
+                    }
+                ]
+            ),
+        }
+
+    wf.tool = fake_tool
+    asyncio.run(wf._read_items(["eumemic/aios"]))
+    assert verbs and set(verbs) == {"GET"}
+    with pytest.raises(wf.ReadFailure):
+        asyncio.run(wf._gh("/repos/eumemic/aios/issues/1", method="PATCH"))

--- a/tests/unit/test_work_state_reconciler.py
+++ b/tests/unit/test_work_state_reconciler.py
@@ -1,0 +1,733 @@
+"""Unit tests for the phase-1 work-state reconciler (#2043).
+
+The reconciler exists because **a GitHub label is an assertion nothing re-checks**.
+These tests protect the two properties that make it worth having:
+
+1. **The classifier is right** — the four classes (ZOMBIE / DEAD / MISLABELLED /
+   LAGGING), including the precedence rules (live > suspended > terminal) and the
+   "parked is NOT running" rule.
+2. **It fails LOUD** — a failed read can never render as health. This is the
+   acceptance criterion that outranks the feature, so it gets the most tests:
+   every source-failure path is asserted to produce ``verdict == "ALARM"`` **and**
+   ``counts is None``, and the "0 disagreements" rendering is asserted to be
+   reachable ONLY from a successful read.
+
+The workflow-script mirror in ``infra/workflows/work-state-reconciler.wf.py`` is
+tested against the SAME fixtures as the library core, so the two cannot drift.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRunStatus
+from aios.reconcilers.work_state import (
+    CLASSES,
+    LIVE_RUN_STATUSES,
+    SUSPENDED_RUN_STATUSES,
+    Disagreement,
+    ReconcileReport,
+    RunRecord,
+    SourceFailed,
+    SourceOk,
+    WorkItem,
+    build_report,
+    classify_item,
+    index_runs,
+    is_pipeline_state_label,
+    normalise_repo,
+    render_json,
+    render_markdown,
+    run_record_from_payload,
+)
+from aios.reconcilers.work_state import (
+    TERMINAL_RUN_STATUSES as RECON_TERMINAL,
+)
+from aios.reconcilers.work_state_cli import (
+    DEFAULT_REPOS,
+    ObserveOnlyViolation,
+    ReadFailure,
+    _get,
+    _next_link,
+    fetch_repo_items,
+    read_aios_runs,
+    read_github_items,
+    reconcile,
+)
+
+# ─── fixtures ────────────────────────────────────────────────────────────────
+
+
+def item(
+    number: int,
+    *,
+    repo: str = "eumemic/aios",
+    labels: tuple[str, ...] = ("dispatched",),
+    kind: str = "issue",
+    linked: tuple[int, ...] = (),
+) -> WorkItem:
+    return WorkItem(
+        repo=repo,
+        number=number,
+        kind=kind,  # type: ignore[arg-type]
+        title=f"item {number}",
+        labels=labels,
+        html_url=f"https://github.com/{repo}/issues/{number}",
+        updated_at="2026-07-20T00:00:00Z",
+        linked_pr_numbers=linked,
+    )
+
+
+def run(
+    status: str, *, repo: str | None = "eumemic/aios", number: int | None = 1, run_id: str = "run_1"
+) -> RunRecord:
+    return RunRecord(run_id=run_id, status=status, repo=repo, issue_number=number)
+
+
+def ok_report(items: list[WorkItem], runs: list[RunRecord], **kw: Any) -> ReconcileReport:
+    return build_report(
+        items_read=SourceOk(name="github", items=tuple(items)),
+        runs_read=SourceOk(name="aios-runs", items=tuple(runs)),
+        **kw,
+    )
+
+
+# ─── (1) the four classes ────────────────────────────────────────────────────
+
+
+def test_zombie_dispatched_with_no_run_ever() -> None:
+    """The headline defect: `dispatched` for days, nothing ever picked it up."""
+    report = ok_report([item(2000)], [])
+    assert report.verdict == "OK"
+    (d,) = report.disagreements
+    assert d.classification == "ZOMBIE"
+    assert d.run_ids == ()
+    assert "NO run exists" in d.detail
+
+
+def test_dead_dispatched_but_run_terminal() -> None:
+    for status in sorted(RECON_TERMINAL):
+        report = ok_report([item(1)], [run(status)])
+        (d,) = report.disagreements
+        assert d.classification == "DEAD", status
+        assert d.run_statuses == (status,)
+
+
+def test_mislabelled_dispatched_but_run_suspended_at_a_gate() -> None:
+    """Parked is NOT running — a suspended run is its own condition, never 'agree'."""
+    report = ok_report([item(1)], [run("suspended")])
+    (d,) = report.disagreements
+    assert d.classification == "MISLABELLED"
+    assert "parked is NOT running" in d.detail
+
+
+def test_lagging_live_run_but_no_dispatched_label() -> None:
+    report = ok_report([item(1, labels=("approved",))], [run("running")])
+    (d,) = report.disagreements
+    assert d.classification == "LAGGING"
+
+
+@pytest.mark.parametrize("status", sorted(LIVE_RUN_STATUSES))
+def test_dispatched_with_a_live_run_agrees(status: str) -> None:
+    """The healthy case must produce NO disagreement — otherwise the report is noise."""
+    assert ok_report([item(1)], [run(status)]).disagreements == ()
+
+
+def test_no_label_and_no_live_run_is_not_a_disagreement() -> None:
+    assert ok_report([item(1, labels=("hold",))], [run("completed")]).disagreements == ()
+
+
+# ─── (2) precedence: live > suspended > terminal ─────────────────────────────
+
+
+def test_one_live_run_outranks_terminal_and_suspended_siblings() -> None:
+    """A re-dispatch leaves dead runs behind; one live run still means work IS happening."""
+    runs = [
+        run("errored", run_id="r1"),
+        run("suspended", run_id="r2"),
+        run("running", run_id="r3"),
+    ]
+    assert classify_item(item(1), runs) is None
+
+
+def test_suspended_outranks_terminal_when_nothing_is_live() -> None:
+    verdict = classify_item(item(1), [run("completed", run_id="r1"), run("suspended", run_id="r2")])
+    assert verdict is not None and verdict.classification == "MISLABELLED"
+    assert verdict.run_ids == ("r2",)  # the report points at the SUSPENDED run, not the corpse
+
+
+def test_unrecognised_status_is_never_asserted_dead() -> None:
+    """An unknown status is not evidence of death; a false DEAD trains people to ignore us."""
+    verdict = classify_item(item(1), [run("quiescing")])
+    assert verdict is not None
+    assert verdict.classification == "MISLABELLED"
+    assert "unrecognised-run-status" in verdict.caveats
+
+
+# ─── (3) the join key ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("eumemic/aios", "eumemic/aios"),
+        ("aios", "eumemic/aios"),
+        ("https://github.com/eumemic/eumemic-ops", "eumemic/eumemic-ops"),
+        ("git@github.com:eumemic/aios.git", "eumemic/aios"),
+        ({"owner": "eumemic", "name": "autodev"}, "eumemic/autodev"),
+        ("", None),
+        (None, None),
+        (17, None),
+        ("a/b/c", None),
+    ],
+)
+def test_normalise_repo(raw: Any, expected: str | None) -> None:
+    assert normalise_repo(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("payload", "key"),
+    [
+        ({"repo": "eumemic/aios", "issue_number": 2000}, ("eumemic/aios", 2000)),
+        ({"repo": "aios", "issue": "#2000"}, ("eumemic/aios", 2000)),
+        ({"repository": "eumemic/aios", "number": "2000"}, ("eumemic/aios", 2000)),
+        ({"repo": "eumemic/aios", "issue_number": True}, None),  # bool is not a number
+        ({"repo": "eumemic/aios"}, None),
+        ({}, None),
+    ],
+)
+def test_run_record_key_extraction(payload: dict[str, Any], key: tuple[str, int] | None) -> None:
+    record = run_record_from_payload({"id": "r", "status": "running", "input": payload})
+    assert record.key == key
+
+
+def test_run_with_unreadable_input_is_reported_never_dropped() -> None:
+    """A silently-dropped run is a missing 'agree', which manufactures a false ZOMBIE."""
+    orphan = RunRecord(run_id="r9", status="running", repo=None, issue_number=None)
+    report = ok_report([item(1)], [run("running"), orphan])
+    assert report.disagreements == ()
+    assert [u.run_id for u in report.unmatched_runs] == ["r9"]
+    assert index_runs([orphan]) == {}
+
+
+def test_live_run_against_a_non_open_item_is_surfaced_not_swallowed() -> None:
+    report = ok_report([], [run("running", number=4242)])
+    assert report.verdict == "OK"
+    (unmatched,) = report.unmatched_runs
+    assert unmatched.issue_number == 4242
+    assert "not open" in unmatched.reason
+
+
+# ─── (4) FAIL LOUD — the criterion that outranks the feature ─────────────────
+
+
+def test_failed_github_read_alarms_and_has_NO_counts() -> None:
+    report = build_report(
+        items_read=SourceFailed(name="github", reason="HTTP 401"),
+        runs_read=SourceOk(name="aios-runs", items=()),
+    )
+    assert report.verdict == "ALARM"
+    assert report.counts is None  # NOT {}, NOT zeros — there is nothing to render
+    assert report.to_dict()["counts"] is None
+    assert report.to_dict()["total_disagreements"] is None
+
+
+def test_failed_runs_read_alarms() -> None:
+    report = build_report(
+        items_read=SourceOk(name="github", items=(item(1),)),
+        runs_read=SourceFailed(name="aios-runs", reason="connection refused"),
+    )
+    assert report.verdict == "ALARM"
+    assert report.counts is None
+    assert report.disagreements == ()  # no classification is even attempted
+
+
+def test_successful_empty_read_is_health_and_is_DISTINGUISHABLE_from_failure() -> None:
+    """'Read failed' vs 'read succeeded and found nothing' must never collapse."""
+    healthy = ok_report([], [])
+    assert healthy.verdict == "OK"
+    assert healthy.counts == dict.fromkeys(CLASSES, 0)
+    broken = build_report(
+        items_read=SourceFailed(name="github", reason="boom"),
+        runs_read=SourceOk(name="aios-runs", items=()),
+    )
+    assert broken.counts is None
+    assert healthy.disagreement_hash() != broken.disagreement_hash()
+
+
+def test_markdown_of_an_alarm_never_reads_as_a_clean_bill() -> None:
+    md = render_markdown(
+        build_report(
+            items_read=SourceFailed(name="github", reason="HTTP 403 rate limited"),
+            runs_read=SourceOk(name="aios-runs", items=()),
+        )
+    )
+    assert "ALARM" in md
+    assert "NOT a report of zero disagreements" in md
+    assert "HTTP 403 rate limited" in md
+    # The healthy vocabulary must be ABSENT — no table, no per-class zeros.
+    assert "| **ZOMBIE** |" not in md
+    assert "Read OK" not in md
+
+
+def test_missing_credentials_alarm_rather_than_skip_a_source() -> None:
+    """The 2026-07-25 failure exactly: a rejected credential rendered as 'nothing held'."""
+    report = reconcile(repos=["eumemic/aios"], github_token=None, aios_url=None, aios_api_key=None)
+    assert report.verdict == "ALARM"
+    assert report.counts is None
+    assert {f.name for f in report.failures} == {"github", "aios-runs"}
+
+
+def test_http_error_becomes_a_source_failure_not_an_empty_page() -> None:
+    def boom(url: str, headers: Any) -> Any:
+        raise ReadFailure(f"GET {url} → HTTP 500")
+
+    assert isinstance(read_github_items(["eumemic/aios"], token="t", getter=boom), SourceFailed)
+    assert isinstance(read_aios_runs(base_url="http://x", api_key="k", getter=boom), SourceFailed)
+
+
+def test_one_repo_failing_fails_the_WHOLE_github_source() -> None:
+    """A partial read is a lie shaped like health: the unread repo is where the zombies are."""
+    calls: list[str] = []
+
+    def getter(url: str, headers: Any) -> Any:
+        calls.append(url)
+        if "eumemic-ops" in url:
+            raise ReadFailure("HTTP 404")
+        return [], {}
+
+    result = read_github_items(["eumemic/aios", "eumemic/eumemic-ops"], token="t", getter=getter)
+    assert isinstance(result, SourceFailed)
+    assert "404" in result.reason
+
+
+def test_unparseable_body_is_a_read_failure_not_an_empty_result() -> None:
+    def getter(url: str, headers: Any) -> Any:
+        return {"not": "a list"}, {}
+
+    assert isinstance(read_github_items(["eumemic/aios"], token="t", getter=getter), SourceFailed)
+
+
+def test_runs_envelope_without_data_key_is_a_contract_failure() -> None:
+    def getter(url: str, headers: Any) -> Any:
+        return {"unexpected": []}, {}
+
+    result = read_aios_runs(base_url="http://x", api_key="k", getter=getter)
+    assert isinstance(result, SourceFailed)
+    assert "data" in result.reason
+
+
+def test_unexpected_row_shape_alarms_rather_than_silently_dropping_rows() -> None:
+    report = build_report(
+        items_read=SourceOk(name="github", items=(item(1), "not an item")),
+        runs_read=SourceOk(name="aios-runs", items=()),
+    )
+    assert report.verdict == "ALARM"
+    assert report.counts is None
+
+
+def test_cli_exit_code_is_2_on_alarm_and_never_0() -> None:
+    from aios.reconcilers import work_state_cli
+
+    code = work_state_cli.main(["--repo", "eumemic/aios", "--format", "json"])
+    assert code == 2  # no credentials in the test env ⇒ ALARM ⇒ non-zero
+
+
+# ─── (5) pagination: exhaustion, or an explicit floor ────────────────────────
+
+
+def test_page_cap_marks_the_source_non_exhaustive_and_counts_render_as_floors() -> None:
+    def getter(url: str, headers: Any) -> Any:
+        return [
+            {
+                "number": 1,
+                "title": "t",
+                "labels": [{"name": "dispatched"}],
+                "html_url": "u",
+                "updated_at": "",
+            }
+        ], {"Link": '<https://api.github.com/next>; rel="next"'}
+
+    items, exhaustive = fetch_repo_items("eumemic/aios", token="t", getter=getter, max_pages=3)
+    assert exhaustive is False
+    assert len(items) == 3
+
+    report = build_report(
+        items_read=SourceOk(name="github", items=tuple(items), exhaustive=False),
+        runs_read=SourceOk(name="aios-runs", items=()),
+    )
+    assert report.exhaustive is False
+    assert report.truncated_sources == ("github",)
+    md = render_markdown(report)
+    assert "FLOORS, not totals" in md
+    assert "at least" in md
+
+
+def test_link_header_pagination_is_followed_to_exhaustion() -> None:
+    pages = {
+        "https://api.github.com/repos/eumemic/aios/issues?state=open&per_page=100&sort=created&direction=desc": (
+            [
+                {
+                    "number": 1,
+                    "title": "a",
+                    "labels": [{"name": "dispatched"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ],
+            {"Link": '<https://api.github.com/p2>; rel="next"'},
+        ),
+        "https://api.github.com/p2": (
+            [
+                {
+                    "number": 2,
+                    "title": "b",
+                    "labels": [{"name": "approved"}],
+                    "html_url": "",
+                    "updated_at": "",
+                }
+            ],
+            {},
+        ),
+    }
+
+    def getter(url: str, headers: Any) -> Any:
+        return pages[url]
+
+    items, exhaustive = fetch_repo_items("eumemic/aios", token="t", getter=getter)
+    assert exhaustive is True
+    assert [i.number for i in items] == [1, 2]
+
+
+def test_next_link_parsing() -> None:
+    header = '<https://api.github.com/a?page=2>; rel="next", <https://api.github.com/a?page=9>; rel="last"'
+    assert _next_link({"Link": header}) == "https://api.github.com/a?page=2"
+    assert _next_link({}) is None
+    assert _next_link({"Link": '<https://x>; rel="last"'}) is None
+
+
+def test_items_without_pipeline_labels_are_filtered_but_all_open_items_are_enumerated() -> None:
+    """LAGGING is defined by the ABSENCE of `dispatched`, so we must not query by it."""
+    seen: list[str] = []
+
+    def getter(url: str, headers: Any) -> Any:
+        seen.append(url)
+        return [
+            {
+                "number": 1,
+                "title": "x",
+                "labels": [{"name": "bug"}],
+                "html_url": "",
+                "updated_at": "",
+            },
+            {
+                "number": 2,
+                "title": "y",
+                "labels": [{"name": "dispatched"}],
+                "html_url": "",
+                "updated_at": "",
+            },
+        ], {}
+
+    items, _ = fetch_repo_items("eumemic/aios", token="t", getter=getter)
+    assert [i.number for i in items] == [2]
+    assert all("labels=" not in url for url in seen)
+
+
+# ─── (6) change detection ────────────────────────────────────────────────────
+
+
+def test_hash_is_stable_under_ordering_and_run_id_churn() -> None:
+    a = ok_report([item(1), item(2)], [run("errored", number=1, run_id="r1")])
+    b = ok_report([item(2), item(1)], [run("errored", number=1, run_id="r99")])
+    assert a.disagreement_hash() == b.disagreement_hash()
+
+
+def test_hash_changes_when_a_run_transitions() -> None:
+    parked = ok_report([item(1)], [run("suspended")])
+    dead = ok_report([item(1)], [run("errored")])
+    assert parked.disagreement_hash() != dead.disagreement_hash()
+
+
+def test_hash_changes_when_an_item_joins_or_leaves_the_set() -> None:
+    one = ok_report([item(1)], [])
+    two = ok_report([item(1), item(2)], [])
+    assert one.disagreement_hash() != two.disagreement_hash()
+
+
+def test_alarm_hash_is_driven_by_failure_reasons_so_a_new_outage_wakes_the_seat() -> None:
+    def alarm(reason: str) -> ReconcileReport:
+        return build_report(
+            items_read=SourceFailed(name="github", reason=reason),
+            runs_read=SourceOk(name="aios-runs", items=()),
+        )
+
+    assert alarm("HTTP 500").disagreement_hash() == alarm("HTTP 500").disagreement_hash()
+    assert alarm("HTTP 500").disagreement_hash() != alarm("HTTP 403").disagreement_hash()
+
+
+# ─── (7) the eumemic-company#71 shape: a ZOMBIE with linked PRs ──────────────
+
+
+def test_zombie_with_linked_prs_is_flagged_as_suspect_join_key() -> None:
+    """'No run ever' + 'a PR exists' cannot both be true of healthy work."""
+    (d,) = ok_report([item(71, repo="eumemic/eumemic-company", linked=(72, 73))], []).disagreements
+    assert d.classification == "ZOMBIE"
+    assert "has-linked-prs" in d.caveats
+    assert "#72" in d.detail and "verify the join key" in d.detail
+    assert "⚠️" in render_markdown(ok_report([item(71, linked=(72,))], []))
+
+
+# ─── (8) OBSERVE-ONLY: the phase-1 hard constraint ──────────────────────────
+
+
+def test_transport_refuses_any_verb_other_than_GET() -> None:
+    with pytest.raises(ObserveOnlyViolation):
+        _get("https://api.github.com/repos/eumemic/aios/issues/1", {}, method="PATCH")
+    with pytest.raises(ObserveOnlyViolation):
+        _get("https://api.github.com/repos/eumemic/aios/issues/1", {}, method="POST")
+
+
+def test_reconciler_source_contains_no_mutating_github_call() -> None:
+    """A grep-level guard: the reconciler must never grow a write path."""
+    for path in (
+        Path("src/aios/reconcilers/work_state.py"),
+        Path("src/aios/reconcilers/work_state_cli.py"),
+        Path("infra/workflows/work-state-reconciler.wf.py"),
+    ):
+        source = path.read_text()
+        for verb in ('"POST"', '"PATCH"', '"PUT"', '"DELETE"'):
+            offenders = [
+                line
+                for line in source.splitlines()
+                if verb in line and "refus" not in line.lower() and "method !=" not in line
+            ]
+            assert not offenders, f"{path} may mutate: {offenders}"
+
+
+def test_report_records_zero_writes() -> None:
+    report = reconcile(repos=[], github_token=None, aios_url=None, aios_api_key=None)
+    assert report.meta["writes_performed"] == 0
+    assert report.meta["phase"] == "1-observe-only"
+
+
+# ─── (9) drift guards ────────────────────────────────────────────────────────
+
+
+def test_status_vocabulary_matches_the_models_source_of_truth() -> None:
+    """The reconciler restates WfRunStatus (the script host can't import aios.*);
+    this test is what stops a new status from silently falling through."""
+    from typing import get_args
+
+    assert RECON_TERMINAL == TERMINAL_RUN_STATUSES
+    assert set(get_args(WfRunStatus)) == LIVE_RUN_STATUSES | SUSPENDED_RUN_STATUSES | RECON_TERMINAL
+
+
+def test_default_repos_cover_the_org_set_named_in_2043() -> None:
+    assert set(DEFAULT_REPOS) >= {
+        "eumemic/aios",
+        "eumemic/eumemic-ops",
+        "eumemic/eumemic-company",
+        "eumemic/aios-console",
+        "eumemic/autodev",
+    }
+
+
+def test_pipeline_label_predicate() -> None:
+    assert is_pipeline_state_label("dispatched")
+    assert is_pipeline_state_label("needs:human/review")
+    assert not is_pipeline_state_label("bug")
+
+
+# ─── (10) the workflow-script mirror agrees with the library core ───────────
+
+
+def _load_wf_module() -> Any:
+    path = Path("infra/workflows/work-state-reconciler.wf.py")
+    spec = importlib.util.spec_from_file_location("wf_work_state", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_SCENARIOS: list[tuple[str, tuple[str, ...], list[str]]] = [
+    ("ZOMBIE", ("dispatched",), []),
+    ("DEAD", ("dispatched",), ["completed"]),
+    ("DEAD", ("dispatched",), ["errored", "cancelled"]),
+    ("MISLABELLED", ("dispatched",), ["suspended"]),
+    ("MISLABELLED", ("dispatched",), ["completed", "suspended"]),
+    ("LAGGING", ("approved",), ["running"]),
+    ("", ("dispatched",), ["running"]),
+    ("", ("dispatched",), ["errored", "running"]),
+    ("", ("approved",), ["completed"]),
+]
+
+
+@pytest.mark.parametrize(("expected", "labels", "statuses"), _SCENARIOS)
+def test_workflow_script_mirror_classifies_identically(
+    expected: str, labels: tuple[str, ...], statuses: list[str]
+) -> None:
+    wf = _load_wf_module()
+    lib_verdict = classify_item(
+        item(1, labels=labels), [run(s, run_id=f"r{n}") for n, s in enumerate(statuses)]
+    )
+    wf_verdict = wf.classify(
+        {
+            "repo": "eumemic/aios",
+            "number": 1,
+            "kind": "issue",
+            "title": "item 1",
+            "labels": list(labels),
+            "url": "",
+            "updated_at": "",
+        },
+        [{"id": f"r{n}", "status": s} for n, s in enumerate(statuses)],
+    )
+    assert (lib_verdict.classification if lib_verdict else "") == expected
+    assert (wf_verdict["classification"] if wf_verdict else "") == expected
+
+
+def test_workflow_script_alarms_with_null_counts_on_failure() -> None:
+    wf = _load_wf_module()
+    report = wf.build([], True, [], True, [{"source": "github", "reason": "HTTP 500"}])
+    assert report["verdict"] == "ALARM"
+    assert report["counts"] is None
+    assert report["total_disagreements"] is None
+
+
+def test_workflow_script_and_library_agree_on_the_hash() -> None:
+    """Both forms must produce the SAME change-detection hash for the same world."""
+    wf = _load_wf_module()
+    items = [item(2000), item(337, repo="eumemic/eumemic-ops")]
+    runs = [run("suspended", number=2000, run_id="r1")]
+    lib = ok_report(items, runs)
+    wf_report = wf.build(
+        [
+            {
+                "repo": i.repo,
+                "number": i.number,
+                "kind": i.kind,
+                "title": i.title,
+                "labels": list(i.labels),
+                "url": i.html_url,
+                "updated_at": i.updated_at,
+            }
+            for i in items
+        ],
+        True,
+        [
+            {
+                "id": r.run_id,
+                "status": r.status,
+                "input": {"repo": r.repo, "issue_number": r.issue_number},
+            }
+            for r in runs
+        ],
+        True,
+        [],
+    )
+    assert wf_report["counts"] == dict(lib.counts or {})
+    assert wf.disagreement_hash(wf_report) == lib.disagreement_hash()
+
+
+def test_workflow_script_validates_against_its_declared_surface() -> None:
+    """The script must pass create-time validation with exactly the tools it declares."""
+    from aios.models.agents import ToolSpec
+    from aios.workflows.script_validation import validate_workflow_script
+
+    script = Path("infra/workflows/work-state-reconciler.wf.py").read_text()
+    validate_workflow_script(script, [ToolSpec(type="http_request"), ToolSpec(type="list_runs")])
+
+
+def test_workflow_script_makes_no_model_or_agent_calls() -> None:
+    """#2043: the reconciler is MECHANICAL. Intelligence is reserved for judgment."""
+    script = Path("infra/workflows/work-state-reconciler.wf.py").read_text()
+    for forbidden in ("agent(", "llm(", "await agent", "prompt("):
+        assert forbidden not in script
+
+
+# ─── (11) end-to-end shape on the known-zombie fixture ──────────────────────
+
+
+def test_end_to_end_on_the_known_2043_zombie_set() -> None:
+    """The #2043 sanity set: if the reconciler finds nothing here, the CODE is wrong."""
+    known = [
+        ("eumemic/aios", 2000),
+        ("eumemic/eumemic-ops", 337),
+        ("eumemic/eumemic-ops", 331),
+        ("eumemic/eumemic-company", 210),
+        ("eumemic/eumemic-company", 199),
+        ("eumemic/eumemic-company", 192),
+        ("eumemic/eumemic-company", 166),
+        ("eumemic/eumemic-company", 151),
+        ("eumemic/eumemic-company", 147),
+        ("eumemic/eumemic-company", 135),
+        ("eumemic/eumemic-company", 71),
+        ("eumemic/eumemic-company", 50),
+        ("eumemic/aios-console", 166),
+        ("eumemic/aios-console", 12),
+    ]
+    items = [
+        item(n, repo=r, labels=("approved", "dispatched"), linked=((72,) if n == 71 else ()))
+        for r, n in known
+    ]
+    report = ok_report(items, [run("running", repo="eumemic/aios", number=1)])
+    counts = report.counts
+    assert counts is not None
+    assert counts["ZOMBIE"] == 14
+    assert {(d.repo, d.number) for d in report.by_class("ZOMBIE")} == set(known)
+    # #71 is the designed-in check on the join logic, not a silent pass.
+    (suspect,) = [d for d in report.disagreements if d.number == 71]
+    assert suspect.caveats == ("has-linked-prs",)
+    payload = json.loads(render_json(report))
+    assert payload["verdict"] == "OK"
+    assert payload["counts"]["ZOMBIE"] == 14
+    assert "ZOMBIE (14)" in render_markdown(report)
+
+
+def test_disagreements_are_sorted_by_class_then_repo_then_number() -> None:
+    items = [
+        item(9, labels=("approved",)),
+        item(5),
+        item(3, repo="eumemic/aios-console"),
+    ]
+    runs = [run("running", number=9)]
+    got = [(d.classification, d.repo, d.number) for d in ok_report(items, runs).disagreements]
+    assert got == [
+        ("ZOMBIE", "eumemic/aios", 5),
+        ("ZOMBIE", "eumemic/aios-console", 3),
+        ("LAGGING", "eumemic/aios", 9),
+    ]
+
+
+def test_report_to_dict_round_trips_as_json() -> None:
+    payload = json.loads(render_json(ok_report([item(1)], [run("suspended")])))
+    assert payload["disagreements"][0]["classification"] == "MISLABELLED"
+    assert isinstance(payload["disagreement_hash"], str)
+    assert payload["exhaustive"] is True
+    assert payload["failures"] == []
+    # The healthy shape carries real counts; the ALARM shape carries null. Never both.
+    assert payload["counts"]["MISLABELLED"] == 1
+
+
+def test_disagreement_identity_excludes_run_ids() -> None:
+    a = Disagreement(
+        classification="DEAD",
+        repo="r",
+        number=1,
+        kind="issue",
+        title="t",
+        html_url="",
+        labels=(),
+        detail="",
+        run_ids=("r1",),
+        run_statuses=("errored",),
+    )
+    b = a.__class__(**{**a.__dict__, "run_ids": ("r2",)})
+    assert a.identity() == b.identity()

--- a/tests/unit/test_work_state_reconciler.py
+++ b/tests/unit/test_work_state_reconciler.py
@@ -930,7 +930,8 @@ def test_B1_has_more_with_an_unusable_cursor_is_a_READ_FAILURE() -> None:
     and reported exhaustive=True — a truncated read rendered as exhaustive, which is the
     2026-07-25 failure mode this PR exists to kill. Every ZOMBIE rests on 'no run in the
     list I read', so an unread page manufactures false ZOMBIEs."""
-    for bad_cursor in (None, "", 0, {}):
+    bad_cursors: tuple[object, ...] = (None, "", 0, {})
+    for bad_cursor in bad_cursors:
 
         def getter(url: str, headers: Any, _c: Any = bad_cursor) -> Any:
             return (

--- a/tests/unit/test_work_state_reconciler.py
+++ b/tests/unit/test_work_state_reconciler.py
@@ -1113,9 +1113,7 @@ def test_C4_the_INVERTED_probe_finds_a_transfer_from_a_REALIZABLE_world() -> Non
 
     report = build_report(
         items_read=source,
-        runs_read=SourceOk(
-            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
-        ),
+        runs_read=SourceOk(name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)),
         transfers=transfers,
     )
 
@@ -1179,9 +1177,7 @@ def test_C4_the_OLD_probe_direction_could_not_have_seen_this_world() -> None:
     assert not any("issues/71" in p for p in enum_paths)
     blind = build_report(
         items_read=source,
-        runs_read=SourceOk(
-            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
-        ),
+        runs_read=SourceOk(name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)),
     )
     assert (blind.counts or {})["ZOMBIE"] == 1, (
         "this fixture must reproduce the FALSE ZOMBIE, or it is not testing the defect"
@@ -1191,9 +1187,7 @@ def test_C4_the_OLD_probe_direction_could_not_have_seen_this_world() -> None:
     _s, transfers, _p = _cli_reader(world, ["eumemic/eumemic-ops"], runs)
     fixed = build_report(
         items_read=_s,
-        runs_read=SourceOk(
-            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
-        ),
+        runs_read=SourceOk(name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)),
         transfers=transfers,
     )
     assert (fixed.counts or {})["ZOMBIE"] == 0
@@ -1241,9 +1235,7 @@ def test_C4_a_stale_key_that_resolves_to_ITSELF_is_not_a_transfer() -> None:
     assert transfers == ()
     report = build_report(
         items_read=source,
-        runs_read=SourceOk(
-            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
-        ),
+        runs_read=SourceOk(name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)),
         transfers=transfers,
     )
     assert (report.counts or {})["ZOMBIE"] == 1, "a real zombie must stay a zombie"
@@ -1256,6 +1248,7 @@ def test_C4_probe_read_error_is_a_NOTE_not_an_ALARM() -> None:
     It must not ALARM the whole reconcile — but it must not be silent either, since an
     unprobed key is a transfer we did not look for.
     """
+
     def getter(url: str, headers: Any) -> Any:
         raise ReadFailure(f"GET {url} → HTTP 404: gone")
 
@@ -1271,12 +1264,11 @@ def test_C4_probe_read_error_is_a_NOTE_not_an_ALARM() -> None:
 
 def test_C4_probe_cap_is_reported_as_a_gap_not_ignored() -> None:
     """Hitting the probe ceiling says so. An unprobed key is an unseen transfer."""
+
     def getter(url: str, headers: Any) -> Any:
         return {"number": 1, "url": url}, {}
 
-    runs = [
-        run("completed", repo="eumemic/aios", number=n, run_id=f"r{n}") for n in range(10, 20)
-    ]
+    runs = [run("completed", repo="eumemic/aios", number=n, run_id=f"r{n}") for n in range(10, 20)]
     transfers, notes = probe_stale_keys([], runs, token="t", getter=getter, max_probes=3)
     assert transfers == ()
     assert any("capped at 3 of 10" in n and "NOT probed" in n for n in notes)
@@ -1325,6 +1317,7 @@ def test_ITEM2_transfer_notes_are_folded_into_the_disagreement_hash() -> None:
     newly-discovered transfer as "unchanged, nothing to say" and stay silent about the
     exact fact a triager needs.
     """
+
     def report(transfers: tuple[TransferEvidence, ...]) -> ReconcileReport:
         return build_report(
             items_read=SourceOk(name="github", items=()),
@@ -1352,6 +1345,7 @@ def test_ITEM2_transfer_notes_are_folded_into_the_disagreement_hash() -> None:
 
 def test_ITEM2_transfer_notes_change_the_hash_on_the_ALARM_path_too() -> None:
     """An outage must not mask a newly-discovered stale key."""
+
     def alarm(transfers: tuple[TransferEvidence, ...]) -> ReconcileReport:
         return build_report(
             items_read=SourceFailed(name="github", reason="HTTP 500"),
@@ -1610,15 +1604,11 @@ def _assert_forms_agree(
     """
     runs = runs or []
     source, cli_transfers, cli_paths = _cli_reader(world, repos, runs)
-    (wf, wf_items, wf_exhaustive, wf_notes, wf_transfers), wf_paths = _wf_reader(
-        world, repos, runs
-    )
+    (wf, wf_items, wf_exhaustive, wf_notes, wf_transfers), wf_paths = _wf_reader(world, repos, runs)
 
     lib_report = build_report(
         items_read=source,
-        runs_read=SourceOk(
-            name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)
-        ),
+        runs_read=SourceOk(name="aios-runs", items=tuple(run_record_from_payload(r) for r in runs)),
         transfers=cli_transfers,
     )
     wf_report = wf.build(wf_items, wf_exhaustive, runs, True, [], wf_notes, wf_transfers)
@@ -1981,7 +1971,13 @@ def test_C4_mirror_probe_read_error_is_a_NOTE_not_an_ALARM() -> None:
     transfers, notes = asyncio.run(
         wf._probe_stale_keys(
             [],
-            [{"id": "r_x", "status": "completed", "input": {"repo": "eumemic/aios", "issue": 4242}}],
+            [
+                {
+                    "id": "r_x",
+                    "status": "completed",
+                    "input": {"repo": "eumemic/aios", "issue": 4242},
+                }
+            ],
         )
     )
     assert transfers == []


### PR DESCRIPTION
Closes #2043 (phase 1).

## The defect

**A GitHub label is an assertion that nothing re-checks against the world.** `dispatched` is a sticker: it stays stuck whether or not any machine ever picked the work up. Measured on 2026-07-25, **14 issues across the org carried `dispatched` + `approved` with no run and no PR**, up to 12 days old — including a fix for a defect taxing every agent daily and an explicit chairman directive. The stall detectors could not see them **because they read labels too**: a detector that consumes the same asserted state it is meant to check is not a detector.

The truth already exists. The dev pipeline is a durable aios workflow with **one run per issue** — `run.input` carries `{repo, issue_number}`, `run.status` carries live state. Nothing joined the two. **This PR is the join.**

## What's here

| file | role |
|---|---|
| `src/aios/reconcilers/work_state.py` | **Pure** core: dataclasses, join, classifier, hash. No network, no clock, no env — fully unit-testable offline, deterministic, re-runnable. |
| `src/aios/reconcilers/work_state_cli.py` | I/O shell: reads GitHub + the aios API, wraps every read so failure becomes a `SourceFailed`. |
| `infra/workflows/work-state-reconciler.wf.py` | The durable workflow form (the script host can't import `aios.*`, so the logic is mirrored — and drift-guarded, see below). |
| `tests/unit/test_work_state_reconciler.py` | 70 tests. |

The reconciler is **deterministic**: no model calls, no agents. Joining two lists is mechanical computation; intelligence is reserved for judgment. A test asserts the workflow script contains no `agent(`/`llm(` call so that stays true.

## Classification logic

| label says | runs say | class |
|---|---|---|
| `dispatched` | a live run exists | *agree* (no output) |
| `dispatched` | **no run, ever** | **ZOMBIE** |
| `dispatched` | every run terminal | **DEAD** |
| `dispatched` | run suspended at a gate | **MISLABELLED** |
| no `dispatched` | a live run exists | **LAGGING** |

Precedence is **live > suspended > terminal**, and it matters:

- **One live run wins.** A re-dispatch leaves dead runs behind; if anything is live, work really is happening, whatever the corpses say.
- **Parked is NOT running.** A `suspended` run is waiting on a human at a gate — a *different condition* from running, so it gets its own class rather than being folded into "agree". That fold is precisely how a gate-parked item hides behind `dispatched` forever.
- **An unrecognised status is never asserted DEAD.** It classifies as MISLABELLED with an `unrecognised-run-status` caveat. A false DEAD is a false alarm, and false alarms train people to ignore the report.

Two things are deliberately *not* silently dropped, because each would manufacture a phantom "agree" or a false ZOMBIE:

- A run whose `run.input` yields no usable `(repo, issue_number)` is reported under **`unmatched_runs`**, never skipped.
- A live run keyed to an item that isn't open is reported there too — so a **broken join surfaces as data** instead of as a quietly-shrinking count.

The join key normaliser accepts every shape months of dispatchers actually wrote (`owner/name`, bare `name`, GitHub URLs, `{owner, name}`, `"#337"`, `"337"`) and returns `None` rather than guessing when it can't parse — a wrong guess is a phantom agreement.

Enumeration lists **all** open items and filters locally rather than querying `?labels=dispatched`: **LAGGING is defined by the absence of that label**, so a query narrowed to it is structurally incapable of finding it. Same shape as the bug being fixed.

## How fail-loud is enforced (the criterion that outranks the feature)

An empty result from a broken query rendering as health happened **twice on 2026-07-25**. That is the bug class this whole effort exists to kill, so it's closed **structurally, at the type level** — not by discipline at call sites:

1. **"Read failed" and "read succeeded and found nothing" are different *types*.** `SourceOk` carries `items` (possibly empty — real health); `SourceFailed` carries **no items at all**. A failed read cannot be iterated into "0 disagreements" because there is nothing to iterate.
2. **`counts` is `None` on ALARM** — not `{}`, not zeros. There is *no count to render*. A caller wanting to print "0 disagreements" is forced to handle ALARM first.
3. **`build_report` inspects the source objects, not their contents.** Any `SourceFailed` ⇒ ALARM immediately; no classification is attempted.
4. **One repo failing fails the whole GitHub source.** No per-repo `continue` — a partial read is a lie shaped like health, and the unread repo is exactly where the disagreements might be.
5. **Missing credentials are a read failure, not a skipped source.** (This is the 2026-07-25 failure verbatim: a rejected credential rendered as "nothing held".)
6. A 200 with an unparseable body, a missing `data`/`runs` envelope key, an unexpected row type, or a truncated HTTP response are all **read failures**, not empty pages.
7. **No bare `except: pass`, no exit-0-on-error.** CLI exits `2` on ALARM, `3` on `--fail-on-disagreement`, `0` only on a genuinely successful read.
8. **Pagination to exhaustion, or an explicit floor.** Hitting a page cap marks the source non-exhaustive; every count then renders as "at least N" with a warning banner. Never a silent partial total.
9. **The ALARM markdown cannot read as a clean bill** — it prints "This is NOT a report of zero disagreements", and a test asserts the healthy vocabulary (the counts table, "Read OK") is absent from it.

Change detection hashes the disagreement **set** by identity = class + item + run *statuses* (not run ids), so a re-dispatch producing the same verdict for the same reason doesn't spam the seat, while a real transition (suspended → errored) does. On ALARM the hash folds in failure reasons, so a **new** outage still wakes the seat — silence is never health.

## Observe-only — the phase-1 hard constraint

**Zero mutations of the reconciled issues/PRs.** No label edits, no comments on them, no re-dispatch, no closes. Enforced at the *only door to the network*: `_get` raises `ObserveOnlyViolation` on any verb but GET, in both the CLI and the workflow form, so a future "while we're here, just fix the label" edit fails loudly instead of shipping. A grep-level test asserts no mutating verb appears in any of the three files, and the report records `writes_performed: 0`. Phase 2 (demotion) is gated on reviewing a week of phase-1 data.

## Sanity check against reality

Ran the GitHub side live across all five repos (`exhaustive=True`, 64 pipeline-labelled open items, **17 carrying `dispatched`**). It surfaced **all 14** issues named in #2043 — aios#2000, eumemic-ops#337/#331, eumemic-company#210/#199/#192/#166/#151/#147/#135/#71/#50, aios-console#166/#12 — plus aios#919, aios#2037 and eumemic-company#183, which carry `autodev:built` and are worth triaging.

**eumemic-company#71 is handled as the issue predicted.** It has linked PRs, so "no run ever" and "a PR exists" can't both be true of healthy work. Rather than silently counting it as a zombie, the reconciler reads the issue timeline and attaches a `has-linked-prs` caveat plus "verify the join key before believing this" to the finding — the designed-in check on the join logic, kept as a first-class output.

**Not verified live:** the runs half of the join. This sandbox has no aios API credential (`AIOS_URL`/`AIOS_API_KEY` unset, and the tool broker exposes no HTTP surface), so I could not execute a real `list_runs` against `wf_01KV4YGV4PSGP08TJBAY32J2VK`. The run-side reader and the join are covered by unit tests with fixture payloads; **the first real run should be checked by a human before phase 2 is built on its output.** Notably, running it here with no credentials produced `verdict: ALARM` with `counts: null` and exit 2 — which is the correct behaviour and the reason I can state this limitation rather than having shipped a green "0 disagreements".

## Drift guards

The workflow-script mirror is bound to the library core by tests that run **the same fixtures through both** and assert identical classifications and an identical hash. The status vocabulary (`LIVE`/`SUSPENDED`/`TERMINAL`) is asserted to match `WfRunStatus` and `TERMINAL_RUN_STATUSES` exactly, so a newly added run status can't silently fall through the classifier. The workflow script is also run through `validate_workflow_script` against its declared surface (`http_request`, `list_runs`).

## Checks

- `ruff check` + `ruff format --check` — clean
- `mypy` — clean (strict, 4 files)
- `pytest tests/unit/test_work_state_reconciler.py` + the workflow-script validation suites — **93 passed**
- The full `tests/unit` suite exceeded the sandbox time budget; CI should run it.

**DO NOT MERGE** — phase 1 is observe-only by design; please review the classification precedence and the fail-loud contract before this starts reporting.


## Known residual (ITEM 3 — NOT done)

**The drift guard is still hand-maintained marker matching, and it cannot catch a capability that NEITHER form has.** That is exactly the hole C4 fell through: both forms agreed, both were wrong, and the guard was structurally incapable of noticing because it only ever compares the two forms *to each other*. Deriving the capability set from the code (so an unreachable-signal capability is detectable) was **not attempted** in this pass and remains open.

What this pass *did* strengthen, so the boundary is clear:

- the guard now drives the C4 stale-key probe through **both** transports and compares the structured `TransferEvidence` field-for-field, not just prose notes — so a C4 that exists in only one form still cannot ship;
- `test_C4_the_OLD_probe_direction_could_not_have_seen_this_world` pins the *realizability* of the C4 fixture specifically, by asserting the old probe direction reproduces the false ZOMBIE. This is a one-off assertion about C4, **not** a general mechanism: nothing prevents the next capability from being tested against an impossible world.

Deliberately left whole rather than half-finished — a partial guard that reads as a complete one is worse than none.
