### PR TITLE
Vault UX: allow editing environment_variable allowed_hosts/secret_name via revoke+recreate semantics (immutability stays, fat-fingers stop hurting)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5338,7 +5338,7 @@
           "vaults"
         ],
         "summary": "Update Credential",
-        "description": "Update a credential's metadata and/or rotate its auth secrets.\n\nOmitted secret fields are preserved (decrypt-merge-encrypt cycle on the\nencrypted payload). ``target_url`` and ``auth_type`` are immutable\nand not accepted in the body. To rotate an OAuth refresh token, send\nonly the new ``refresh_token`` (and optional ``access_token`` /\n``expires_at``); other auth fields stay intact.",
+        "description": "Update a credential's metadata and/or rotate its auth secrets.\n\nOmitted secret fields are preserved (decrypt-merge-encrypt cycle on the\nencrypted payload). ``target_url`` and ``auth_type`` are immutable. Changing\nan environment-variable credential's ``secret_name`` or ``allowed_hosts``\natomically archives the old row and creates a replacement with a new id,\ncarrying its encrypted secret unless ``secret_value`` is supplied. The new\nid changes sandbox placeholders, so affected sandboxes recycle on their next\nprovision. To rotate an OAuth refresh token, send only the new\n``refresh_token`` (and optional ``access_token`` / ``expires_at``); other\nauth fields stay intact.",
         "operationId": "update_vault_credential",
         "parameters": [
           {
@@ -19523,12 +19523,38 @@
               }
             ],
             "title": "Metadata"
+          },
+          "secret_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secret Name"
+          },
+          "allowed_hosts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Hosts"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "title": "VaultCredentialUpdate",
-        "description": "Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.\n\n``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are\nimmutable \u2014 not accepted here. Omitted secret fields are preserved\n(decrypt-merge-encrypt)."
+        "description": "Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.\n\n``target_url`` and ``auth_type`` are immutable. For an\n``environment_variable`` credential, changing ``secret_name`` or\n``allowed_hosts`` atomically archives the old row and creates a replacement\nwith a new id. Omitted secret fields are preserved (decrypt-merge-encrypt)."
       },
       "VaultUpdate": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/vaults/update_vault_credential.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/vaults/update_vault_credential.py
@@ -82,10 +82,14 @@ def sync_detailed(
      Update a credential's metadata and/or rotate its auth secrets.
 
     Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
-    encrypted payload). ``target_url`` and ``auth_type`` are immutable
-    and not accepted in the body. To rotate an OAuth refresh token, send
-    only the new ``refresh_token`` (and optional ``access_token`` /
-    ``expires_at``); other auth fields stay intact.
+    encrypted payload). ``target_url`` and ``auth_type`` are immutable. Changing
+    an environment-variable credential's ``secret_name`` or ``allowed_hosts``
+    atomically archives the old row and creates a replacement with a new id,
+    carrying its encrypted secret unless ``secret_value`` is supplied. The new
+    id changes sandbox placeholders, so affected sandboxes recycle on their next
+    provision. To rotate an OAuth refresh token, send only the new
+    ``refresh_token`` (and optional ``access_token`` / ``expires_at``); other
+    auth fields stay intact.
 
     Args:
         vault_id (str):
@@ -94,9 +98,10 @@ def sync_detailed(
         body (VaultCredentialUpdate): Request body for ``PUT
             /v1/vaults/{vault_id}/credentials/{id}``.
 
-            ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
-            immutable — not accepted here. Omitted secret fields are preserved
-            (decrypt-merge-encrypt).
+            ``target_url`` and ``auth_type`` are immutable. For an
+            ``environment_variable`` credential, changing ``secret_name`` or
+            ``allowed_hosts`` atomically archives the old row and creates a replacement
+            with a new id. Omitted secret fields are preserved (decrypt-merge-encrypt).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -133,10 +138,14 @@ def sync(
      Update a credential's metadata and/or rotate its auth secrets.
 
     Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
-    encrypted payload). ``target_url`` and ``auth_type`` are immutable
-    and not accepted in the body. To rotate an OAuth refresh token, send
-    only the new ``refresh_token`` (and optional ``access_token`` /
-    ``expires_at``); other auth fields stay intact.
+    encrypted payload). ``target_url`` and ``auth_type`` are immutable. Changing
+    an environment-variable credential's ``secret_name`` or ``allowed_hosts``
+    atomically archives the old row and creates a replacement with a new id,
+    carrying its encrypted secret unless ``secret_value`` is supplied. The new
+    id changes sandbox placeholders, so affected sandboxes recycle on their next
+    provision. To rotate an OAuth refresh token, send only the new
+    ``refresh_token`` (and optional ``access_token`` / ``expires_at``); other
+    auth fields stay intact.
 
     Args:
         vault_id (str):
@@ -145,9 +154,10 @@ def sync(
         body (VaultCredentialUpdate): Request body for ``PUT
             /v1/vaults/{vault_id}/credentials/{id}``.
 
-            ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
-            immutable — not accepted here. Omitted secret fields are preserved
-            (decrypt-merge-encrypt).
+            ``target_url`` and ``auth_type`` are immutable. For an
+            ``environment_variable`` credential, changing ``secret_name`` or
+            ``allowed_hosts`` atomically archives the old row and creates a replacement
+            with a new id. Omitted secret fields are preserved (decrypt-merge-encrypt).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -179,10 +189,14 @@ async def asyncio_detailed(
      Update a credential's metadata and/or rotate its auth secrets.
 
     Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
-    encrypted payload). ``target_url`` and ``auth_type`` are immutable
-    and not accepted in the body. To rotate an OAuth refresh token, send
-    only the new ``refresh_token`` (and optional ``access_token`` /
-    ``expires_at``); other auth fields stay intact.
+    encrypted payload). ``target_url`` and ``auth_type`` are immutable. Changing
+    an environment-variable credential's ``secret_name`` or ``allowed_hosts``
+    atomically archives the old row and creates a replacement with a new id,
+    carrying its encrypted secret unless ``secret_value`` is supplied. The new
+    id changes sandbox placeholders, so affected sandboxes recycle on their next
+    provision. To rotate an OAuth refresh token, send only the new
+    ``refresh_token`` (and optional ``access_token`` / ``expires_at``); other
+    auth fields stay intact.
 
     Args:
         vault_id (str):
@@ -191,9 +205,10 @@ async def asyncio_detailed(
         body (VaultCredentialUpdate): Request body for ``PUT
             /v1/vaults/{vault_id}/credentials/{id}``.
 
-            ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
-            immutable — not accepted here. Omitted secret fields are preserved
-            (decrypt-merge-encrypt).
+            ``target_url`` and ``auth_type`` are immutable. For an
+            ``environment_variable`` credential, changing ``secret_name`` or
+            ``allowed_hosts`` atomically archives the old row and creates a replacement
+            with a new id. Omitted secret fields are preserved (decrypt-merge-encrypt).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -228,10 +243,14 @@ async def asyncio(
      Update a credential's metadata and/or rotate its auth secrets.
 
     Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
-    encrypted payload). ``target_url`` and ``auth_type`` are immutable
-    and not accepted in the body. To rotate an OAuth refresh token, send
-    only the new ``refresh_token`` (and optional ``access_token`` /
-    ``expires_at``); other auth fields stay intact.
+    encrypted payload). ``target_url`` and ``auth_type`` are immutable. Changing
+    an environment-variable credential's ``secret_name`` or ``allowed_hosts``
+    atomically archives the old row and creates a replacement with a new id,
+    carrying its encrypted secret unless ``secret_value`` is supplied. The new
+    id changes sandbox placeholders, so affected sandboxes recycle on their next
+    provision. To rotate an OAuth refresh token, send only the new
+    ``refresh_token`` (and optional ``access_token`` / ``expires_at``); other
+    auth fields stay intact.
 
     Args:
         vault_id (str):
@@ -240,9 +259,10 @@ async def asyncio(
         body (VaultCredentialUpdate): Request body for ``PUT
             /v1/vaults/{vault_id}/credentials/{id}``.
 
-            ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
-            immutable — not accepted here. Omitted secret fields are preserved
-            (decrypt-merge-encrypt).
+            ``target_url`` and ``auth_type`` are immutable. For an
+            ``environment_variable`` credential, changing ``secret_name`` or
+            ``allowed_hosts`` atomically archives the old row and creates a replacement
+            with a new id. Omitted secret fields are preserved (decrypt-merge-encrypt).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_update.py
@@ -25,9 +25,10 @@ T = TypeVar("T", bound="VaultCredentialUpdate")
 class VaultCredentialUpdate:
     """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
 
-    ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
-    immutable — not accepted here. Omitted secret fields are preserved
-    (decrypt-merge-encrypt).
+    ``target_url`` and ``auth_type`` are immutable. For an
+    ``environment_variable`` credential, changing ``secret_name`` or
+    ``allowed_hosts`` atomically archives the old row and creates a replacement
+    with a new id. Omitted secret fields are preserved (decrypt-merge-encrypt).
 
         Attributes:
             access_token (None | str | Unset):
@@ -46,6 +47,8 @@ class VaultCredentialUpdate:
             secret_value (None | str | Unset):
             display_name (None | str | Unset):
             metadata (None | Unset | VaultCredentialUpdateMetadataType0):
+            secret_name (None | str | Unset):
+            allowed_hosts (list[str] | None | Unset):
     """
 
     access_token: None | str | Unset = UNSET
@@ -70,6 +73,8 @@ class VaultCredentialUpdate:
     secret_value: None | str | Unset = UNSET
     display_name: None | str | Unset = UNSET
     metadata: None | Unset | VaultCredentialUpdateMetadataType0 = UNSET
+    secret_name: None | str | Unset = UNSET
+    allowed_hosts: list[str] | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
@@ -185,6 +190,21 @@ class VaultCredentialUpdate:
         else:
             metadata = self.metadata
 
+        secret_name: None | str | Unset
+        if isinstance(self.secret_name, Unset):
+            secret_name = UNSET
+        else:
+            secret_name = self.secret_name
+
+        allowed_hosts: list[str] | None | Unset
+        if isinstance(self.allowed_hosts, Unset):
+            allowed_hosts = UNSET
+        elif isinstance(self.allowed_hosts, list):
+            allowed_hosts = self.allowed_hosts
+
+        else:
+            allowed_hosts = self.allowed_hosts
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
@@ -220,6 +240,10 @@ class VaultCredentialUpdate:
             field_dict["display_name"] = display_name
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if secret_name is not UNSET:
+            field_dict["secret_name"] = secret_name
+        if allowed_hosts is not UNSET:
+            field_dict["allowed_hosts"] = allowed_hosts
 
         return field_dict
 
@@ -443,6 +467,32 @@ class VaultCredentialUpdate:
 
         metadata = _parse_metadata(d.pop("metadata", UNSET))
 
+        def _parse_secret_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        secret_name = _parse_secret_name(d.pop("secret_name", UNSET))
+
+        def _parse_allowed_hosts(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                allowed_hosts_type_0 = cast(list[str], data)
+
+                return allowed_hosts_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        allowed_hosts = _parse_allowed_hosts(d.pop("allowed_hosts", UNSET))
+
         vault_credential_update = cls(
             access_token=access_token,
             expires_at=expires_at,
@@ -460,6 +510,8 @@ class VaultCredentialUpdate:
             secret_value=secret_value,
             display_name=display_name,
             metadata=metadata,
+            secret_name=secret_name,
+            allowed_hosts=allowed_hosts,
         )
 
         return vault_credential_update

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_terminal_summary_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_terminal_summary_type_0.py
@@ -6,11 +6,19 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+<<<<<<<< HEAD:packages/aios-sdk/aios_sdk/_generated/models/wf_run_terminal_summary_type_0.py
 T = TypeVar("T", bound="WfRunTerminalSummaryType0")
 
 
 @_attrs_define
 class WfRunTerminalSummaryType0:
+========
+T = TypeVar("T", bound="VaultCredentialMetadataType0")
+
+
+@_attrs_define
+class VaultCredentialMetadataType0:
+>>>>>>>> fd5ad37a (Regenerate OpenAPI and SDK for nullable vault metadata):packages/aios-sdk/aios_sdk/_generated/models/vault_credential_metadata_type_0.py
     """ """
 
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -25,10 +33,17 @@ class WfRunTerminalSummaryType0:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
+<<<<<<<< HEAD:packages/aios-sdk/aios_sdk/_generated/models/wf_run_terminal_summary_type_0.py
         wf_run_terminal_summary_type_0 = cls()
 
         wf_run_terminal_summary_type_0.additional_properties = d
         return wf_run_terminal_summary_type_0
+========
+        vault_credential_metadata_type_0 = cls()
+
+        vault_credential_metadata_type_0.additional_properties = d
+        return vault_credential_metadata_type_0
+>>>>>>>> fd5ad37a (Regenerate OpenAPI and SDK for nullable vault metadata):packages/aios-sdk/aios_sdk/_generated/models/vault_credential_metadata_type_0.py
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_terminal_summary_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_terminal_summary_type_0.py
@@ -6,19 +6,11 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-<<<<<<<< HEAD:packages/aios-sdk/aios_sdk/_generated/models/wf_run_terminal_summary_type_0.py
 T = TypeVar("T", bound="WfRunTerminalSummaryType0")
 
 
 @_attrs_define
 class WfRunTerminalSummaryType0:
-========
-T = TypeVar("T", bound="VaultCredentialMetadataType0")
-
-
-@_attrs_define
-class VaultCredentialMetadataType0:
->>>>>>>> fd5ad37a (Regenerate OpenAPI and SDK for nullable vault metadata):packages/aios-sdk/aios_sdk/_generated/models/vault_credential_metadata_type_0.py
     """ """
 
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -33,17 +25,10 @@ class VaultCredentialMetadataType0:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-<<<<<<<< HEAD:packages/aios-sdk/aios_sdk/_generated/models/wf_run_terminal_summary_type_0.py
         wf_run_terminal_summary_type_0 = cls()
 
         wf_run_terminal_summary_type_0.additional_properties = d
         return wf_run_terminal_summary_type_0
-========
-        vault_credential_metadata_type_0 = cls()
-
-        vault_credential_metadata_type_0.additional_properties = d
-        return vault_credential_metadata_type_0
->>>>>>>> fd5ad37a (Regenerate OpenAPI and SDK for nullable vault metadata):packages/aios-sdk/aios_sdk/_generated/models/vault_credential_metadata_type_0.py
 
     @property
     def additional_keys(self) -> list[str]:

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -269,10 +269,14 @@ async def update_credential(
     """Update a credential's metadata and/or rotate its auth secrets.
 
     Omitted secret fields are preserved (decrypt-merge-encrypt cycle on the
-    encrypted payload). ``target_url`` and ``auth_type`` are immutable
-    and not accepted in the body. To rotate an OAuth refresh token, send
-    only the new ``refresh_token`` (and optional ``access_token`` /
-    ``expires_at``); other auth fields stay intact.
+    encrypted payload). ``target_url`` and ``auth_type`` are immutable. Changing
+    an environment-variable credential's ``secret_name`` or ``allowed_hosts``
+    atomically archives the old row and creates a replacement with a new id,
+    carrying its encrypted secret unless ``secret_value`` is supplied. The new
+    id changes sandbox placeholders, so affected sandboxes recycle on their next
+    provision. To rotate an OAuth refresh token, send only the new
+    ``refresh_token`` (and optional ``access_token`` / ``expires_at``); other
+    auth fields stay intact.
     """
     return await service.update_vault_credential(
         pool,

--- a/src/aios/db/queries/vaults.py
+++ b/src/aios/db/queries/vaults.py
@@ -238,7 +238,7 @@ async def insert_vault_credential(
     allowed_hosts: list[str] | None,
     auth_type: AuthType,
     blob: EncryptedBlob,
-    metadata: dict[str, Any],
+    metadata: dict[str, Any] | None,
 ) -> VaultCredential:
     new_id = make_id(VAULT_CREDENTIAL)
     metadata_json = json.dumps(metadata)

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -367,6 +367,9 @@ class VaultCredential(BaseModel):
     auth_type: AuthType
     secret_name: str | None = None
     allowed_hosts: list[str] | None = None
+    # Explicit ``metadata: null`` on update means "clear" and is persisted as
+    # JSON null.  The read contract must therefore represent both populated
+    # metadata objects and the cleared state produced by that write path.
     metadata: dict[str, Any] | None
     created_at: datetime
     updated_at: datetime

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -319,13 +319,38 @@ class VaultCredentialCreate(_VaultCredentialSecrets):
 class VaultCredentialUpdate(_VaultCredentialSecrets):
     """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
 
-    ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
-    immutable — not accepted here. Omitted secret fields are preserved
-    (decrypt-merge-encrypt).
+    ``target_url`` and ``auth_type`` are immutable. For an
+    ``environment_variable`` credential, changing ``secret_name`` or
+    ``allowed_hosts`` atomically archives the old row and creates a replacement
+    with a new id. Omitted secret fields are preserved (decrypt-merge-encrypt).
     """
 
     display_name: str | None = Field(default=None, max_length=128)
     metadata: dict[str, Any] | None = None
+    secret_name: str | None = Field(default=None, max_length=128)
+    allowed_hosts: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _validate_environment_variable_scope(self) -> VaultCredentialUpdate:
+        if "secret_name" in self.model_fields_set:
+            if not self.secret_name or not _SECRET_NAME_RE.fullmatch(self.secret_name):
+                raise ValueError(
+                    f"invalid secret_name {self.secret_name!r}: must be a POSIX env var name "
+                    "([A-Za-z_][A-Za-z0-9_]*)"
+                )
+            if self.secret_name in RESERVED_SANDBOX_ENV_KEYS:
+                raise ValueError(
+                    f"secret_name {self.secret_name!r} is reserved by the sandbox runtime"
+                )
+        if "allowed_hosts" in self.model_fields_set:
+            if not self.allowed_hosts:
+                raise ValueError("allowed_hosts must be non-empty")
+            canonical: list[str] = []
+            for entry in self.allowed_hosts:
+                host, prefix = parse_allowed_host_entry(entry)
+                canonical.append(host if prefix is None else host + prefix)
+            self.allowed_hosts = list(dict.fromkeys(canonical))
+        return self
 
 
 class VaultCredential(BaseModel):

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -637,15 +637,61 @@ async def update_vault_credential(
         merged = _merge_auth_payload(existing_payload, body, cred.auth_type)
         new_blob = subkey.encrypt_dict(merged)
 
-        updated = await queries.update_vault_credential(
-            conn,
-            vault_id,
-            credential_id,
-            blob=new_blob,
-            display_name=(body.display_name if "display_name" in body.model_fields_set else ...),
-            metadata=body.metadata if "metadata" in body.model_fields_set else ...,
-            account_id=account_id,
+        scope_fields = {"secret_name", "allowed_hosts"} & body.model_fields_set
+        if scope_fields and cred.auth_type != "environment_variable":
+            raise ValidationError(
+                "secret_name and allowed_hosts apply only to environment_variable credentials",
+                detail={"auth_type": cred.auth_type, "fields": sorted(scope_fields)},
+            )
+        secret_name = body.secret_name if "secret_name" in scope_fields else cred.secret_name
+        allowed_hosts = (
+            body.allowed_hosts if "allowed_hosts" in scope_fields else cred.allowed_hosts
         )
+        rescoping = bool(
+            scope_fields
+            and (secret_name != cred.secret_name or allowed_hosts != cred.allowed_hosts)
+        )
+        if rescoping:
+            # The scope-bearing row is immutable: archive it (which also scrubs
+            # its ciphertext) and insert a replacement in the same transaction.
+            # We decrypted before archive, so the replacement can carry the
+            # secret without exposing or re-entering it. The new id also yields
+            # a new sandbox placeholder and therefore provision-time recycle.
+            await queries.archive_vault_credential(
+                conn, vault_id, credential_id, account_id=account_id
+            )
+            updated = await queries.insert_vault_credential(
+                conn,
+                vault_id=vault_id,
+                display_name=(
+                    body.display_name
+                    if "display_name" in body.model_fields_set
+                    else cred.display_name
+                ),
+                target_url=None,
+                secret_name=secret_name,
+                allowed_hosts=allowed_hosts,
+                auth_type=cred.auth_type,
+                blob=new_blob,
+                metadata=(
+                    body.metadata
+                    if "metadata" in body.model_fields_set and body.metadata is not None
+                    else cred.metadata
+                ),
+                account_id=account_id,
+            )
+        else:
+            updated = await queries.update_vault_credential(
+                conn,
+                vault_id,
+                credential_id,
+                blob=new_blob,
+                display_name=(
+                    body.display_name if "display_name" in body.model_fields_set else ...
+                ),
+                metadata=body.metadata if "metadata" in body.model_fields_set else ...,
+                account_id=account_id,
+            )
     # NOTIFY after commit (invariant 6) so the worker evicts the pooled MCP
     # session that still carries the pre-rotation secret (#1030).
     await _notify_evict_vault(pool, vault_id)

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -674,9 +674,13 @@ async def update_vault_credential(
                 auth_type=cred.auth_type,
                 blob=new_blob,
                 metadata=(
-                    body.metadata
-                    if "metadata" in body.model_fields_set and body.metadata is not None
-                    else cred.metadata
+                    # Presence in ``model_fields_set`` — not nullity — decides:
+                    # an explicit ``metadata: null`` must CLEAR, exactly as it
+                    # does on the ordinary update path below. Only a genuinely
+                    # OMITTED field falls back to the existing value (the
+                    # replacement row is new, so "leave alone" has to be
+                    # materialized as ``cred.metadata``).
+                    body.metadata if "metadata" in body.model_fields_set else cred.metadata
                 ),
                 account_id=account_id,
             )

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -334,6 +334,49 @@ class TestVaultCredentialCRUD:
         )
         assert cred2.id != cred1.id
 
+    async def test_environment_variable_rescope_and_metadata_clear_are_atomic(
+        self, pool: Any, crypto_box: Any
+    ) -> None:
+        """Rescoping must not discard an explicit metadata update."""
+        account_id = "acc_test_stub"
+        from aios.services import vaults as svc
+
+        vault = await svc.create_vault(
+            pool, display_name="env-rescope-metadata", metadata={}, account_id=account_id
+        )
+        cred = await svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault.id,
+            body=VaultCredentialCreate(
+                auth_type="environment_variable",
+                secret_name="RESCOPED_KEY",
+                allowed_hosts=["old.example.com"],
+                secret_value=SecretStr("secret"),
+                metadata={"owner": "ops"},
+            ),
+            account_id=account_id,
+        )
+
+        replacement = await svc.update_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault.id,
+            credential_id=cred.id,
+            body=VaultCredentialUpdate(
+                allowed_hosts=["new.example.com"],
+                metadata=None,
+            ),
+            account_id=account_id,
+        )
+        fetched = await svc.get_vault_credential(
+            pool, vault.id, replacement.id, account_id=account_id
+        )
+
+        assert replacement.id != cred.id
+        assert fetched.allowed_hosts == ["new.example.com"]
+        assert fetched.metadata is None
+
     async def test_environment_variable_rotates_secret(self, pool: Any, crypto_box: Any) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.db import queries

--- a/tests/integration/test_vault_credential_account_scoping.py
+++ b/tests/integration/test_vault_credential_account_scoping.py
@@ -1,0 +1,273 @@
+"""Account scoping on the vault-credential paths is enforced by the SQL predicate.
+
+Every test here is written to FAIL if the ``AND account_id = $N`` predicate is
+removed from the query it exercises.  That is the point: the pre-existing
+coverage asserted cross-account failure over *mocked* queries (or a mocked
+query *result*), so it would still have passed with the predicate deleted --
+the tests-that-cannot-fail class, sitting on an authority boundary.
+
+The credential PUT reaches the database through two different shapes -- the
+ordinary in-place update and the rescope archive+insert replacement -- so both
+are driven here, plus the query layer directly.  A foreign ``account_id`` must
+produce ``NotFoundError`` (the authority answer), not a decrypt failure and not
+a mutated row: crypto failing *incidentally* is not access control, and a
+credential must not be read, archived, or replaced across a tenant boundary.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+from pydantic import SecretStr
+
+from aios.crypto.vault import CryptoBox
+from aios.db import queries as db_queries
+from aios.db.pool import create_pool
+from aios.errors import NotFoundError
+from aios.models.vaults import VaultCredentialCreate, VaultCredentialUpdate
+from aios.services import vaults as vaults_service
+
+pytestmark = pytest.mark.integration
+
+ACC_OWNER = "acc_vc_scope_owner"
+ACC_OTHER = "acc_vc_scope_other"
+
+
+@pytest.fixture
+def crypto_box() -> CryptoBox:
+    return CryptoBox(os.urandom(32))
+
+
+@pytest.fixture
+async def vault_pool(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                "display_name) VALUES ($1, NULL, TRUE, 'vc-scope-root')",
+                ACC_OWNER,
+            )
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                "display_name) VALUES ($1, $2, FALSE, 'vc-scope-other')",
+                ACC_OTHER,
+                ACC_OWNER,
+            )
+        yield pool
+    finally:
+        await pool.close()
+
+
+async def _seed_credential(pool: asyncpg.Pool[Any], crypto_box: CryptoBox) -> tuple[str, str]:
+    """Create a vault + environment_variable credential owned by ``ACC_OWNER``."""
+    vault = await vaults_service.create_vault(
+        pool, display_name="scoped-vault", metadata={}, account_id=ACC_OWNER
+    )
+    cred = await vaults_service.create_vault_credential(
+        pool,
+        crypto_box,
+        vault_id=vault.id,
+        body=VaultCredentialCreate(
+            auth_type="environment_variable",
+            secret_name="SCOPED_KEY",
+            allowed_hosts=["owner.example.com"],
+            secret_value=SecretStr("owner-secret"),
+            metadata={"owner": "ops"},
+        ),
+        account_id=ACC_OWNER,
+    )
+    return vault.id, cred.id
+
+
+async def _assert_row_untouched(pool: asyncpg.Pool[Any], vault_id: str, credential_id: str) -> None:
+    """The owner's credential is still active, still scoped, still holds its secret."""
+    cred = await vaults_service.get_vault_credential(
+        pool, vault_id, credential_id, account_id=ACC_OWNER
+    )
+    assert cred.archived_at is None, "foreign account archived the owner's credential"
+    assert cred.allowed_hosts == ["owner.example.com"]
+    assert cred.secret_name == "SCOPED_KEY"
+    async with pool.acquire() as conn:
+        ciphertext = await conn.fetchval(
+            "SELECT ciphertext FROM vault_credentials WHERE id = $1", credential_id
+        )
+    assert bytes(ciphertext) != b"", "foreign account scrubbed the owner's ciphertext"
+
+
+class TestVaultCredentialAccountScoping:
+    """A foreign account must not reach another tenant's credential."""
+
+    async def test_rescope_path_refuses_foreign_account(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        """The archive+insert replacement path is account-scoped.
+
+        This is the path this PR adds.  Removing the account predicate lets the
+        foreign caller archive the owner's row and mint a replacement under its
+        own account -- destroying another tenant's credential.
+        """
+        vault_id, credential_id = await _seed_credential(vault_pool, crypto_box)
+
+        with pytest.raises(NotFoundError):
+            await vaults_service.update_vault_credential(
+                vault_pool,
+                crypto_box,
+                vault_id=vault_id,
+                credential_id=credential_id,
+                body=VaultCredentialUpdate(allowed_hosts=["attacker.example.com"]),
+                account_id=ACC_OTHER,
+            )
+
+        await _assert_row_untouched(vault_pool, vault_id, credential_id)
+
+    async def test_ordinary_update_path_refuses_foreign_account(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        """The in-place update path is account-scoped too.
+
+        Same request shape, no rescope -- the other input that reaches the same
+        wrong outcome if the predicate is dropped.
+        """
+        vault_id, credential_id = await _seed_credential(vault_pool, crypto_box)
+
+        with pytest.raises(NotFoundError):
+            await vaults_service.update_vault_credential(
+                vault_pool,
+                crypto_box,
+                vault_id=vault_id,
+                credential_id=credential_id,
+                body=VaultCredentialUpdate(display_name="pwned"),
+                account_id=ACC_OTHER,
+            )
+
+        cred = await vaults_service.get_vault_credential(
+            vault_pool, vault_id, credential_id, account_id=ACC_OWNER
+        )
+        assert cred.display_name != "pwned"
+        await _assert_row_untouched(vault_pool, vault_id, credential_id)
+
+    async def test_metadata_clear_refuses_foreign_account(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        """The explicit ``metadata: null`` clear is not a way around the predicate.
+
+        The clear is the behaviour this PR changed; it must still be gated by
+        account, on the rescope path where the two features combine.
+        """
+        vault_id, credential_id = await _seed_credential(vault_pool, crypto_box)
+
+        with pytest.raises(NotFoundError):
+            await vaults_service.update_vault_credential(
+                vault_pool,
+                crypto_box,
+                vault_id=vault_id,
+                credential_id=credential_id,
+                body=VaultCredentialUpdate(allowed_hosts=["attacker.example.com"], metadata=None),
+                account_id=ACC_OTHER,
+            )
+
+        cred = await vaults_service.get_vault_credential(
+            vault_pool, vault_id, credential_id, account_id=ACC_OWNER
+        )
+        assert cred.metadata == {"owner": "ops"}, "foreign account cleared owner metadata"
+        await _assert_row_untouched(vault_pool, vault_id, credential_id)
+
+    async def test_owner_rescope_succeeds(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        """Positive control: the predicate blocks the foreigner, not everyone.
+
+        Without this, every assertion above would still pass if the service
+        simply raised ``NotFoundError`` unconditionally.
+        """
+        vault_id, credential_id = await _seed_credential(vault_pool, crypto_box)
+
+        replacement = await vaults_service.update_vault_credential(
+            vault_pool,
+            crypto_box,
+            vault_id=vault_id,
+            credential_id=credential_id,
+            body=VaultCredentialUpdate(allowed_hosts=["new.example.com"]),
+            account_id=ACC_OWNER,
+        )
+
+        assert replacement.id != credential_id
+        assert replacement.allowed_hosts == ["new.example.com"]
+
+
+class TestVaultCredentialQueryLayerScoping:
+    """The predicate lives in SQL, so assert it in SQL -- one test per query.
+
+    Driving the service only ever proves the *first* gate it hits.  These pin
+    each credential query independently, so deleting the predicate from any one
+    of them turns a test red rather than being masked by an earlier check.
+    """
+
+    async def test_get_with_blob_is_scoped(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        vault_id, credential_id = await _seed_credential(vault_pool, crypto_box)
+        async with vault_pool.acquire() as conn:
+            with pytest.raises(NotFoundError):
+                await db_queries.get_vault_credential_with_blob(
+                    conn, vault_id, credential_id, account_id=ACC_OTHER
+                )
+
+    async def test_get_is_scoped(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        vault_id, credential_id = await _seed_credential(vault_pool, crypto_box)
+        async with vault_pool.acquire() as conn:
+            with pytest.raises(NotFoundError):
+                await db_queries.get_vault_credential(
+                    conn, vault_id, credential_id, account_id=ACC_OTHER
+                )
+
+    async def test_archive_is_scoped(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        """Archive scrubs the ciphertext -- an unscoped archive is destructive."""
+        vault_id, credential_id = await _seed_credential(vault_pool, crypto_box)
+        async with vault_pool.acquire() as conn:
+            with pytest.raises(NotFoundError):
+                await db_queries.archive_vault_credential(
+                    conn, vault_id, credential_id, account_id=ACC_OTHER
+                )
+        await _assert_row_untouched(vault_pool, vault_id, credential_id)
+
+    async def test_update_is_scoped(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        vault_id, credential_id = await _seed_credential(vault_pool, crypto_box)
+        async with vault_pool.acquire() as conn:
+            with pytest.raises(NotFoundError):
+                await db_queries.update_vault_credential(
+                    conn,
+                    vault_id,
+                    credential_id,
+                    account_id=ACC_OTHER,
+                    display_name="pwned",
+                )
+        cred = await vaults_service.get_vault_credential(
+            vault_pool, vault_id, credential_id, account_id=ACC_OWNER
+        )
+        assert cred.display_name != "pwned"
+
+    async def test_list_is_scoped(
+        self, vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+    ) -> None:
+        vault_id, _ = await _seed_credential(vault_pool, crypto_box)
+        async with vault_pool.acquire() as conn:
+            assert (
+                await db_queries.list_vault_credentials(conn, vault_id, account_id=ACC_OTHER) == []
+            )
+            assert (
+                await db_queries.list_vault_credentials(conn, vault_id, account_id=ACC_OWNER) != []
+            )

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -586,6 +586,31 @@ class TestUpdateVaultCredentialCallSite:
         assert kwargs["display_name"] is None  # not Ellipsis — explicitly passed
 
 
+class TestVaultCredentialMetadataReadContract:
+    def test_cleared_metadata_row_parses_as_vault_credential(self) -> None:
+        """The JSON-null value produced by a clear remains readable."""
+        from aios.db.queries.vaults import _row_to_vault_credential
+
+        now = datetime.now(UTC)
+        credential = _row_to_vault_credential(
+            {
+                "id": "vc_cleared",
+                "vault_id": "vlt_1",
+                "display_name": "mailgun",
+                "target_url": None,
+                "auth_type": "environment_variable",
+                "secret_name": "MAILGUN_API_KEY",
+                "allowed_hosts": ["mailgun.com"],
+                "metadata": None,
+                "created_at": now,
+                "updated_at": now,
+                "archived_at": None,
+            }
+        )
+
+        assert credential.metadata is None
+
+
 class TestUpdateVaultCredentialMetadataClearParity:
     """``metadata: null`` must CLEAR metadata identically whether or not the
     update also rescopes the credential.

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -586,6 +586,147 @@ class TestUpdateVaultCredentialCallSite:
         assert kwargs["display_name"] is None  # not Ellipsis — explicitly passed
 
 
+class TestUpdateVaultCredentialMetadataClearParity:
+    """``metadata: null`` must CLEAR metadata identically whether or not the
+    update also rescopes the credential.
+
+    The rescope branch inserts a *replacement* row, so it has to reconstruct
+    every field rather than pass a "leave alone" sentinel. Deciding that
+    reconstruction with ``body.metadata is not None`` conflates *omitted* with
+    *explicitly null*: the same PUT then clears metadata on the ordinary path
+    but silently preserves it on the rescope path. Presence in
+    ``model_fields_set`` — not the value's truthiness/nullity — is what
+    distinguishes the two.
+    """
+
+    @staticmethod
+    def _env_var_credential() -> VaultCredential:
+        return VaultCredential(
+            id="vc_1",
+            vault_id="vlt_1",
+            display_name="mailgun",
+            target_url=None,
+            auth_type="environment_variable",
+            secret_name="MAILGUN_API_KEY",
+            allowed_hosts=["mailgun.com"],
+            metadata={"owner": "ops"},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+    async def _metadata_sent_for(
+        self, crypto_box: CryptoBox, body: VaultCredentialUpdate, *, rescope: bool
+    ) -> Any:
+        """Drive the service once and return the metadata it handed the DB layer.
+
+        Normalizes across the two branches so the assertions can compare them:
+        the rescope branch reports the replacement row's ``metadata`` kwarg,
+        the ordinary branch reports its ``metadata`` kwarg (``...`` meaning
+        "leave the stored value alone").
+        """
+        account_id = "acc_test_stub"
+        existing = self._env_var_credential()
+        existing_blob = crypto_box.derive_account_subkey(account_id).encrypt_dict(
+            {"secret_value": "carried-secret"}
+        )
+        conn = MagicMock()
+        pool = fake_pool_yielding_conn(conn)
+
+        with (
+            patch.object(
+                queries,
+                "get_vault_credential_with_blob",
+                AsyncMock(return_value=(existing, existing_blob)),
+            ),
+            patch.object(queries, "archive_vault_credential", AsyncMock(return_value=existing)),
+            patch.object(
+                queries, "insert_vault_credential", AsyncMock(return_value=existing)
+            ) as insert,
+            patch.object(
+                queries, "update_vault_credential", AsyncMock(return_value=existing)
+            ) as upd,
+        ):
+            await vaults_service.update_vault_credential(
+                pool,
+                crypto_box,
+                vault_id="vlt_1",
+                credential_id="vc_1",
+                body=body,
+                account_id=account_id,
+            )
+
+        if rescope:
+            assert insert.await_args is not None, "expected the replacement-row path"
+            assert upd.await_args is None
+            return insert.await_args.kwargs["metadata"]
+        assert upd.await_args is not None, "expected the ordinary update path"
+        assert insert.await_args is None
+        return upd.await_args.kwargs["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_null_metadata_clears_on_rescope_path(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        # A rescope (allowed_hosts change) combined with an explicit
+        # ``metadata: null`` must CLEAR metadata — not silently carry the
+        # existing {"owner": "ops"} over onto the replacement row.
+        sent = await self._metadata_sent_for(
+            crypto_box,
+            VaultCredentialUpdate(allowed_hosts=["api.mailgun.net"], metadata=None),
+            rescope=True,
+        )
+        assert sent is None, f"rescope path failed to clear metadata: sent {sent!r}"
+
+    @pytest.mark.asyncio
+    async def test_explicit_null_metadata_clears_identically_with_and_without_rescope(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        # The equivalence IS the property: the same explicitly-null metadata
+        # request must have the same observable effect on the stored metadata
+        # regardless of whether a rescope happened to occur.
+        with_rescope = await self._metadata_sent_for(
+            crypto_box,
+            VaultCredentialUpdate(allowed_hosts=["api.mailgun.net"], metadata=None),
+            rescope=True,
+        )
+        without_rescope = await self._metadata_sent_for(
+            crypto_box,
+            VaultCredentialUpdate(metadata=None),
+            rescope=False,
+        )
+        assert without_rescope is None  # the ordinary path already clears
+        assert with_rescope == without_rescope, (
+            "same request, different outcome depending on rescope: "
+            f"rescope sent {with_rescope!r}, non-rescope sent {without_rescope!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_omitted_metadata_preserves_existing_on_rescope_path(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        # The other direction: omitted is NOT the same as explicitly null. A
+        # rescope that never mentions metadata must carry the existing value
+        # onto the replacement row (the row is new, so "leave alone" has to be
+        # materialized as the old value).
+        sent = await self._metadata_sent_for(
+            crypto_box,
+            VaultCredentialUpdate(allowed_hosts=["api.mailgun.net"]),
+            rescope=True,
+        )
+        assert sent == {"owner": "ops"}, f"omitted metadata was not preserved: sent {sent!r}"
+
+    @pytest.mark.asyncio
+    async def test_explicit_metadata_value_is_written_on_rescope_path(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        sent = await self._metadata_sent_for(
+            crypto_box,
+            VaultCredentialUpdate(allowed_hosts=["api.mailgun.net"], metadata={"owner": "sec"}),
+            rescope=True,
+        )
+        assert sent == {"owner": "sec"}
+
+
 # ── OAuth refresh ────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -492,6 +492,64 @@ class TestUpdateVaultCredentialCallSite:
         assert kwargs["blob"] is not None  # always re-encrypted
 
     @pytest.mark.asyncio
+    async def test_rescoping_env_var_archives_and_recreates_with_carried_secret(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        account_id = "acc_test_stub"
+        existing = VaultCredential(
+            id="vc_1",
+            vault_id="vlt_1",
+            display_name="mailgun",
+            target_url=None,
+            auth_type="environment_variable",
+            secret_name="MAILGUN_API_KEY",
+            allowed_hosts=["mailgun.com"],
+            metadata={"owner": "ops"},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        existing_blob = crypto_box.derive_account_subkey(account_id).encrypt_dict(
+            {"secret_value": "carried-secret"}
+        )
+        replacement = existing.model_copy(
+            update={"id": "vc_2", "allowed_hosts": ["api.mailgun.net"]}
+        )
+        conn = MagicMock()
+        pool = fake_pool_yielding_conn(conn)
+
+        with (
+            patch.object(
+                queries,
+                "get_vault_credential_with_blob",
+                AsyncMock(return_value=(existing, existing_blob)),
+            ),
+            patch.object(
+                queries, "archive_vault_credential", AsyncMock(return_value=existing)
+            ) as archive,
+            patch.object(
+                queries, "insert_vault_credential", AsyncMock(return_value=replacement)
+            ) as insert,
+        ):
+            result = await vaults_service.update_vault_credential(
+                pool,
+                crypto_box,
+                vault_id="vlt_1",
+                credential_id="vc_1",
+                body=VaultCredentialUpdate(allowed_hosts=["api.mailgun.net"]),
+                account_id=account_id,
+            )
+
+        assert result.id == "vc_2"
+        archive.assert_awaited_once_with(conn, "vlt_1", "vc_1", account_id=account_id)
+        assert insert.await_args is not None
+        kwargs = insert.await_args.kwargs
+        assert kwargs["secret_name"] == "MAILGUN_API_KEY"
+        assert kwargs["allowed_hosts"] == ["api.mailgun.net"]
+        assert crypto_box.derive_account_subkey(account_id).decrypt_dict(kwargs["blob"]) == {
+            "secret_value": "carried-secret"
+        }
+
+    @pytest.mark.asyncio
     async def test_passes_display_name_when_set_even_to_none(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         existing = _existing_credential()


### PR DESCRIPTION
Automated dev-pipeline build for issue #2018.