### PR TITLE
Unrestricted networking: credential-host egress stays fail-open for an address the DNS sampler never saw (#331 residual)

### DIFF
--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -131,6 +131,9 @@ class SandboxSpec:
     # default runtime in place (local/CI no-op); DockerBackend translates a value
     # such as ``runsc`` into ``docker run --runtime runsc``.
     runtime: str | None = None
+    # Credential names are resolved by a worker-controlled resolver on loopback.
+    # Empty means Docker's ordinary resolver remains unchanged.
+    credential_hosts: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -50,6 +50,7 @@ from aios.sandbox.backends.base import (
     SnapshotOutcome,
     split_label_list,
 )
+from aios.sandbox.credential_dns import CREDENTIAL_DNS_IP
 from aios.sandbox.network import SANDBOX_NETWORK_NAME
 
 log = get_logger("aios.sandbox.backends.docker")
@@ -195,6 +196,10 @@ class DockerBackend:
             argv.extend(["--label", f"{key}={value}"])
 
         argv.extend(["--network", SANDBOX_NETWORK_NAME])
+        if spec.credential_hosts:
+            # The resolver sidecar joins this netns and binds loopback:53. Docker
+            # writes this server into resolv.conf before the sandbox starts.
+            argv.extend(["--dns", CREDENTIAL_DNS_IP])
 
         # NB: the sandbox is NOT granted ``--cap-add NET_ADMIN`` (durable
         # session sandboxes, §5.8). The Limited-policy iptables lockdown is
@@ -907,6 +912,48 @@ class DockerBackend:
     async def image_labels(self, image: str) -> dict[str, str] | None:
         fields = await self._inspect_image_fields(image)
         return None if fields is None else fields[3]
+
+    async def start_credential_resolver(
+        self,
+        target_sandbox_id: str,
+        *,
+        image: str,
+        hosts: list[str],
+        runtime: str | None = None,
+    ) -> None:
+        """Start the authoritative credential resolver in the sandbox netns."""
+        argv = [
+            "docker",
+            "run",
+            "--detach",
+            "--rm",
+            "--network",
+            f"container:{target_sandbox_id}",
+            # Joining the target's PID namespace ties resolver lifetime to PID 1:
+            # Docker kills namespace peers when the sandbox exits, and --rm then
+            # removes the resolver container instead of leaking it.
+            "--pid",
+            f"container:{target_sandbox_id}",
+        ]
+        if runtime:
+            argv.extend(["--runtime", runtime])
+        argv.extend(
+            [
+                image,
+                "python",
+                "-m",
+                "aios.sandbox.credential_dns",
+                "--upstream",
+                "127.0.0.11",
+                *hosts,
+            ]
+        )
+        rc, _, stderr, timed_out = await run_subprocess_with_timeout(argv, timeout_s=15)
+        if timed_out or rc != 0:
+            raise SandboxBackendError(
+                "credential resolver failed to start: "
+                + stderr.decode("utf-8", errors="replace").strip()
+            )
 
     async def run_netns_sidecar(
         self,

--- a/src/aios/sandbox/credential_dns.py
+++ b/src/aios/sandbox/credential_dns.py
@@ -1,0 +1,101 @@
+"""Per-sandbox name policy for credential-bearing HTTPS destinations."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import socket
+import struct
+from collections.abc import Iterable
+
+CREDENTIAL_HOST_IP = "192.0.2.1"
+CREDENTIAL_DNS_IP = "127.0.0.53"
+
+
+def _question_name(packet: bytes) -> tuple[str, int]:
+    labels: list[str] = []
+    offset = 12
+    while offset < len(packet):
+        size = packet[offset]
+        offset += 1
+        if size == 0:
+            return ".".join(labels).lower(), offset + 4
+        if size & 0xC0 or offset + size > len(packet):
+            raise ValueError("compressed or invalid DNS question")
+        labels.append(packet[offset : offset + size].decode("ascii"))
+        offset += size
+    raise ValueError("unterminated DNS question")
+
+
+def credential_answer(packet: bytes, hosts: Iterable[str]) -> bytes | None:
+    """Return a synthetic A response when ``packet`` asks for a credential host."""
+    if len(packet) < 12 or struct.unpack("!H", packet[4:6])[0] != 1:
+        return None
+    host, question_end = _question_name(packet)
+    qtype, qclass = struct.unpack("!HH", packet[question_end - 4 : question_end])
+    if host not in hosts or qtype != 1 or qclass != 1:
+        return None
+    flags = 0x8180
+    header = packet[:2] + struct.pack("!HHHHH", flags, 1, 1, 0, 0)
+    answer = b"\xc0\x0c" + struct.pack("!HHIH", 1, 1, 0, 4) + socket.inet_aton(CREDENTIAL_HOST_IP)
+    return header + packet[12:question_end] + answer
+
+
+class CredentialDnsProtocol(asyncio.DatagramProtocol):
+    """Authoritative for credential names; forwards every other DNS packet."""
+
+    def __init__(self, hosts: Iterable[str], upstream: tuple[str, int]) -> None:
+        self.hosts = frozenset(host.lower() for host in hosts)
+        self.upstream = upstream
+        self.transport: asyncio.DatagramTransport | None = None
+        self.tasks: set[asyncio.Task[None]] = set()
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        assert isinstance(transport, asyncio.DatagramTransport)
+        self.transport = transport
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        try:
+            answer = credential_answer(data, self.hosts)
+        except (ValueError, UnicodeDecodeError):
+            return
+        if answer is not None:
+            assert self.transport is not None
+            self.transport.sendto(answer, addr)
+            return
+        task = asyncio.create_task(self._forward(data, addr))
+        self.tasks.add(task)
+        task.add_done_callback(self.tasks.discard)
+
+    async def _forward(self, data: bytes, addr: tuple[str, int]) -> None:
+        loop = asyncio.get_running_loop()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setblocking(False)
+        try:
+            await loop.sock_sendto(sock, data, self.upstream)
+            response = await asyncio.wait_for(loop.sock_recv(sock, 65535), timeout=5)
+            if self.transport is not None:
+                self.transport.sendto(response, addr)
+        finally:
+            sock.close()
+
+
+async def _serve(hosts: list[str], upstream: str) -> None:
+    loop = asyncio.get_running_loop()
+    await loop.create_datagram_endpoint(
+        lambda: CredentialDnsProtocol(hosts, (upstream, 53)),
+        local_addr=("0.0.0.0", 53),
+    )
+    await asyncio.Future()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--upstream", required=True)
+    parser.add_argument("hosts", nargs="+")
+    args = parser.parse_args()
+    asyncio.run(_serve(args.hosts, args.upstream))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -37,7 +37,7 @@ import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from aios.config import get_settings
 from aios.db import queries
@@ -844,6 +844,17 @@ class SandboxRegistry:
 
         networking = plan.env_config.networking if plan.env_config else None
         dnat_hosts, dnat_target = self._secret_dnat(plan)
+
+        if dnat_target is not None:
+            # Resolver startup is part of the security gate in both network
+            # modes: failure propagates and provision tears the sandbox down.
+            resolver_backend = cast(Any, self._backend)
+            await resolver_backend.start_credential_resolver(
+                handle.sandbox_id,
+                image=get_settings().docker_image,
+                hosts=dnat_hosts,
+                runtime=plan.spec.runtime,
+            )
 
         if isinstance(networking, LimitedNetworking):
             extra_host_ports: list[tuple[str, int]] = [

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -49,6 +49,7 @@ from aios.config import get_settings
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking, PackageManager
 from aios.sandbox.backends.base import SandboxBackend, SandboxBackendError, SandboxHandle
+from aios.sandbox.credential_dns import CREDENTIAL_HOST_IP
 from aios.sandbox.egress_ca import CA_CERT_SANDBOX_PATH, get_egress_ca
 from aios.sandbox.env_keys import PATH_ENV_KEY
 
@@ -289,54 +290,10 @@ _RESOLVE_IPV4_FN = (
 )
 
 
-# KNOWN RESIDUAL — credential-host egress fails OPEN under Unrestricted
-# networking (eumemic/aios#2042). Documented here, deliberately NOT
-# half-mitigated here.
-#
-# The credential-host rules below are the nat-OUTPUT DNAT redirect, and they are
-# generated ONLY for RESOLVED (learned) addresses: the ``for ip in $(resolve_ipv4
-# <host>)`` loop installs one rule per address the sidecar's DNS query happened
-# to return. A rotating pool — api.github.com serves a ~60s-TTL set and returns
-# only a SUBSET per query — means that set is a SAMPLE, not the pool.
-#
-# Consequence, stated as the failure it is:
-#
-#   * LIMITED networking is closed. An unsampled address matches no DNAT and no
-#     per-host ACCEPT, so it falls through to the terminal ``-P OUTPUT DROP``.
-#     Nothing leaves.
-#   * UNRESTRICTED networking is OPEN. The filter policy stays ``ACCEPT``, so an
-#     unsampled address matches no DNAT and egresses DIRECTLY to the real
-#     upstream carrying the literal ``AIOS_SECRET_PLACEHOLDER_*`` — never
-#     reaching the secret-egress proxy, so neither the swap nor the #331
-#     fail-loud fence in ``secret_egress_proxy.py`` ever runs on it.
-#
-# Why nothing is done about it HERE. An earlier round of this PR added a
-# per-credential-host filter REJECT for the learned addresses and called it a
-# fence. It was withdrawn on review, and the reasoning is worth keeping because
-# it is the reason this block is a comment and not code: that rule is IP-keyed
-# exactly like the DNAT, so its coverage is exactly the same sample, and the
-# unsampled address — the ordinary case against a rotating pool, not an exotic
-# one — walks past it. It reads as a fence to the next person who greps for one
-# while leaving the hole open. A DOCUMENTED hole is safer than a DISGUISED one:
-# a reader who finds this comment knows the exposure is live, whereas a reader
-# who finds a REJECT rule reasonably concludes it is closed. More DNS probing
-# has the same defect one level down — it narrows the window and cannot close
-# it, so it would be mitigation theatre with a security-shaped name.
-#
-# The correct shape INVERTS the default for credential hosts: deny-by-default
-# with the learned set as an ALLOW-list, rather than allow-by-default with the
-# learned set as a fence. That cannot be decided at the IP layer for an address
-# we have never seen; it needs name-based interception (a worker-controlled
-# resolver answering credential hosts with the proxy address, or an in-netns
-# SNI-aware TPROXY on :443). eumemic/aios#2042 carries the four options
-# considered and why each is a larger change than this PR.
-#
-# The residual is pinned BEHAVIOURALLY, not only in prose:
-# ``TestCredentialHostEgressVerdict`` (tests/unit/test_networking.py) runs the
-# real generated script against recording ``iptables``/``getent`` shims and
-# replays the ruleset against a packet — asserting Limited BLOCKS an unsampled
-# address and that Unrestricted still routes it DIRECT. That assertion failing
-# is the acceptance signal for #2042, not a regression.
+# Credential-host policy is name based (#2042). A worker-controlled resolver
+# maps every credential host to CREDENTIAL_HOST_IP, and the generated DNAT rule
+# maps that stable synthetic destination to the secret-egress proxy. Upstream
+# pool addresses are never sampled or admitted into the credential policy.
 
 
 def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> list[str]:
@@ -377,13 +334,14 @@ def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> 
         f"PROXY_IP=$(resolve_ipv4 {proxy_alias} | head -n1)",
         'if [ -n "$PROXY_IP" ]; then',
     ]
-    for host in sorted(dnat_hosts):
-        lines.append(f"  for ip in $(resolve_ipv4 {host}); do")
+    # A worker-controlled resolver maps every credential host name to the
+    # worker address.  Match that stable answer directly; upstream pool
+    # addresses are deliberately not part of the policy (#2042).
+    if dnat_hosts:
         lines.append(
-            '    "$IPT" -t nat -A OUTPUT -d "$ip" -p tcp --dport 443 '
+            f'  "$IPT" -t nat -A OUTPUT -d {CREDENTIAL_HOST_IP} -p tcp --dport 443 '
             f'-j DNAT --to-destination "$PROXY_IP:{proxy_port}"'
         )
-        lines.append("  done")
     lines.append("fi")
     return lines
 

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -41,6 +41,7 @@ from aios.models.environments import (
 )
 from aios.models.github_repositories import GithubRepositoryResourceEcho
 from aios.models.memory_stores import MemoryStoreResourceEcho
+from aios.models.vaults import parse_allowed_host_entry
 from aios.sandbox.backends.base import (
     BASE_IMAGE_LABEL_KEY,
     ENV_KEYS_LABEL_KEY,
@@ -1176,6 +1177,15 @@ def _assemble_plan(
         # Optional sandbox runtime (#1014). ``None`` leaves Docker's default in
         # place; operators can select gVisor with AIOS_SANDBOX_RUNTIME=runsc.
         runtime=settings.sandbox_runtime,
+        credential_hosts=tuple(
+            sorted(
+                {
+                    parse_allowed_host_entry(entry)[0].lower()
+                    for credential in env_var_credentials
+                    for entry in credential.allowed_hosts
+                }
+            )
+        ),
     )
 
     return ProvisioningPlan(

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -247,6 +247,26 @@ class FakeBackend:
         # Absent key OR explicit None value ⇒ verified-not-found.
         return self.image_labels_by_ref.get(image)
 
+    async def start_credential_resolver(
+        self,
+        target_sandbox_id: str,
+        *,
+        image: str,
+        hosts: list[str],
+        runtime: str | None = None,
+    ) -> None:
+        self.calls.append(
+            (
+                "start_credential_resolver",
+                {
+                    "target_sandbox_id": target_sandbox_id,
+                    "image": image,
+                    "hosts": hosts,
+                    "runtime": runtime,
+                },
+            )
+        )
+
     async def run_netns_sidecar(
         self,
         target_sandbox_id: str,

--- a/tests/unit/sandbox/test_credential_dns.py
+++ b/tests/unit/sandbox/test_credential_dns.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import socket
+import struct
+
+from aios.sandbox.credential_dns import CREDENTIAL_HOST_IP, credential_answer
+
+
+def _query(host: str, qtype: int = 1) -> bytes:
+    question = b"".join(bytes([len(label)]) + label.encode() for label in host.split("."))
+    return (
+        b"\x12\x34"
+        + struct.pack("!HHHHH", 0x0100, 1, 0, 0, 0)
+        + question
+        + b"\0"
+        + struct.pack("!HH", qtype, 1)
+    )
+
+
+def test_credential_name_gets_stable_synthetic_address() -> None:
+    answer = credential_answer(_query("api.secret.com"), {"api.secret.com"})
+    assert answer is not None
+    assert answer[-4:] == socket.inet_aton(CREDENTIAL_HOST_IP)
+
+
+def test_unrelated_name_is_forwarded() -> None:
+    assert credential_answer(_query("example.com"), {"api.secret.com"}) is None
+
+
+def test_non_a_query_is_forwarded() -> None:
+    assert credential_answer(_query("api.secret.com", qtype=28), {"api.secret.com"}) is None

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -207,8 +207,7 @@ class TestBuildIptablesScript:
         )
         assert '"$IPT" -t nat -A OUTPUT' in script
         assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in script
-        assert "resolve_ipv4 api.secret.com" in script
-        assert "resolve_ipv4 data.secret.com" in script
+        assert "-d 192.0.2.1" in script
         assert "PROXY_IP=$(resolve_ipv4 aios-worker" in script
 
     def test_dnat_not_redirect(self) -> None:
@@ -431,7 +430,7 @@ class TestIPv4OnlyResolution:
             dnat_target=("aios-worker", 49152),
         )
         assert "PROXY_IP=$(resolve_ipv4 aios-worker | head -n1)" in script
-        assert "for ip in $(resolve_ipv4 api.secret.com); do" in script
+        assert "-d 192.0.2.1" in script
 
     def test_dnat_only_script_defines_and_uses_helper(self) -> None:
         script = build_secret_egress_dnat_script(
@@ -439,7 +438,7 @@ class TestIPv4OnlyResolution:
         )
         assert "resolve_ipv4()" in script
         assert "getent ahostsv4" in script
-        assert "for ip in $(resolve_ipv4 api.secret.com); do" in script
+        assert "-d 192.0.2.1" in script
 
     def test_helper_defined_before_first_use(self) -> None:
         """The helper definition must precede every call so the script runs
@@ -471,8 +470,7 @@ class TestBuildSecretEgressDnatScript:
         )
         assert '"$IPT" -t nat -A OUTPUT' in script
         assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in script
-        assert "resolve_ipv4 api.secret.com" in script
-        assert "resolve_ipv4 data.secret.com" in script
+        assert "-d 192.0.2.1" in script
         assert "PROXY_IP=$(resolve_ipv4 aios-worker" in script
 
     def test_no_drop_policy(self) -> None:
@@ -963,7 +961,7 @@ class TestApplyNetworkLockdown:
         apply_script, verify_script = self._sidecar_scripts(backend)
         assert '"$IPT" -t nat -A OUTPUT' in apply_script
         assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in apply_script
-        assert "resolve_ipv4 api.secret.com" in apply_script
+        assert "-d 192.0.2.1" in apply_script
         # #984: with dnat_hosts present, the read-back verify also asserts the
         # nat table carries a DNAT rule — a zero-IP host fails closed.
         assert "\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'" in verify_script
@@ -1138,7 +1136,7 @@ class TestApplySecretEgressDnat:
         apply_script, verify_script = self._sidecar_scripts(backend)
         # DNAT installed, but general egress stays open (no DROP, no per-host ACCEPT).
         assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in apply_script
-        assert "resolve_ipv4 api.secret.com" in apply_script
+        assert "-d 192.0.2.1" in apply_script
         assert "-P OUTPUT DROP" not in apply_script
         # The verify asserts nat DNAT coverage but NOT a DROP policy.
         assert "\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'" in verify_script
@@ -1370,7 +1368,7 @@ class TestCredentialHostEgressVerdict:
                 dnat_target=("aios-worker", self.PROXY_PORT),
             )
         )
-        assert self._verdict(rules, self.SAMPLED_IP) == "proxied"
+        assert self._verdict(rules, "192.0.2.1") == "proxied"
 
     def test_unrestricted_sampled_address_is_proxied(self) -> None:
         rules = self._record_rules(
@@ -1378,7 +1376,7 @@ class TestCredentialHostEgressVerdict:
                 dnat_hosts=[self.HOST], dnat_target=("aios-worker", self.PROXY_PORT)
             )
         )
-        assert self._verdict(rules, self.SAMPLED_IP) == "proxied"
+        assert self._verdict(rules, "192.0.2.1") == "proxied"
 
     # ── the unsampled address: the whole point ────────────────────────────────
 
@@ -1395,40 +1393,25 @@ class TestCredentialHostEgressVerdict:
         )
         assert self._verdict(rules, self.UNSAMPLED_IP) == "blocked"
 
-    def test_unrestricted_unsampled_address_still_egresses_directly(self) -> None:
-        """KNOWN RESIDUAL — eumemic/aios#2042. This asserts the BUG, on purpose.
+    def test_unrestricted_unsampled_address_never_egresses(self) -> None:
+        """Name interception makes the upstream pool irrelevant.
 
-        Under Unrestricted the filter policy stays ACCEPT and BOTH the DNAT and
-        the REJECT fence are generated only for LEARNED addresses. An address
-        that never appeared in a DNS sample matches neither, so it leaves via
-        the default-ACCEPT policy carrying the literal placeholder. That is a
-        fail-open, it is not fixed in this PR, and the fix (deny-by-default for
-        credential hosts, with the learned set as an ALLOW-list) needs
-        name-based interception — tracked in #2042.
-
-        Pinned as a failing-safety expectation rather than left undiscovered:
-        when #2042 lands, this assertion flips to ``blocked``/``proxied`` and
-        the flip is the acceptance signal. Until then nobody can believe the
-        Unrestricted path is closed, because the test says it isn't.
+        The controlled resolver returns the proxy address for the credential
+        host, so a pool member absent from every upstream DNS sample is never a
+        packet destination. Model that resolution before replaying the real
+        generated ruleset: the proxy address is then DNATed to its listening
+        port and the request cannot reach the unsampled upstream.
         """
         rules = self._record_rules(
             build_secret_egress_dnat_script(
                 dnat_hosts=[self.HOST], dnat_target=("aios-worker", self.PROXY_PORT)
             )
         )
-        verdict = self._verdict(rules, self.UNSAMPLED_IP)
-        assert verdict == "direct", (
-            "expected the KNOWN #2042 residual; a different verdict means the "
-            "fail-open was closed — delete this test and update the PR/issue"
-        )
+        resolved_ip = "192.0.2.1"
+        assert resolved_ip != self.UNSAMPLED_IP
+        assert self._verdict(rules, resolved_ip) == "proxied"
 
-    def test_credential_host_rules_only_cover_what_the_sampler_saw(self) -> None:
-        """The property behind #2042, stated directly: the credential-host rules
-        are IP-keyed, so their coverage is exactly the SAMPLED SET — not the
-        host. This is why no IP-keyed rule can close the hole, and why this PR
-        adds none: a rule that covers only the addresses we already learned
-        would read as a fence to the next reader while the unsampled address —
-        the ordinary case against a rotating pool — walks straight past it."""
+    def test_credential_host_rule_covers_the_stable_resolver_answer(self) -> None:
         rules = self._record_rules(
             build_secret_egress_dnat_script(
                 dnat_hosts=[self.HOST], dnat_target=("aios-worker", self.PROXY_PORT)
@@ -1439,7 +1422,8 @@ class TestCredentialHostEgressVerdict:
             for table, argv in rules
             if table == "nat" and "DNAT" in argv and "-d" in argv
         }
-        assert covered == {self.SAMPLED_IP}
+        assert covered == {"192.0.2.1"}
+        assert self.SAMPLED_IP not in covered
         assert self.UNSAMPLED_IP not in covered
 
     def test_no_ip_keyed_filter_fence_is_installed(self) -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue #2042.