### PR TITLE
Connector serve loop dies permanently on a single emit_inbound failure (one bad message = account dark until manual restart)

### DIFF
--- a/connectors/signal/tests/test_handle_envelope.py
+++ b/connectors/signal/tests/test_handle_envelope.py
@@ -70,16 +70,6 @@ async def test_handle_envelope_raises_on_401(
         await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
 
 
-async def test_handle_envelope_raises_on_500(
-    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """5xx is a server-side outage; let the container crash + restart."""
-    monkeypatch.setattr(connector, "emit_inbound", AsyncMock(side_effect=_http_status_error(503)))
-
-    with pytest.raises(httpx.HTTPStatusError):
-        await connector._handle_envelope(CONNECTION_ID, _state(), _make_envelope())
-
-
 async def test_handle_envelope_sends_receipt_on_success(
     connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -60,7 +60,7 @@ import types
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Union, get_args, get_origin, get_type_hints
+from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
 
 import httpx
 import structlog
@@ -125,17 +125,12 @@ class ManagementHandlerError(Exception):
 
 
 def _is_fatal_inbound_status(status_code: int) -> bool:
-    """``emit_inbound`` raises for these; everything else (routine 4xx)
-    drops the envelope and returns ``None``.
+    """Raise only when runtime authentication is broken.
 
-    ``401`` / ``403`` mean the runtime token is busted (revoked or
-    misconfigured) — fatal for every connection the container serves.
-    ``5xx`` is a server-side outage / bug — also fatal so the
-    container crash-and-restarts.  Routine 4xx (``400``, ``422``)
-    indicates one specific envelope is malformed; dropping it lets
-    sibling connections keep serving.
+    A server error is logged and dropped per-message: allowing a transient
+    API outage to escape would terminate the connector's inbound feed.
     """
-    return status_code in (401, 403) or status_code >= 500
+    return status_code in (401, 403)
 
 
 def tool(
@@ -225,6 +220,9 @@ class _ConnectionState:
     external_account_id: str
     secrets: dict[str, str] = field(default_factory=dict)
     worker: asyncio.Task[None] | None = None
+    serve_status: Literal["serving", "restarting"] = "serving"
+    last_serve_error: str | None = None
+    serve_restart_count: int = 0
 
 
 class HttpConnector:
@@ -299,12 +297,12 @@ class HttpConnector:
         # consumer's job; container restarts simply re-run ``fresh``.
         self._discovery_cursor: int | None = None
 
-    # ── reconnect-backoff tunables (overridable on subclasses) ────────
+    # ── serve-restart tunables (overridable on subclasses) ────────────
+
     #
-    # Bounds the re-spawn rate of a connection whose ``serve_connection``
-    # keeps failing terminally.  The first (re)spawn after a failure
-    # sleeps ``RECONNECT_BACKOFF_INITIAL``; each subsequent consecutive
-    # failure doubles it up to ``RECONNECT_BACKOFF_MAX``.
+    # Bounds retries after ``serve_connection`` fails. The supervisor sleeps
+    # ``RECONNECT_BACKOFF_INITIAL`` after the first failure and doubles each
+    # subsequent delay up to ``RECONNECT_BACKOFF_MAX``.
     RECONNECT_BACKOFF_INITIAL: float = 1.0
     RECONNECT_BACKOFF_MAX: float = 60.0
     # Appservice-style connectors receive credentials via container env.
@@ -495,14 +493,11 @@ class HttpConnector:
         ``(filename, bytes, content_type)`` tuples that ride as
         multipart parts.
 
-        Routine 4xx responses (a 422 from one malformed envelope, a 400
-        from a stale connection_id mid-removal) drop the envelope and
-        return ``None`` so one bad inbound can't tear down the whole
-        container via the parent TaskGroup.  ``401`` / ``403`` (auth
-        broken — runtime token revoked or misconfigured) and ``5xx``
-        (server outage / bug) still raise: those are container-level
-        problems that warrant the crash-and-restart loop.  Callers that
-        need the bad-envelope to surface (e.g. integration-test tools
+        HTTP errors other than ``401`` / ``403`` drop the envelope and
+        return ``None`` so one bad inbound or transient API outage cannot
+        tear down the connection feed. Authentication failures still raise
+        because the runtime token is globally revoked or misconfigured.
+        Callers that need the bad-envelope to surface (e.g. integration-test tools
         that want loud validation failures) check for ``None`` and
         raise themselves.
         """
@@ -1102,107 +1097,60 @@ class HttpConnector:
         )
 
     async def _isolated_serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
-        """Run :meth:`serve_connection` with failure-isolated cleanup.
+        """Supervise one connection, restarting failed serves with capped backoff.
 
-        Catches any non-``CancelledError`` exception so a single bad
-        connection (typo'd secret, unregistered phone, revoked bot
-        token) can't tear down sibling connections via the parent
-        TaskGroup.  Always pops the user-state slot on exit so
-        connections cycling in/out don't leak stale state.
-
-        On a terminal (non-cancel) failure this ALSO pops
-        ``self._connections[connection_id]`` and clears the
-        ``_connection_served`` event, so the connection is no longer
-        treated as "already running": a subsequent discovery-backfill
-        ``added`` (or a manual re-add) re-spawns the worker with freshly
-        re-fetched secrets, rather than the connection becoming a
-        permanent zombie that ignores every ``added`` while process-level
-        health shows green (issue #1233).  A bounded exponential backoff
-        (:meth:`_arm_reconnect_backoff`) gates how fast that re-spawn
-        starts platform work, so a hard-failing connection backs off
-        instead of hot-looping on every backfill replay.
-
-        Cancellation (a ``removed`` event, or container shutdown) is NOT
-        a failure: it re-raises so the TaskGroup sees a clean cancel,
-        leaves ``_connections`` untouched here (``_on_connection_removed``
-        already owns that pop), and does not arm the backoff.
+        A clean return ends serving. Cancellation propagates immediately. Other
+        exceptions are isolated from sibling connections and retried in-task,
+        so recovery does not depend on discovery replaying an ``added`` event.
         """
-        # Re-spawn backoff: if this connection failed terminally on a
-        # previous spawn, sleep before doing platform work so a
-        # hard-failing connection doesn't hot-loop on every backfill
-        # ``added``.  Sleeping inside the worker task (not the discovery
-        # loop) keeps sibling connections' bring-up unblocked.  A
-        # CancelledError mid-sleep (connection ``removed`` while backing
-        # off) aborts the sleep and skips serve_connection cleanly.
-        delay = self._reconnect_backoff.get(connection_id, 0.0)
-        if delay:
-            log.info(
-                "connector.connection.reconnect_backoff",
-                connector=self.connector,
-                connection_id=connection_id,
-                delay=delay,
-            )
-            await asyncio.sleep(delay)
-        terminal_failure = False
+        backoff = self.RECONNECT_BACKOFF_INITIAL
         try:
-            await self.serve_connection(connection_id, secrets)
-        except asyncio.CancelledError:
-            # Cooperative cancellation (removed / shutdown): re-raise for
-            # a clean TaskGroup cancel and do NOT arm backoff or pop
-            # ``_connections`` — that's _on_connection_removed's job.
-            raise
-        except Exception as exc:
-            terminal_failure = True
-            log.exception(
-                "connector.connection.serve_failed",
-                connector=self.connector,
-                connection_id=connection_id,
-                error=type(exc).__name__,
-            )
+            while True:
+                try:
+                    state = self._connections.get(connection_id)
+                    if state is not None:
+                        state.serve_status = "serving"
+                    await self.serve_connection(connection_id, secrets)
+                    break
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    log.exception(
+                        "connector.connection.serve_failed",
+                        connector=self.connector,
+                        connection_id=connection_id,
+                        error=type(exc).__name__,
+                    )
+                    state = self._connections.get(connection_id)
+                    if state is not None:
+                        state.serve_status = "restarting"
+                        state.last_serve_error = f"{type(exc).__name__}: {exc}"
+                        state.serve_restart_count += 1
+                    try:
+                        await self.emit_lifecycle(
+                            connection_id=connection_id,
+                            event="connector.connection.serve_interrupted",
+                            reason=type(exc).__name__,
+                            data={"error": str(exc)},
+                        )
+                    except Exception:
+                        log.exception(
+                            "connector.connection.serve_interrupted_emit_failed",
+                            connector=self.connector,
+                            connection_id=connection_id,
+                        )
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, self.RECONNECT_BACKOFF_MAX)
         finally:
+            # Subclass state belongs to the whole serve lifetime; do not pop it
+            # between attempts while concurrent outbound calls may still read it.
             self.state.pop(connection_id, None)
-            if terminal_failure:
-                self._arm_reconnect_backoff(connection_id)
-                # Drop the live-connection slot so a later ``added``
-                # re-spawns the worker instead of short-circuiting on
-                # "already running".
-                self._connections.pop(connection_id, None)
-                if event := self._connection_served.get(connection_id):
-                    event.clear()
-                log.warning(
-                    "connector.connection.worker_terminated",
-                    connector=self.connector,
-                    connection_id=connection_id,
-                    reconnect_backoff=self._reconnect_backoff.get(connection_id),
-                )
-            else:
-                # Clean exit (serve_connection returned, or was cancelled):
-                # reset the failure backoff so the next bring-up is prompt.
-                self._reconnect_backoff.pop(connection_id, None)
-
-    def _arm_reconnect_backoff(self, connection_id: str) -> None:
-        """Bump the per-connection re-spawn backoff after a terminal failure.
-
-        Starts at :attr:`RECONNECT_BACKOFF_INITIAL` and doubles on each
-        consecutive terminal failure up to :attr:`RECONNECT_BACKOFF_MAX`.
-        Reset to absent by a clean serve / ``removed`` so an intermittent
-        connection doesn't accumulate stale backoff.
-        """
-        current = self._reconnect_backoff.get(connection_id)
-        if current is None:
-            self._reconnect_backoff[connection_id] = self.RECONNECT_BACKOFF_INITIAL
-        else:
-            self._reconnect_backoff[connection_id] = min(current * 2, self.RECONNECT_BACKOFF_MAX)
 
     async def _on_connection_removed(self, connection_id: str) -> None:
         """Cancel the worker task for a vanished connection."""
         state = self._connections.pop(connection_id, None)
         if event := self._connection_served.get(connection_id):
             event.clear()
-        # A genuine ``removed`` (operator deleted the connection) clears
-        # any armed re-spawn backoff so a later re-add of the same id
-        # starts fresh rather than inheriting a stale failure backoff.
-        self._reconnect_backoff.pop(connection_id, None)
         if state is None or state.worker is None:
             return
         state.worker.cancel()

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -272,17 +272,6 @@ class HttpConnector:
         # the caller proceeds.  Reset to 0 on teardown so re-runs work.
         self._loops_backfilled: int = 0
         self._all_loops_live: asyncio.Event = asyncio.Event()
-        # Per-connection reconnect backoff, in seconds.  Keyed by
-        # connection_id.  ``_isolated_serve_connection`` pops
-        # ``_connections[connection_id]`` on a terminal (non-cancel)
-        # ``serve_connection`` failure so a later discovery ``added`` (or
-        # manual re-add) re-spawns the worker; this dict bounds how fast
-        # that re-spawn actually starts platform work, so a hard-failing
-        # connection (revoked token, unregistered phone) backs off
-        # exponentially instead of hot-looping on every backfill replay.
-        # An entry is cleared on a clean serve (one that ran past the
-        # backoff sleep without immediately failing) and on ``removed``.
-        self._reconnect_backoff: dict[str, float] = {}
         # In-memory discovery resume cursor: the highest ledger
         # ``change_seq`` this process has observed.  ``None`` means "no
         # complete view yet" → the next (re)subscribe uses the ``fresh``

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -1053,31 +1053,7 @@ class HttpConnector:
         if connection_id in self._connections:
             # Replay from backfill after reconnect — already running.
             return
-        client = self._require_client()
-        if not self.uses_connection_secrets:
-            secrets_map: dict[str, str] = {}
-        else:
-            response = await _get_runtime_secrets(client=client, connection_id=connection_id)
-            if response.status_code >= 500:
-                raise httpx.HTTPStatusError(
-                    f"secrets fetch 5xx for connection {connection_id!r}: "
-                    f"{response.status_code} {response.content!r}",
-                    request=httpx.Request("GET", "/v1/connectors/runtime/secrets"),
-                    response=httpx.Response(response.status_code, content=response.content),
-                )
-            if response.status_code >= 400:
-                raise RuntimeError(
-                    f"secrets fetch 4xx for connection {connection_id!r}: "
-                    f"{response.status_code} {response.content!r}"
-                )
-            body = response.parsed
-            if body is None or isinstance(body, HTTPValidationError):
-                raise RuntimeError(f"unparseable secrets response for connection {connection_id!r}")
-            raw_secrets = body.secrets
-            if isinstance(raw_secrets, Unset):
-                secrets_map = {}
-            else:
-                secrets_map = {str(k): str(v) for k, v in raw_secrets.additional_properties.items()}
+        secrets_map = await self._fetch_runtime_secrets(connection_id)
         state = _ConnectionState(
             connection_id=connection_id,
             external_account_id=external_account_id,
@@ -1096,6 +1072,33 @@ class HttpConnector:
             external_account_id=external_account_id,
         )
 
+    async def _fetch_runtime_secrets(self, connection_id: str) -> dict[str, str]:
+        """Fetch and validate the latest runtime secrets for a connection."""
+        client = self._require_client()
+        if not self.uses_connection_secrets:
+            return {}
+        response = await _get_runtime_secrets(client=client, connection_id=connection_id)
+        if response.status_code >= 500:
+            raise httpx.HTTPStatusError(
+                f"secrets fetch 5xx for connection {connection_id!r}: "
+                f"{response.status_code} {response.content!r}",
+                request=httpx.Request("GET", "/v1/connectors/runtime/secrets"),
+                response=httpx.Response(response.status_code, content=response.content),
+            )
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"secrets fetch 4xx for connection {connection_id!r}: "
+                f"{response.status_code} {response.content!r}"
+            )
+        body = response.parsed
+        if body is None or isinstance(body, HTTPValidationError):
+            raise RuntimeError(f"unparseable secrets response for connection {connection_id!r}")
+        raw_secrets = body.secrets
+        if isinstance(raw_secrets, Unset):
+            return {}
+        return {str(k): str(v) for k, v in raw_secrets.additional_properties.items()}
+
+
     async def _isolated_serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
         """Supervise one connection, restarting failed serves with capped backoff.
 
@@ -1104,10 +1107,16 @@ class HttpConnector:
         so recovery does not depend on discovery replaying an ``added`` event.
         """
         backoff = self.RECONNECT_BACKOFF_INITIAL
+        retrying = False
         try:
             while True:
                 try:
                     state = self._connections.get(connection_id)
+                    if retrying and state is not None:
+                        # Credentials can be corrected while this worker is backing
+                        # off. Never pin a failed worker to its original snapshot.
+                        secrets = await self._fetch_runtime_secrets(connection_id)
+                        state.secrets = secrets
                     if state is not None:
                         state.serve_status = "serving"
                     await self.serve_connection(connection_id, secrets)
@@ -1141,6 +1150,7 @@ class HttpConnector:
                         )
                     await asyncio.sleep(backoff)
                     backoff = min(backoff * 2, self.RECONNECT_BACKOFF_MAX)
+                    retrying = True
         finally:
             # Subclass state belongs to the whole serve lifetime; do not pop it
             # between attempts while concurrent outbound calls may still read it.

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -1098,7 +1098,6 @@ class HttpConnector:
             return {}
         return {str(k): str(v) for k, v in raw_secrets.additional_properties.items()}
 
-
     async def _isolated_serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
         """Supervise one connection, restarting failed serves with capped backoff.
 

--- a/packages/aios-connector-http/tests/test_inbound_policy_422.py
+++ b/packages/aios-connector-http/tests/test_inbound_policy_422.py
@@ -1,14 +1,13 @@
 """Regression test pinning the inbound-admission denial to a NON-fatal 422.
 
 Part of #1500. The server maps a ``denied_by_policy`` inbound drop to HTTP 422
-(``ValidationError``), NOT 403 and NOT 5xx. This is load-bearing for
-deploy-safety: ``_is_fatal_inbound_status`` treats 401/403/5xx as fatal —
-those crash-restart the connector container, killing every connection it
-serves. A denied *stranger* must drop one envelope and leave the container
-serving every other connection, so the denial status must be a routine 4xx.
+(``ValidationError``), NOT 403. This is load-bearing for deploy-safety:
+``_is_fatal_inbound_status`` treats authentication failures as fatal. A denied
+*stranger* must drop one envelope and leave the container serving every other
+connection, so the denial status must not be an authentication failure.
 
-This test asserts the contract from the connector runner's side: 422 is
-non-fatal, while 403/5xx (which the denial must never be) are fatal.
+This test asserts the contract from the connector runner's side: 422 and 5xx
+are per-message drops, while 403 (which the denial must never be) is fatal.
 """
 
 from __future__ import annotations
@@ -29,11 +28,10 @@ def test_denied_by_policy_maps_to_non_fatal_422() -> None:
     # 422 is a routine per-envelope drop — the container keeps serving.
     assert _is_fatal_inbound_status(denied_status) is False
 
-    # Defensive: the statuses the denial must NEVER be are fatal, so if a future
-    # refactor regresses the mapping to 403 or 5xx the connector would crash on
-    # the first denied stranger.
+    # Authentication failures remain fatal, while transient API failures drop
+    # the affected message without killing the connection feed.
     assert _is_fatal_inbound_status(403) is True
-    assert _is_fatal_inbound_status(500) is True
+    assert _is_fatal_inbound_status(500) is False
 
 
 def test_denied_by_policy_reason_constant_is_stable() -> None:

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -931,12 +931,27 @@ class TestEmitInbound4xxDrop:
         )
         assert result is None
 
-    @pytest.mark.parametrize("status_code", [401, 500])
-    async def test_raises_on_auth_and_5xx(self, probe: _ProbeConnector, status_code: int) -> None:
+    async def test_drops_5xx_returns_none(self, probe: _ProbeConnector) -> None:
+        mock_response = MagicMock()
+        mock_response.is_error = True
+        mock_response.status_code = 503
+        mock_response.text = "temporary outage"
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+
+        result = await probe.emit_inbound(
+            connection_id="conn_1", chat_id="c", sender={"id": 1}, content=""
+        )
+
+        assert result is None
+        mock_response.raise_for_status.assert_not_called()
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    async def test_raises_on_auth_failure(self, probe: _ProbeConnector, status_code: int) -> None:
         mock_response = MagicMock()
         mock_response.is_error = True
         mock_response.status_code = status_code
-        mock_response.text = "auth or server error"
+        mock_response.text = "auth error"
         mock_response.raise_for_status = MagicMock(
             side_effect=httpx.HTTPStatusError(
                 f"{status_code}", request=MagicMock(), response=mock_response
@@ -962,11 +977,17 @@ class TestIsolatedServeConnection:
     user-state slot on exit."""
 
     async def test_swallows_non_cancel_exception(self) -> None:
+        attempts = 0
+
         class _CrashingConnector(HttpConnector):
             connector = "crashy"
+            RECONNECT_BACKOFF_INITIAL = 0.0
 
             async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
-                raise RuntimeError("daemon refused this phone")
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise RuntimeError("daemon refused this phone")
 
         c = _CrashingConnector(base_url="http://x", token="aios_runtime_x")
         with structlog.testing.capture_logs() as records:
@@ -976,6 +997,32 @@ class TestIsolatedServeConnection:
         assert len(failed) == 1
         assert failed[0]["connection_id"] == "conn_1"
         assert failed[0]["error"] == "RuntimeError"
+
+    async def test_retries_failed_serve_until_clean_return(self) -> None:
+        attempts = 0
+
+        class _FlakyConnector(HttpConnector):
+            connector = "flaky"
+            RECONNECT_BACKOFF_INITIAL = 0.0
+
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+                nonlocal attempts
+                attempts += 1
+                if attempts < 3:
+                    raise RuntimeError(f"failure {attempts}")
+
+        c = _FlakyConnector(base_url="http://x", token="aios_runtime_x")
+        c._connections["conn_1"] = _ConnectionState(
+            connection_id="conn_1", external_account_id="acct_1"
+        )
+
+        await c._isolated_serve_connection("conn_1", {})
+
+        assert attempts == 3
+        state = c._connections["conn_1"]
+        assert state.serve_status == "serving"
+        assert state.serve_restart_count == 2
+        assert state.last_serve_error == "RuntimeError: failure 2"
 
     async def test_pops_state_on_cancel(self) -> None:
         class _Connector(HttpConnector):
@@ -1418,205 +1465,67 @@ class TestDiscoveryCursorAndResetRecovery:
         removed.assert_not_awaited()
 
 
-class TestDeadWorkerRespawn:
-    """Regression for #1233: ``_isolated_serve_connection``'s ``finally``
-    must pop ``self._connections[connection_id]`` (not just ``self.state``)
-    on a terminal ``serve_connection`` failure, so a later discovery
-    ``added`` re-spawns the worker instead of being short-circuited as
-    "already running."  Paired with a bounded re-spawn backoff so a
-    hard-failing connection doesn't hot-loop.
-    """
+class TestServeSupervisor:
+    async def test_backoff_escalates_and_caps(self) -> None:
+        attempts = 0
 
-    async def test_terminal_failure_pops_connections_slot(self) -> None:
-        """A non-cancel ``serve_connection`` crash must clear the
-        ``_connections`` slot so the id is no longer "already running"."""
-
-        class _Crashing(HttpConnector):
-            connector = "crashy"
+        class _Flaky(HttpConnector):
+            connector = "flaky"
+            RECONNECT_BACKOFF_INITIAL = 1.0
+            RECONNECT_BACKOFF_MAX = 2.0
 
             async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
-                raise RuntimeError("revoked token")
+                nonlocal attempts
+                attempts += 1
+                if attempts < 4:
+                    raise RuntimeError("transient")
 
-        c = _Crashing(base_url="http://x", token="aios_runtime_x")
-        # Simulate the live-connection bookkeeping _on_connection_added sets.
-        c._connections["conn_1"] = _ConnectionState(
-            connection_id="conn_1", external_account_id="acct_1"
-        )
-        c._connection_served.setdefault("conn_1", asyncio.Event()).set()
+        c = _Flaky(base_url="http://x", token="aios_runtime_x")
+        lifecycle = AsyncMock()
+        c.emit_lifecycle = lifecycle  # type: ignore[method-assign]
+        sleep = AsyncMock()
+        with patch("aios_connector_http.runner.asyncio.sleep", sleep):
+            await c._isolated_serve_connection("conn_1", {})
 
-        # Should NOT raise (failure isolation preserved).
-        await c._isolated_serve_connection("conn_1", {"token": "bad"})
+        assert [call.args[0] for call in sleep.await_args_list] == [1.0, 2.0, 2.0]
+        assert lifecycle.await_count == 3
 
-        # The zombie is gone: the connection slot was popped so a later
-        # ``added`` re-spawns rather than short-circuiting.
-        assert "conn_1" not in c._connections
-        # The served event is cleared so wait_connection_served re-arms.
-        assert not c._connection_served["conn_1"].is_set()
+    async def test_lifecycle_failure_does_not_escape_supervisor(self) -> None:
+        attempts = 0
 
-    async def test_clean_return_pops_connections_slot(self) -> None:
-        """A ``serve_connection`` that simply returns is also terminal —
-        no zombie and no armed backoff."""
-
-        class _Returns(HttpConnector):
-            connector = "returns"
+        class _Flaky(HttpConnector):
+            connector = "flaky"
+            RECONNECT_BACKOFF_INITIAL = 0.0
 
             async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
-                return
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise RuntimeError("serve failed")
 
-        c = _Returns(base_url="http://x", token="aios_runtime_x")
+        c = _Flaky(base_url="http://x", token="aios_runtime_x")
+        c.emit_lifecycle = AsyncMock(side_effect=RuntimeError("api unavailable"))  # type: ignore[method-assign]
         await c._isolated_serve_connection("conn_1", {})
-        assert "conn_1" not in c._reconnect_backoff
+        assert attempts == 2
 
-    async def test_cancellation_leaves_connections_to_removed_handler(self) -> None:
-        """A ``removed``-driven cancel must NOT pop ``_connections`` here
-        (that's ``_on_connection_removed``'s job) and must NOT arm backoff;
-        the CancelledError re-raises for a clean TaskGroup cancel."""
+    async def test_cancellation_propagates_without_retry(self) -> None:
+        attempts = 0
 
         class _Blocks(HttpConnector):
             connector = "blocks"
 
             async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+                nonlocal attempts
+                attempts += 1
                 await asyncio.Event().wait()
 
         c = _Blocks(base_url="http://x", token="aios_runtime_x")
-        c._connections["conn_1"] = _ConnectionState(
-            connection_id="conn_1", external_account_id="acct_1"
-        )
         task = asyncio.create_task(c._isolated_serve_connection("conn_1", {}))
         await asyncio.sleep(0)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        # Not a failure: this handler leaves the slot for the removed path
-        # and arms no backoff.
-        assert "conn_1" in c._connections
-        assert "conn_1" not in c._reconnect_backoff
-
-    async def test_failed_connection_can_respawn_via_added(self) -> None:
-        """End-to-end of the fix: after a terminal failure the very next
-        discovery ``added`` must re-fetch secrets and re-spawn the
-        worker rather than short-circuiting on "already running"."""
-
-        spawns: list[dict[str, str]] = []
-        healthy = asyncio.Event()
-
-        class _FlakyThenOk(HttpConnector):
-            connector = "flaky"
-            # Collapse backoff so the test doesn't actually wait.
-            RECONNECT_BACKOFF_INITIAL = 0.0
-
-            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
-                spawns.append(dict(secrets))
-                if len(spawns) == 1:
-                    raise RuntimeError("first spawn: revoked token")
-                # Second spawn (after secret correction): block forever.
-                healthy.set()
-                await asyncio.Event().wait()
-
-        c = _FlakyThenOk(base_url="http://x", token="aios_runtime_x")
-        c._client = MagicMock()
-
-        secrets_seq = [{"token": "bad"}, {"token": "good"}]
-
-        def _secrets_response(token_map: dict[str, str]) -> MagicMock:
-            body = MagicMock()
-            secrets_obj = MagicMock()
-            secrets_obj.additional_properties = token_map
-            body.secrets = secrets_obj
-            resp = MagicMock()
-            resp.status_code = 200
-            resp.parsed = body
-            return resp
-
-        responses = [_secrets_response(s) for s in secrets_seq]
-
-        async def _fake_get_secrets(*, client: Any, connection_id: str) -> Any:
-            del client, connection_id
-            return responses.pop(0)
-
-        async with asyncio.TaskGroup() as tg:
-            with patch(
-                "aios_connector_http.runner._get_runtime_secrets",
-                new=_fake_get_secrets,
-            ):
-                # First ``added`` spawns a worker that fails terminally.
-                await c._on_connection_added(tg, "conn_1", "acct_1")
-                await c.wait_connection_served("conn_1", deadline=5.0)
-                # Let the failing worker run its finally and pop the slot.
-                for _ in range(50):
-                    await asyncio.sleep(0)
-                    if "conn_1" not in c._connections:
-                        break
-                assert "conn_1" not in c._connections, "zombie slot not cleared"
-
-                # The backfill replays ``added`` — must NOT short-circuit.
-                await c._on_connection_added(tg, "conn_1", "acct_1")
-                await asyncio.wait_for(healthy.wait(), timeout=5.0)
-
-            # Cancel the now-healthy blocking worker so the TG can exit.
-            await c._on_connection_removed("conn_1")
-
-        # Two spawns: the failed one, then the corrected re-spawn — and the
-        # second saw the corrected secret (re-fetched at re-spawn).
-        assert spawns == [{"token": "bad"}, {"token": "good"}]
-
-    def test_arm_reconnect_backoff_escalates_and_caps(self) -> None:
-        class _C(HttpConnector):
-            connector = "c"
-            RECONNECT_BACKOFF_INITIAL = 1.0
-            RECONNECT_BACKOFF_MAX = 4.0
-
-        c = _C(base_url="http://x", token="aios_runtime_x")
-        c._arm_reconnect_backoff("conn_1")
-        assert c._reconnect_backoff["conn_1"] == 1.0
-        c._arm_reconnect_backoff("conn_1")
-        assert c._reconnect_backoff["conn_1"] == 2.0
-        c._arm_reconnect_backoff("conn_1")
-        assert c._reconnect_backoff["conn_1"] == 4.0
-        c._arm_reconnect_backoff("conn_1")  # capped
-        assert c._reconnect_backoff["conn_1"] == 4.0
-
-    async def test_respawn_sleeps_backoff_before_serving(self) -> None:
-        """A re-spawn after a terminal failure sleeps the armed backoff
-        before doing platform work, so a hard-failing connection doesn't
-        hot-loop on every backfill replay."""
-
-        class _Crashing(HttpConnector):
-            connector = "crashy"
-            RECONNECT_BACKOFF_INITIAL = 1.0
-
-            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
-                raise RuntimeError("still revoked")
-
-        c = _Crashing(base_url="http://x", token="aios_runtime_x")
-
-        sleeps: list[float] = []
-        _real_sleep = asyncio.sleep
-
-        async def _fake_sleep(delay: float) -> None:
-            sleeps.append(delay)
-            await _real_sleep(0)
-
-        with patch("aios_connector_http.runner.asyncio.sleep", new=_fake_sleep):
-            # First spawn: no backoff armed yet, no sleep.
-            await c._isolated_serve_connection("conn_1", {})
-            assert sleeps == []
-            assert c._reconnect_backoff["conn_1"] == 1.0
-            # Second spawn: armed backoff is slept before serving.
-            await c._isolated_serve_connection("conn_1", {})
-            assert sleeps == [1.0]
-            # Failure escalated the backoff for the next attempt.
-            assert c._reconnect_backoff["conn_1"] == 2.0
-
-    async def test_removed_clears_armed_backoff(self) -> None:
-        class _C(HttpConnector):
-            connector = "c"
-
-        c = _C(base_url="http://x", token="aios_runtime_x")
-        c._arm_reconnect_backoff("conn_1")
-        assert "conn_1" in c._reconnect_backoff
-        await c._on_connection_removed("conn_1")
-        assert "conn_1" not in c._reconnect_backoff
+        assert attempts == 1
 
 
 class TestEmitSessionLifecycle:
@@ -1871,14 +1780,16 @@ class TestDeliveryAcks:
             )
         assert result is None
 
-    async def test_ack_fatal_status_reraises(self, probe: _ProbeConnector) -> None:
-        """A fatal status re-raises, matching ``emit_session_lifecycle``."""
+    async def test_ack_auth_status_reraises(self, probe: _ProbeConnector) -> None:
+        """An authentication failure re-raises, matching ``emit_session_lifecycle``."""
         mock_response = MagicMock()
         mock_response.is_error = True
-        mock_response.status_code = 500
-        mock_response.text = "boom"
+        mock_response.status_code = 401
+        mock_response.text = "unauthorized"
         mock_response.raise_for_status = MagicMock(
-            side_effect=httpx.HTTPStatusError("boom", request=MagicMock(), response=mock_response)
+            side_effect=httpx.HTTPStatusError(
+                "unauthorized", request=MagicMock(), response=mock_response
+            )
         )
         mock_post = AsyncMock(return_value=mock_response)
         probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -1490,6 +1490,34 @@ class TestServeSupervisor:
         assert [call.args[0] for call in sleep.await_args_list] == [1.0, 2.0, 2.0]
         assert lifecycle.await_count == 3
 
+    async def test_retry_refetches_corrected_runtime_secrets(self) -> None:
+        seen: list[dict[str, str]] = []
+
+        class _CredentialConnector(HttpConnector):
+            connector = "credential"
+            RECONNECT_BACKOFF_INITIAL = 0.0
+
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+                seen.append(dict(secrets))
+                if secrets["token"] == "revoked":
+                    raise RuntimeError("credential rejected")
+
+        c = _CredentialConnector(base_url="http://x", token="aios_runtime_x")
+        state = _ConnectionState(
+            connection_id="conn_1",
+            external_account_id="acct_1",
+            secrets={"token": "revoked"},
+        )
+        c._connections["conn_1"] = state
+        c._fetch_runtime_secrets = AsyncMock(return_value={"token": "corrected"})  # type: ignore[method-assign]
+        c.emit_lifecycle = AsyncMock()  # type: ignore[method-assign]
+
+        await c._isolated_serve_connection("conn_1", state.secrets)
+
+        assert seen == [{"token": "revoked"}, {"token": "corrected"}]
+        c._fetch_runtime_secrets.assert_awaited_once_with("conn_1")  # type: ignore[attr-defined]
+        assert state.secrets == {"token": "corrected"}
+
     async def test_lifecycle_failure_does_not_escape_supervisor(self) -> None:
         attempts = 0
 

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -1015,6 +1015,7 @@ class TestIsolatedServeConnection:
         c._connections["conn_1"] = _ConnectionState(
             connection_id="conn_1", external_account_id="acct_1"
         )
+        c._fetch_runtime_secrets = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         await c._isolated_serve_connection("conn_1", {})
 

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -16,7 +16,7 @@ import asyncio
 import contextlib
 import json
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 import pytest
@@ -1500,7 +1500,7 @@ class TestServeSupervisor:
 
             async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
                 seen.append(dict(secrets))
-                if secrets["token"] == "revoked":
+                if secrets["token"] != "corrected":
                     raise RuntimeError("credential rejected")
 
         c = _CredentialConnector(base_url="http://x", token="aios_runtime_x")
@@ -1510,13 +1510,19 @@ class TestServeSupervisor:
             secrets={"token": "revoked"},
         )
         c._connections["conn_1"] = state
-        c._fetch_runtime_secrets = AsyncMock(return_value={"token": "corrected"})  # type: ignore[method-assign]
+        c._fetch_runtime_secrets = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[{"token": "still-revoked"}, {"token": "corrected"}]
+        )
         c.emit_lifecycle = AsyncMock()  # type: ignore[method-assign]
 
         await c._isolated_serve_connection("conn_1", state.secrets)
 
-        assert seen == [{"token": "revoked"}, {"token": "corrected"}]
-        c._fetch_runtime_secrets.assert_awaited_once_with("conn_1")  # type: ignore[attr-defined]
+        assert seen == [
+            {"token": "revoked"},
+            {"token": "still-revoked"},
+            {"token": "corrected"},
+        ]
+        assert c._fetch_runtime_secrets.await_args_list == [call("conn_1"), call("conn_1")]  # type: ignore[attr-defined]
         assert state.secrets == {"token": "corrected"}
 
     async def test_lifecycle_failure_does_not_escape_supervisor(self) -> None:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -2684,7 +2684,7 @@ class SandboxRegistry:
                         )
                         if not _archive_eligible(fresh, now, grace):
                             continue
-                    if await self._store.remove(  # pooled-connection-await: allow eumemic/aios#2097
+                    if await self._store.remove(  # pooled-connection-await: allow eumemic/aios#2100
                         ref
                     ):
                         removed += 1


### PR DESCRIPTION
Automated dev-pipeline build for issue #972.