### PR TITLE
Silent truncation of child-session task payload (~60 chars) caused a sub-agent to improvise cross-repo writes

### DIFF
--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -713,9 +713,9 @@ async def get_open_obligations(
     edge so the tail-injected obligations block (and the ``obligations`` read
     model) can render it: ``caller_kind`` (``req.data->'caller'->>'kind'`` — the
     **trusted** frame, not the forgeable ``metadata.request`` blob), ``opened_at``
-    (``req.created_at``, for age), and a short ``summary`` (``req.data->>'summary'``,
-    additive — absent on pre-#1413 frames -> ``None`` -> an id-only render line, no
-    migration).
+    (``req.created_at``, for age), and the request content in the legacy-named
+    ``summary`` field (``req.data->>'summary'``, additive — absent on pre-#1413
+    frames -> ``None`` -> a loud unavailable marker, no migration).
 
     #1522 widens the projection to also carry ``output_schema``
     (``req.data->'output_schema'``) — the JSON Schema the request demands of its
@@ -1265,12 +1265,11 @@ async def append_request_opened(
     wake opens the edge exactly once (see :func:`get_open_request_ids` for the
     asked-minus-answered derivation this feeds).
 
-    ``summary`` (#1413) is a short (~60-char) truncated preview of the request
-    input, carried so the always-on tail-injected obligations block can render a
-    human-readable line for an obligation whose original request user message has
-    been windowed out of context. **Purely additive**: omitted (the legacy/None
-    case) it is simply not written to the frame, and the obligations reader treats
-    an absent field as ``None`` -> an id-only render line (no migration, #1131-proof
+    ``summary`` (#1413, retained field name for event compatibility) is the
+    verbatim request input, carried so the always-on tail-injected obligations block
+    can recover the task after its original user message is windowed out. **Purely
+    additive**: omitted (the legacy/None case) it is simply not written to the frame,
+    and the obligations renderer shows a loud unavailable marker (no migration, #1131-proof
     -- frame-extension rather than a LEFT-JOIN on the soon-retired ``metadata`` blob).
     """
     data: dict[str, Any] = {

--- a/src/aios/harness/obligations.py
+++ b/src/aios/harness/obligations.py
@@ -40,12 +40,14 @@ if TYPE_CHECKING:
 # complementary per-session open-goal admission cap.
 MAX_RENDERED_OBLIGATIONS = 10
 
-# Summary truncation length; matches the 60-char preview the channels tail uses
-# and the store-side ``_obligation_summary`` budget.
-_SUMMARY_MAX = 60
+# Requests up to this size remain verbatim in the always-on reminder. Beyond it,
+# render a loud refusal instruction rather than a plausible-looking prefix. This
+# bounds the reserved tail while making instruction loss impossible to miss.
+_TASK_MAX = 8192
+_TASK_TRUNCATED = "[TASK TRUNCATED — return an error; do not act on or infer the missing task]"
 
-# Max chars of a rendered ``output_schema`` contract (#1522). Analogous to the
-# 60-char summary cap, but wider because a schema is a structural contract (it
+# Max chars of a rendered ``output_schema`` contract (#1522). Kept narrower
+# than the task budget because a schema is a structural contract and usually
 # legitimately needs a few keys/types to be useful) — still a HARD cap so a large
 # persisted schema can't blow the reserved tail budget. A schema longer than this
 # is JSON-serialised then elided to this width + an ellipsis. The bound is what
@@ -89,13 +91,13 @@ def _format_age(opened_at: datetime, now: datetime) -> str:
     return f"{hours // 24}d"
 
 
-def _truncate_summary(summary: str | None) -> str:
-    if not summary:
-        return ""
-    s = summary.replace("\n", " ").strip()
-    if len(s) > _SUMMARY_MAX:
-        s = s[:_SUMMARY_MAX] + "…"
-    return s
+def _request_content(summary: str | None) -> str:
+    """Render a verbatim task, or a loud marker when that is impossible."""
+    if summary is None:
+        return "[TASK CONTENT UNAVAILABLE — return an error; do not infer the task]"
+    if len(summary) > _TASK_MAX:
+        return f"{_TASK_TRUNCATED} (received {len(summary)} characters; limit {_TASK_MAX})"
+    return summary
 
 
 def _render_schema(output_schema: dict[str, Any] | None) -> str | None:
@@ -103,8 +105,8 @@ def _render_schema(output_schema: dict[str, Any] | None) -> str | None:
     (#1522), or ``None`` when the request demands no schema.
 
     JSON-serialises the schema (compact separators, sorted keys for stability) and
-    **elides** it to :data:`_SCHEMA_MAX` chars + an ellipsis — the schema-side
-    analogue of the 60-char summary cap. A large persisted schema can therefore
+    **elides** it to :data:`_SCHEMA_MAX` chars + an ellipsis. A large persisted
+    schema can therefore
     NEVER inflate the rendered tail past a fixed per-entry bound, which is what
     keeps :func:`max_obligations_block_local` a correct upper bound (no
     ``read_windowed_events`` budget overflow). Newlines are flattened so the
@@ -122,15 +124,15 @@ def _render_schema(output_schema: dict[str, Any] | None) -> str | None:
 def _obligation_line(obligation: Obligation, *, session_id: str, now: datetime) -> str:
     """One render line for an obligation, oldest-first ordering applied by caller.
 
-    Shape: ``• <request_id> [origin] "<summary>" (open <age>)`` — the literal
-    ``request_id`` first (copy-pasteable; the id the model echoes to
-    ``return``/``error``), then origin, an optional quoted summary, and age.
+    The literal ``request_id`` comes first (copy-pasteable; the id the model
+    echoes to ``return``/``error``), followed by origin, age, and the verbatim
+    task. Tasks beyond the render budget are replaced wholesale by a loud marker;
+    no plausible-looking prefix is ever shown.
     """
     origin = _origin_label(obligation, session_id=session_id)
-    summary = _truncate_summary(obligation.summary)
-    summary_clause = f' "{summary}"' if summary else ""
+    request_content = _request_content(obligation.summary)
     age = _format_age(obligation.opened_at, now)
-    return f"• {obligation.request_id} [{origin}]{summary_clause} (open {age})"
+    return f"• {obligation.request_id} [{origin}] (open {age}) verbatim task: {request_content}"
 
 
 def build_obligations_tail_block(
@@ -149,7 +151,8 @@ def build_obligations_tail_block(
     Header line, then one line per obligation **oldest-first** (the caller already
     fetches them ``ORDER BY req.seq ASC``): the literal ``request_id``, an
     ``[origin]`` label (``api``|``session``|``run``, plus ``self`` for a #1414
-    self-goal), a ``<=60``-char quoted summary, and ``(open <age>)``. The block is
+    self-goal), ``(open <age>)``, and the verbatim task (or a loud truncation
+    marker when it exceeds the render budget). The block is
     capped at :data:`MAX_RENDERED_OBLIGATIONS` lines + a ``+K more`` marker so the
     reserved tail budget stays bounded regardless of obligation count.
 
@@ -183,7 +186,8 @@ def render_owed_entry(obligation: Obligation, *, session_id: str, now: datetime)
 
     Each entry carries ``request_id``, ``caller_kind`` (the trusted frame kind),
     ``origin`` (``api``/``session``/``run`` plus ``self`` for a #1414 self-goal),
-    a ``<=60``-char ``summary``, a terse ``age``, and the **bounded**
+    the verbatim task in ``summary`` (or a loud truncation marker), a terse
+    ``age``, and the **bounded**
     ``output_schema`` contract (elided to :data:`_SCHEMA_MAX`; ``None`` when the
     request demands no schema). The schema bound is what lets the surfacing render
     stay within :func:`max_obligations_block_local`'s upper bound.
@@ -192,7 +196,7 @@ def render_owed_entry(obligation: Obligation, *, session_id: str, now: datetime)
         "request_id": obligation.request_id,
         "caller_kind": obligation.caller_kind or "",
         "origin": _origin_label(obligation, session_id=session_id),
-        "summary": _truncate_summary(obligation.summary),
+        "summary": _request_content(obligation.summary),
         "age": _format_age(obligation.opened_at, now),
         "output_schema": _render_schema(obligation.output_schema),
     }
@@ -223,7 +227,7 @@ def render_owed_listing(
 
     A header line, then one entry per open obligation **oldest-first** (the caller
     fetches them ``ORDER BY req.seq ASC``) drawn from :func:`render_owed_entry`:
-    each line shows ``request_id``, ``[origin]`` (incl. ``self``), quoted summary,
+    each line shows ``request_id``, ``[origin]`` (incl. ``self``), task content,
     age, **and the bounded ``output_schema`` contract** — the format the session
     must produce to answer. Capped at :data:`MAX_RENDERED_OBLIGATIONS` entries +
     a ``+K more`` marker so the rendered size stays bounded regardless of count;
@@ -249,8 +253,9 @@ def max_obligations_block_local(obligations: list[Obligation]) -> int:
     unknown pre-windowing, so it synthesizes a fattest-line bound), the obligation
     set is **already fetched** by ``compute_step_prelude``, so this bounds from the
     REAL obligations — the real count (capped at :data:`MAX_RENDERED_OBLIGATIONS`
-    + the ``+K more`` marker line) and each real summary (re-truncated to the
-    render width). Strictly tighter than a synthetic max; the produced tail at
+    + the ``+K more`` marker line) and each rendered task (verbatim through
+    :data:`_TASK_MAX`, then replaced by a fixed loud marker). Strictly tighter than
+    a synthetic max; the produced tail at
     send time is guaranteed ≤ this bound, so reserving it never overshoots
     ``window_max``.
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -603,20 +603,14 @@ async def stimulate(pool: asyncpg.Pool[Any], stim: Stimulus, *, account_id: str)
     return await _stimulate_existing_tell(pool, stim, account_id=account_id)
 
 
-# Max length of the ``summary`` preview carried on the ``request_opened`` frame
-# (#1413). Matches the 60-char truncation the obligations tail block renders; a
-# slightly larger store budget is pointless since the renderer re-truncates.
-_OBLIGATION_SUMMARY_MAX = 60
-
-
 def _obligation_summary(content: str) -> str:
-    """A short single-line preview of a request input, for the #1413 obligations
-    block. Collapses newlines and truncates to ``_OBLIGATION_SUMMARY_MAX`` chars
-    (ellipsis when clipped) -- mirrors the channels-tail preview clause."""
-    preview = content.replace("\n", " ").strip()
-    if len(preview) > _OBLIGATION_SUMMARY_MAX:
-        preview = preview[:_OBLIGATION_SUMMARY_MAX] + "…"
-    return preview
+    """The verbatim request input carried by the durable obligation edge.
+
+    The original user event can leave the context window while its request remains
+    open. Persisting only a preview here would make the always-on obligation plane
+    silently lose the task at exactly that point, so this copy must remain exact.
+    """
+    return content
 
 
 async def create_child_session(

--- a/tests/unit/test_obligations.py
+++ b/tests/unit/test_obligations.py
@@ -88,24 +88,32 @@ class TestBuildObligationsTailBlock:
         assert block is not None
         assert "[self]" in block["content"]
 
-    def test_summary_quoted_and_truncated_to_60(self) -> None:
-        ob = _ob("req_long", summary="x" * 200)
+    def test_task_payload_over_4kb_is_rendered_verbatim(self) -> None:
+        task = "first line\n" + "x" * 4096 + "\nlast line"
+        ob = _ob("req_long", summary=task)
         block = build_obligations_tail_block([ob], session_id="sess_x", now=_NOW)
         assert block is not None
-        line = block["content"].splitlines()[1]
-        # The quoted preview body is <= 60 chars (+ ellipsis), never the full 200.
-        assert '"' in line
-        body = line.split('"')[1]
-        assert len(body.rstrip("…")) <= 60
+        content = block["content"]
+        assert "verbatim task: " + task in content
+        assert "TRUNCATED" not in content
 
-    def test_missing_summary_renders_id_only_no_crash(self) -> None:
+    def test_oversized_task_fails_loud_instead_of_showing_a_silent_prefix(self) -> None:
+        ob = _ob("req_too_long", summary="dangerous instruction " * 1000)
+        block = build_obligations_tail_block([ob], session_id="sess_x", now=_NOW)
+        assert block is not None
+        content = block["content"]
+        assert "TASK TRUNCATED" in content
+        assert "return an error; do not act on or infer" in content
+        assert "dangerous instruction" not in content
+
+    def test_missing_task_fails_loud(self) -> None:
         ob = _ob("req_nosum", summary=None)
         block = build_obligations_tail_block([ob], session_id="sess_x", now=_NOW)
         assert block is not None
         line = block["content"].splitlines()[1]
         assert "req_nosum" in line
-        # No empty quoted clause for an absent summary.
-        assert '""' not in line
+        assert "TASK CONTENT UNAVAILABLE" in line
+        assert "do not infer" in line
 
     def test_age_clause_present(self) -> None:
         ob = _ob("req_age", age=timedelta(minutes=5))

--- a/tests/unit/test_request_opened_edge.py
+++ b/tests/unit/test_request_opened_edge.py
@@ -348,9 +348,14 @@ def test_both_writers_pass_summary_to_append_request_opened() -> None:
     assert _writer_passes_summary(sessions_svc._stimulate_existing_ask)
 
 
+def test_obligation_edge_preserves_task_payload_over_4kb_verbatim() -> None:
+    task = "first line\n" + "x" * 4096 + "\nlast line"
+    assert sessions_svc._obligation_summary(task) == task
+
+
 def test_append_request_opened_summary_is_additive() -> None:
-    """The summary is written only when present (absent ⇒ no key ⇒ id-only render,
-    no migration). The frame data dict is built conditionally, not unconditionally."""
+    """The request copy is written only when present (absent ⇒ no key ⇒ loud
+    unavailable marker, no migration). The frame data dict is conditional."""
     func_src = _src(sessions_q.append_request_opened)
     assert 'data["summary"] = summary' in func_src
     assert "if summary is not None" in func_src


### PR DESCRIPTION
Automated dev-pipeline build for issue #2071.