### PR TITLE
workspace-root startup validation has no in-band exit: no report-only mode, fails on first row, no pre-flight command

### DIFF
--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -88,61 +88,79 @@ def create_app() -> FastAPI:
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         log.info("api.startup", db_url=_redact_dsn(settings.db_url))
         pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
-        crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-        async with pool.acquire() as conn:
-            await queries.audit_credentialless_root(conn)
-        await procrastinate_app.open_async()
-        app.state.pool = pool
-        app.state.crypto_box = crypto_box
-        app.state.procrastinate = procrastinate_app
-        app.state.db_url = settings.db_url
-        # Readiness stays RED until the fail-closed boot-admission gate proves
-        # the live DB is safe for this code. ``/ready`` reads this flag, so a
-        # behind / residue-bearing / unreachable DB never lets the new
-        # container serve while the old one is still healthy (#1575).
-        app.state.retirements_ok = False
-
-        # #959: the api runs as uid 1000 and can't repair ownership (no
-        # CAP_CHOWN). If the worker (root) created a shared root first and
-        # left it root-owned, ``POST /sessions/{id}/files`` 500s on mkdir.
-        # The api can't fix it — but it can refuse to fail silently. Log
-        # loudly and keep serving non-FS routes; the worker's startup
-        # repair pass is what actually heals the tree.
-        euid = os.geteuid()
-        for p in (
-            settings.workspace_root,
-            uploads_root(),
-            attachments_root(),
-            memory_stores_root(),
-        ):
-            if p.exists() and not os.access(p, os.W_OK):
-                try:
-                    st_uid = p.stat().st_uid
-                except OSError:
-                    st_uid = -1
-                log.warning("api.workspace_unwritable", path=str(p), euid=euid, st_uid=st_uid)
-
-        # The ``/context`` endpoint (issue #60) reuses the worker's
-        # ``compose_step_context`` → ``compute_step_prelude`` path, which
-        # reaches for ``runtime.require_crypto_box()`` to decrypt per-vault
-        # MCP OAuth tokens and ``runtime.require_tool_provider()`` to merge
-        # connection-declared tools (#328 PR 4). Mirror the worker's
-        # globals on the API side so the shared composer works from either
-        # process.
-        from aios_connectors.providers import SubsystemToolProvider
-
+        procrastinate_opened = False
         prev_crypto = runtime.crypto_box
         prev_tool_provider = runtime.tool_provider
-        runtime.crypto_box = crypto_box
-        runtime.tool_provider = SubsystemToolProvider()
+        runtime_globals_changed = False
+        try:
+            crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+            async with pool.acquire() as conn:
+                await queries.audit_credentialless_root(conn)
+            from aios.sandbox.workspace_root_startup import (
+                validate_workspace_root_against_sessions,
+            )
 
-        # Fail-closed boot-admission gate (#1575): block here — readiness RED —
-        # until the live DB is proven safe for this code (alembic at/past every
-        # contract_rev AND zero live residue on every registered surface). This
-        # runs on EVERY boot, including raw restores, and is never cached.
-        await _await_retirements_admissible(pool, log)
-        app.state.retirements_ok = True
-        log.info("api.boot_gate.admitted")
+            await validate_workspace_root_against_sessions(pool, service="api")
+            await procrastinate_app.open_async()
+            procrastinate_opened = True
+            app.state.pool = pool
+            app.state.crypto_box = crypto_box
+            app.state.procrastinate = procrastinate_app
+            app.state.db_url = settings.db_url
+            # Readiness stays RED until the fail-closed boot-admission gate proves
+            # the live DB is safe for this code. ``/ready`` reads this flag, so a
+            # behind / residue-bearing / unreachable DB never lets the new
+            # container serve while the old one is still healthy (#1575).
+            app.state.retirements_ok = False
+
+            # #959: the api runs as uid 1000 and can't repair ownership (no
+            # CAP_CHOWN). If the worker (root) created a shared root first and
+            # left it root-owned, ``POST /sessions/{id}/files`` 500s on mkdir.
+            # The api can't fix it — but it can refuse to fail silently. Log
+            # loudly and keep serving non-FS routes; the worker's startup
+            # repair pass is what actually heals the tree.
+            euid = os.geteuid()
+            for p in (
+                settings.workspace_root,
+                uploads_root(),
+                attachments_root(),
+                memory_stores_root(),
+            ):
+                if p.exists() and not os.access(p, os.W_OK):
+                    try:
+                        st_uid = p.stat().st_uid
+                    except OSError:
+                        st_uid = -1
+                    log.warning("api.workspace_unwritable", path=str(p), euid=euid, st_uid=st_uid)
+
+            # The ``/context`` endpoint (issue #60) reuses the worker's
+            # ``compose_step_context`` → ``compute_step_prelude`` path, which
+            # reaches for ``runtime.require_crypto_box()`` to decrypt per-vault
+            # MCP OAuth tokens and ``runtime.require_tool_provider()`` to merge
+            # connection-declared tools (#328 PR 4). Mirror the worker's
+            # globals on the API side so the shared composer works from either
+            # process.
+            from aios_connectors.providers import SubsystemToolProvider
+
+            runtime.crypto_box = crypto_box
+            runtime.tool_provider = SubsystemToolProvider()
+            runtime_globals_changed = True
+
+            # Fail-closed boot-admission gate (#1575): block here — readiness RED —
+            # until the live DB is proven safe for this code (alembic at/past every
+            # contract_rev AND zero live residue on every registered surface). This
+            # runs on EVERY boot, including raw restores, and is never cached.
+            await _await_retirements_admissible(pool, log)
+            app.state.retirements_ok = True
+            log.info("api.boot_gate.admitted")
+        except BaseException:
+            if runtime_globals_changed:
+                runtime.crypto_box = prev_crypto
+                runtime.tool_provider = prev_tool_provider
+            if procrastinate_opened:
+                await procrastinate_app.close_async()
+            await pool.close()
+            raise
 
         try:
             yield

--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -188,6 +188,27 @@ def _run_migrate() -> int:
     return 0
 
 
+async def _run_validate_workspace_roots_async() -> int:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+    from aios.sandbox.workspace_root_startup import validate_workspace_root_against_sessions
+
+    settings = get_settings()
+    pool = await create_pool(settings.db_url, min_size=1, max_size=1)
+    try:
+        result = await validate_workspace_root_against_sessions(
+            pool, service="preflight", mode="warn"
+        )
+    finally:
+        await pool.close()
+    typer.echo(f"workspace-root validation found {result.violation_count} violation(s)")
+    return 1 if result.violation_count else 0
+
+
+def _run_validate_workspace_roots() -> int:
+    return asyncio.run(_run_validate_workspace_roots_async())
+
+
 def register(app: typer.Typer) -> None:
     """Attach the operator commands to the root app."""
 
@@ -209,3 +230,16 @@ def register(app: typer.Typer) -> None:
     @app.command("rekey", help="Re-encrypt encrypted rows after AIOS_VAULT_KEY rotation.")
     def rekey() -> None:
         raise typer.Exit(_run_rekey())
+
+    ops = typer.Typer(
+        name="ops", help="Read-only operator pre-flight checks.", no_args_is_help=True
+    )
+
+    @ops.command(
+        "validate-workspace-roots",
+        help="Validate all live session workspace paths against AIOS_WORKSPACE_ROOT.",
+    )
+    def validate_workspace_roots() -> None:
+        raise typer.Exit(_run_validate_workspace_roots())
+
+    app.add_typer(ops, name="ops")

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -394,6 +394,24 @@ class Settings(BaseSettings):
     worker_watchdog_activity_rows: int = Field(default=100, ge=1, le=1000)
     worker_watchdog_max_specimens: int = Field(default=20, ge=1, le=1000)
     worker_watchdog_specimen_dir: Path = Field(default=Path("/tmp/aios-freeze-specimens"))
+    workspace_root_validation: Literal["enforce", "warn", "off"] = Field(
+        default="warn",
+        description="Live-session workspace-root startup validation mode. warn reports every "
+        "violation without blocking startup; enforce reports all violations then fails; off "
+        "skips the scan. Keep warn during rollout until a clean full-fleet report exists.",
+    )
+    workspace_scan_timeout_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        le=120,
+        description="Overall wall-clock budget for live-session workspace-root validation.",
+    )
+    workspace_scan_query_timeout_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        le=60,
+        description="Per-page database query timeout for workspace-root validation.",
+    )
 
     # ── container lifecycle ────────────────────────────────────────────────
     container_idle_timeout_seconds: int = Field(

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -378,6 +378,9 @@ async def worker_main() -> None:
         crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
         async with pool.acquire() as conn:
             await queries.audit_credentialless_root(conn)
+        from aios.sandbox.workspace_root_startup import validate_workspace_root_against_sessions
+
+        await validate_workspace_root_against_sessions(pool, service="worker")
         sandbox_registry = SandboxRegistry(backend=select_sandbox_backend(settings))
         inflight_tool_registry = InflightToolRegistry()
         mcp_session_pool = McpSessionPool()

--- a/src/aios/sandbox/workspace_root_startup.py
+++ b/src/aios/sandbox/workspace_root_startup.py
@@ -1,0 +1,193 @@
+"""Validate persisted live-session workspaces against this process's root."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import asyncpg
+
+from aios.config import get_settings
+from aios.errors import ForbiddenError
+from aios.logging import get_logger
+from aios.sandbox.volumes import validate_workspace_path
+
+WorkspaceRootValidationMode = Literal["enforce", "warn", "off"]
+_WORKSPACE_SCAN_PAGE_SIZE = 1000
+_VIOLATION_SAMPLE_SIZE = 10
+_VALIDATE_TIMEOUT_SECONDS = 2.0
+_CONN_RELEASE_TIMEOUT_SECONDS = 5.0
+
+
+class WorkspaceScanTimeoutError(RuntimeError):
+    """The workspace-root scan exceeded its configured deadline."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceRootViolation:
+    session_id: str
+    account_id: str
+    raw_path: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceRootValidationResult:
+    violation_count: int
+
+
+class WorkspaceRootValidationError(RuntimeError):
+    """One or more live session rows violate the workspace jail."""
+
+    def __init__(
+        self,
+        violation_count: int,
+        sample: list[WorkspaceRootViolation],
+        *,
+        service: str,
+    ) -> None:
+        self.violation_count = violation_count
+        rendered = "; ".join(
+            f"session_id={row.session_id!r}, account_id={row.account_id!r}, "
+            f"workspace_volume_path={row.raw_path!r}, reason={row.reason!r}"
+            for row in sample
+        )
+        omitted = violation_count - len(sample)
+        suffix = f"; {omitted} additional violation(s) omitted" if omitted else ""
+        super().__init__(
+            f"workspace-root validation found {violation_count} violation(s) "
+            f"(service={service!r}); sample: {rendered}{suffix}"
+        )
+
+
+def _remaining(deadline: float) -> float:
+    return max(0.0, deadline - time.monotonic())
+
+
+def _timeout(scan_timeout_seconds: float, service: str, last_id: str | None, phase: str) -> None:
+    raise WorkspaceScanTimeoutError(
+        f"workspace-root validation exceeded {scan_timeout_seconds}s deadline during {phase} "
+        f"(service={service!r}, last_id={last_id!r})"
+    )
+
+
+async def validate_workspace_root_against_sessions(
+    pool: asyncpg.Pool[Any],
+    *,
+    service: str,
+    mode: WorkspaceRootValidationMode | None = None,
+    scan_timeout_seconds: float | None = None,
+    query_timeout_seconds: float | None = None,
+) -> WorkspaceRootValidationResult:
+    """Scan every unarchived session and enforce or report workspace-jail failures.
+
+    ``warn`` logs each violating row and returns normally. ``enforce`` performs
+    the same full scan and logging, then raises one aggregate error. ``off``
+    performs no database work. The pre-flight command invokes this exact
+    function in ``warn`` mode and maps the returned count to its exit status.
+    """
+    settings = get_settings()
+    mode = mode or settings.workspace_root_validation
+    if mode == "off":
+        return WorkspaceRootValidationResult(violation_count=0)
+    scan_timeout_seconds = scan_timeout_seconds or settings.workspace_scan_timeout_seconds
+    query_timeout_seconds = query_timeout_seconds or settings.workspace_scan_query_timeout_seconds
+    deadline = time.monotonic() + scan_timeout_seconds
+    last_id: str | None = None
+    violation_count = 0
+    sample: list[WorkspaceRootViolation] = []
+    log = get_logger("aios.workspace_root_validation")
+
+    while True:
+        remaining = _remaining(deadline)
+        if remaining <= 0:
+            _timeout(scan_timeout_seconds, service, last_id, "pool acquire")
+        ctx = pool.acquire()
+        try:
+            conn = await asyncio.wait_for(ctx.__aenter__(), timeout=remaining)
+        except TimeoutError:
+            _timeout(scan_timeout_seconds, service, last_id, "pool acquire")
+
+        try:
+            remaining = _remaining(deadline)
+            if remaining <= 0:
+                _timeout(scan_timeout_seconds, service, last_id, "query")
+            try:
+                rows = await conn.fetch(
+                    """
+                    SELECT id, account_id, workspace_volume_path
+                      FROM sessions
+                     WHERE archived_at IS NULL
+                       AND ($1::text IS NULL OR id > $1)
+                     ORDER BY id
+                     LIMIT $2
+                    """,
+                    last_id,
+                    _WORKSPACE_SCAN_PAGE_SIZE,
+                    timeout=min(query_timeout_seconds, remaining),
+                )
+            except TimeoutError:
+                _timeout(scan_timeout_seconds, service, last_id, "query")
+        finally:
+            try:
+                await asyncio.wait_for(
+                    ctx.__aexit__(None, None, None), timeout=_CONN_RELEASE_TIMEOUT_SECONDS
+                )
+            except TimeoutError:
+                _timeout(scan_timeout_seconds, service, last_id, "connection release")
+
+        if not rows:
+            break
+        for row in rows:
+            remaining = _remaining(deadline)
+            if remaining <= 0:
+                _timeout(scan_timeout_seconds, service, last_id, "row validation")
+            session_id = row["id"]
+            account_id = row["account_id"]
+            raw_path = row["workspace_volume_path"]
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(
+                        validate_workspace_path,
+                        raw_path,
+                        account_id,
+                        session_id=session_id,
+                    ),
+                    timeout=min(_VALIDATE_TIMEOUT_SECONDS, remaining),
+                )
+            except TimeoutError:
+                _timeout(scan_timeout_seconds, service, session_id, "row validation")
+            except (ForbiddenError, OSError, ValueError) as exc:
+                violation = WorkspaceRootViolation(
+                    session_id=session_id,
+                    account_id=account_id,
+                    raw_path=raw_path,
+                    reason=str(exc),
+                )
+                violation_count += 1
+                if len(sample) < _VIOLATION_SAMPLE_SIZE:
+                    sample.append(violation)
+                log.warning(
+                    "workspace_root_validation.violation",
+                    service=service,
+                    mode=mode,
+                    workspace_root=str(settings.workspace_root),
+                    session_id=session_id,
+                    account_id=account_id,
+                    workspace_volume_path=raw_path,
+                    reason=str(exc),
+                )
+        last_id = rows[-1]["id"]
+
+    result = WorkspaceRootValidationResult(violation_count=violation_count)
+    log.info(
+        "workspace_root_validation.complete",
+        service=service,
+        mode=mode,
+        violation_count=result.violation_count,
+    )
+    if violation_count and mode == "enforce":
+        raise WorkspaceRootValidationError(violation_count, sample, service=service)
+    return result

--- a/tests/unit/cli/test_workspace_root_ops.py
+++ b/tests/unit/cli/test_workspace_root_ops.py
@@ -1,0 +1,53 @@
+"""Exit codes for ``aios ops validate-workspace-roots``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from aios.cli.app import app
+from aios.sandbox.workspace_root_startup import WorkspaceRootValidationResult
+
+runner = CliRunner()
+
+
+def _pool() -> AsyncMock:
+    pool = AsyncMock()
+    pool.close = AsyncMock()
+    return pool
+
+
+def test_preflight_exits_zero_when_clean() -> None:
+    pool = _pool()
+    with (
+        patch("aios.config.get_settings", return_value=SimpleNamespace(db_url="postgresql://db")),
+        patch("aios.db.pool.create_pool", AsyncMock(return_value=pool)),
+        patch(
+            "aios.sandbox.workspace_root_startup.validate_workspace_root_against_sessions",
+            AsyncMock(return_value=WorkspaceRootValidationResult(violation_count=0)),
+        ),
+    ):
+        result = runner.invoke(app, ["ops", "validate-workspace-roots"])
+
+    assert result.exit_code == 0, result.output
+    assert "0 violation(s)" in result.output
+    pool.close.assert_awaited_once()
+
+
+def test_preflight_exits_nonzero_on_violations() -> None:
+    pool = _pool()
+    with (
+        patch("aios.config.get_settings", return_value=SimpleNamespace(db_url="postgresql://db")),
+        patch("aios.db.pool.create_pool", AsyncMock(return_value=pool)),
+        patch(
+            "aios.sandbox.workspace_root_startup.validate_workspace_root_against_sessions",
+            AsyncMock(return_value=WorkspaceRootValidationResult(violation_count=3)),
+        ),
+    ):
+        result = runner.invoke(app, ["ops", "validate-workspace-roots"])
+
+    assert result.exit_code == 1
+    assert "3 violation(s)" in result.output
+    pool.close.assert_awaited_once()

--- a/tests/unit/test_workspace_root_startup.py
+++ b/tests/unit/test_workspace_root_startup.py
@@ -1,0 +1,94 @@
+"""Workspace-root startup validation modes and full enumeration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from aios.sandbox.workspace_root_startup import (
+    WorkspaceRootValidationError,
+    validate_workspace_root_against_sessions,
+)
+
+
+class _Acquire:
+    def __init__(self, conn: Any) -> None:
+        self.conn = conn
+
+    async def __aenter__(self) -> Any:
+        return self.conn
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+
+class _Pool:
+    def __init__(self, rows: list[dict[str, str]]) -> None:
+        self.conn = AsyncMock()
+        self.conn.fetch.side_effect = [rows, []]
+
+    def acquire(self) -> _Acquire:
+        return _Acquire(self.conn)
+
+
+@pytest.mark.asyncio
+async def test_warn_mode_enumerates_every_violation_without_aborting(tmp_path: Path) -> None:
+    rows = [
+        {"id": "sess_a", "account_id": "acc_a", "workspace_volume_path": "/wrong/a"},
+        {"id": "sess_b", "account_id": "acc_b", "workspace_volume_path": "/wrong/b"},
+    ]
+    log = Mock()
+    with (
+        patch("aios.sandbox.workspace_root_startup.get_settings") as settings,
+        patch("aios.sandbox.workspace_root_startup.get_logger", return_value=log),
+    ):
+        settings.return_value.workspace_root = tmp_path
+        settings.return_value.workspace_scan_timeout_seconds = 30.0
+        settings.return_value.workspace_scan_query_timeout_seconds = 10.0
+        result = await validate_workspace_root_against_sessions(
+            _Pool(rows), service="worker", mode="warn"
+        )
+
+    assert result.violation_count == 2
+    assert log.warning.call_count == 2
+    assert {call.kwargs["session_id"] for call in log.warning.call_args_list} == {
+        "sess_a",
+        "sess_b",
+    }
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_scans_all_then_raises_once(tmp_path: Path) -> None:
+    rows = [
+        {"id": f"sess_{i}", "account_id": "acc", "workspace_volume_path": f"/wrong/{i}"}
+        for i in range(12)
+    ]
+    log = Mock()
+    with (
+        patch("aios.sandbox.workspace_root_startup.get_settings") as settings,
+        patch("aios.sandbox.workspace_root_startup.get_logger", return_value=log),
+    ):
+        settings.return_value.workspace_root = tmp_path
+        settings.return_value.workspace_scan_timeout_seconds = 30.0
+        settings.return_value.workspace_scan_query_timeout_seconds = 10.0
+        with pytest.raises(WorkspaceRootValidationError) as caught:
+            await validate_workspace_root_against_sessions(
+                _Pool(rows), service="api", mode="enforce"
+            )
+
+    assert caught.value.violation_count == 12
+    assert "12 violation(s)" in str(caught.value)
+    assert "sess_0" in str(caught.value)
+    assert "sess_11" not in str(caught.value)  # bounded sample
+    assert log.warning.call_count == 12
+
+
+@pytest.mark.asyncio
+async def test_off_mode_does_not_scan() -> None:
+    pool = _Pool([])
+    result = await validate_workspace_root_against_sessions(pool, service="api", mode="off")
+    assert result.violation_count == 0
+    pool.conn.fetch.assert_not_awaited()


### PR DESCRIPTION
Automated dev-pipeline build for issue #2068.