### PR TITLE
supports_vision collapses to 'no' on LiteLLM catalog miss — grok-4.6 vision silently degraded (sibling of #2084)

### DIFF
--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import re
 from typing import Any
 
 from aios.logging import get_logger
@@ -60,17 +61,26 @@ _VISION_OVERRIDES: dict[str, bool] = {}
 _VISION_GATEWAY_PREFIX = "openai/responses/"
 _VISION_GATEWAY_FAMILIES = frozenset({"gpt-5", "gpt-4o", "o4"})
 
+# Maintained family assertions cover provider models whose capability is newer
+# than the pinned LiteLLM catalog. Keep these beside the gateway assertions and
+# completion parameter maps: the catalog is useful metadata, not final
+# authority. xAI's numbered Grok 4 line accepts image input; constrain the
+# match to numbered releases so text-specialized siblings such as grok-code do
+# not inherit vision accidentally.
+_XAI_GROK_4_VISION_RE = re.compile(r"^xai/grok-4(?:\.\d+)*$")
 
-def supports_vision(model: str) -> bool:
+
+def supports_vision(model: str) -> bool | None:
     """True when ``model`` accepts ``image_url`` content parts.
 
     Resolution order:
 
     1. :data:`_VISION_OVERRIDES` — explicit per-model escape hatch (force
        ``True`` or ``False``).
-    2. Known vision families on custom gateway routes, plus any Claude family,
-       are assumed vision-capable. A long-running worker fetches litellm's
-       catalog once at startup, so a Claude model released afterwards makes
+    2. Maintained family assertions for provider and custom gateway routes,
+       plus any Claude family, are assumed vision-capable. A long-running worker
+       fetches litellm's catalog once at startup, so a Claude model released
+       afterwards makes
        ``litellm.get_model_info``
        raise "isn't mapped yet" and we would otherwise collapse to "no vision"
        — silently degrading image reads to a text marker.  Asserting the family
@@ -81,12 +91,13 @@ def supports_vision(model: str) -> bool:
        :attr:`~aios.harness.completion.CacheChannel.ANTHROPIC` — via the
        ``_ANTHROPIC_PROXY_PROVIDERS`` frozenset it reads — in
        :mod:`aios.harness.completion`).
-    3. ``litellm.get_model_info`` for every other provider/model.
+    3. ``litellm.get_model_info`` for every other provider/model. A lookup
+       failure returns ``None`` (unknown), never a confident ``False``.
     """
     if model in _VISION_OVERRIDES:
         return _VISION_OVERRIDES[model]
     normalized = model.lower()
-    if "claude" in normalized:
+    if "claude" in normalized or _XAI_GROK_4_VISION_RE.fullmatch(normalized):
         return True
     if normalized.startswith(_VISION_GATEWAY_PREFIX):
         gateway_model = normalized.removeprefix(_VISION_GATEWAY_PREFIX)
@@ -102,13 +113,10 @@ def supports_vision(model: str) -> bool:
     except Exception as err:
         # ``get_model_info`` raises a mix of ``BadRequestError`` (unknown
         # model), KeyError, and import/network errors depending on the
-        # failure mode.  Collapsing to "no vision" is the safe fallback
-        # (we degrade to a text marker the model can still ``read``), but
-        # the silence makes a transient outage look identical to "unknown
-        # model" — log warn-level so operators have a grep target when
-        # vision unexpectedly degrades across a deploy or provider blip.
+        # failure mode. Preserve that uncertainty rather than claiming the
+        # model has no vision; callers surface it in their visible marker.
         log.warning("vision.litellm_lookup_failed", model=model, error=str(err))
-        return False
+        return None
     return bool(info.get("supports_vision"))
 
 
@@ -174,7 +182,7 @@ def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
         return False
     if size_bytes > INLINE_SIZE_CAP_BYTES:
         return False
-    return supports_vision(model)
+    return supports_vision(model) is True
 
 
 def make_image_url_part(*, content_type: str, data_b64: str) -> dict[str, Any]:

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -25,7 +25,6 @@ from aios.harness.image_resize import ImageDownsampleError, maybe_downsample
 from aios.harness.vision import (
     INLINE_SIZE_CAP_BYTES,
     PROVIDER_INLINE_IMAGE_FORMATS,
-    can_inline_image,
     human_size,
     inline_image_format,
     make_image_url_part,
@@ -258,8 +257,13 @@ async def _read_image(
                     is_error=True,
                 )
 
-    if not can_inline_image(model=model, content_type=mime, size_bytes=size):
-        vision = "yes" if supports_vision(model) else "no"
+    vision_support = supports_vision(model)
+    if not mime.startswith("image/") or size > INLINE_SIZE_CAP_BYTES or vision_support is not True:
+        vision = {
+            True: "yes",
+            False: "no",
+            None: "unknown (LiteLLM catalog lookup failed)",
+        }[vision_support]
         # Render the cap with higher precision than ``human_size`` to
         # avoid the model getting "Image is 3.8MB, cap is 3.8MB" when
         # the truth is 3.93 MB > 3.75 MiB — ``human_size`` rounds both

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -321,6 +321,47 @@ class TestImageBranch:
         assert isinstance(result.content, list)
         assert result.content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
 
+    async def test_grok_4_6_inlines_when_litellm_catalog_is_stale(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        stub_get_session_model.value = "xai/grok-4.6"
+        monkeypatch.setattr(
+            "litellm.get_model_info",
+            lambda _model: (_ for _ in ()).throw(Exception("unknown model")),
+        )
+        _stage_workspace_image("sess_01TEST", "grok.png", valid_png_bytes())
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/grok.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["type"] == "image_url"
+
+    async def test_catalog_miss_reports_unknown_vision_support(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        stub_get_session_model.value = "future/model"
+        monkeypatch.setattr(
+            "litellm.get_model_info",
+            lambda _model: (_ for _ in ()).throw(Exception("unknown model")),
+        )
+        _stage_workspace_image("sess_01TEST", "future.png", valid_png_bytes())
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/future.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        assert "Mind vision support: unknown (LiteLLM catalog lookup failed)" in result.content
+        assert "Mind vision support: no" not in result.content
+
     async def test_blocked_for_non_vision_mind_is_not_an_error(
         self,
         temp_workspace_root: Path,

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -44,9 +44,23 @@ class TestSupportsVision:
         _patch_get_model_info(monkeypatch, {"foo/text": {"supports_vision": False}})
         assert vision.supports_vision("foo/text") is False
 
-    def test_false_when_litellm_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unknown_when_litellm_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_get_model_info(monkeypatch, {})  # any model raises
-        assert vision.supports_vision("totally/unknown") is False
+        assert vision.supports_vision("totally/unknown") is None
+
+    @pytest.mark.parametrize("model", ["xai/grok-4", "xai/grok-4.5", "xai/grok-4.6"])
+    def test_grok_4_family_assumed_vision_capable_despite_stale_litellm(
+        self, monkeypatch: pytest.MonkeyPatch, model: str
+    ) -> None:
+        _patch_get_model_info(monkeypatch, {})
+        assert vision.supports_vision(model) is True
+
+    @pytest.mark.parametrize("model", ["xai/grok-3", "xai/grok-code-fast-1"])
+    def test_other_grok_families_are_not_asserted_as_vision_capable(
+        self, monkeypatch: pytest.MonkeyPatch, model: str
+    ) -> None:
+        _patch_get_model_info(monkeypatch, {})
+        assert vision.supports_vision(model) is None
 
     def test_litellm_exception_emits_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Bare exception path must surface at warn-level so operators can
@@ -60,7 +74,7 @@ class TestSupportsVision:
                 warned.append((event, kwargs))
 
         monkeypatch.setattr("aios.harness.vision.log", _Recorder())
-        assert vision.supports_vision("totally/unknown") is False
+        assert vision.supports_vision("totally/unknown") is None
         assert len(warned) == 1
         event, kwargs = warned[0]
         assert event == "vision.litellm_lookup_failed"
@@ -120,7 +134,7 @@ class TestSupportsVision:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _patch_get_model_info(monkeypatch, {})
-        assert vision.supports_vision("openai/responses/future-text-model") is False
+        assert vision.supports_vision("openai/responses/future-text-model") is None
 
     def test_explicit_override_can_force_claude_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The override dict is consulted before the Claude-family rule, so an


### PR DESCRIPTION
Automated dev-pipeline build for issue #2085.