### PR TITLE
Output-schema validator should coerce-accept a JSON-string `value` that parses to a matching object (Sonnet-5 return-quirk immunization)

### DIFF
--- a/src/aios/tools/invoke.py
+++ b/src/aios/tools/invoke.py
@@ -20,9 +20,8 @@ import contextvars
 import json
 from typing import Any
 
-import jsonschema
-
 from aios.tools.registry import ToolNotFoundError, ToolResult, registry
+from aios.tools.schema_errors import format_schema_violation
 
 # The id of the tool_call the running handler is servicing, scoped per tool task.
 # Set by :func:`invoke_builtin` around the handler call on the model dispatch path
@@ -88,29 +87,26 @@ def validate_arguments(arguments: dict[str, Any], schema: dict[str, Any]) -> str
 
     Returns ``None`` on success, or a human-readable error string that
     enumerates every validation failure (missing required keys,
-    unexpected extra keys, wrong types). The string lands in the
+    unexpected extra keys, wrong types) built by the shared no-echo
+    formatter (:func:`aios.tools.schema_errors.format_schema_violation`) — it
+    never echoes the full ``arguments`` payload, only per-error
+    expected/got lines plus the schema. The string lands in the
     tool_result's ``error`` body, so the model sees every issue at once
     and can self-correct without iterating one-at-a-time.
 
     The schema is the same dict registered with the tool and sent to the
     model as the tool's ``parameters``, so a mismatch genuinely
     indicates the model didn't follow the contract — not a framework
-    bug. Surfacing specific paths (e.g. ``foo.bar[2]``) and
-    passed-value previews keeps the feedback actionable.
+    bug.
     """
-    validator = jsonschema.Draft202012Validator(schema)
-    errors = sorted(validator.iter_errors(arguments), key=lambda e: list(e.absolute_path))
-    if not errors:
-        return None
-    lines = [
-        f"Arguments failed schema validation. You sent: {json.dumps(arguments)}",
-        "Errors:",
-    ]
-    for err in errors:
-        path = ".".join(str(p) for p in err.absolute_path) or "<root>"
-        lines.append(f"  - at {path}: {err.message}")
-    lines.append("Look at the tool's `parameters` schema for the correct shape and retry.")
-    return "\n".join(lines)
+    return format_schema_violation(
+        arguments,
+        schema,
+        root="",
+        intro="Arguments failed schema validation.",
+        retry_hint="Look at the tool's `parameters` schema for the correct shape and retry.",
+        site="invoke.validate_arguments",
+    )
 
 
 def prepare_builtin(tool_name: str, raw_arguments: Any) -> dict[str, Any]:

--- a/src/aios/tools/invoke_session.py
+++ b/src/aios/tools/invoke_session.py
@@ -51,7 +51,6 @@ from __future__ import annotations
 
 from typing import Any, Literal, cast
 
-import jsonschema
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic import ValidationError as PydanticValidationError
 
@@ -66,6 +65,7 @@ from aios.services import tasks as tasks_service
 from aios.services import workflows as wf_service
 from aios.tools.invoke import ToolBail, current_tool_call_id
 from aios.tools.registry import ToolResult, registry
+from aios.tools.schema_errors import format_schema_violation
 
 # Per-park await budget. The tool task is fire-and-forget (implicit-async), so a
 # long park never blocks the caller's other turns; we re-poll in a loop so a
@@ -212,26 +212,27 @@ def _validate_output(value: Any, schema: dict[str, Any] | None) -> ToolResult | 
     """Validate the resolved ``value`` against ``output_schema`` (fail-loud).
 
     ``None`` on success (or no schema); otherwise a model-visible error ToolResult
-    (``output_schema_violation``) so the caller sees a non-conforming answer as an
-    error rather than silently accepting it — mirrors ``workflow_completion``'s
-    ``return`` enforcement, but on the *caller* side for a run/peer answer that
-    bypassed the servicer's own ``return`` schema gate.
+    (``output_schema_violation``) built by the shared no-echo formatter
+    (:func:`aios.tools.schema_errors.format_schema_violation` — #1769 spec v2) so
+    the caller sees a non-conforming answer as an error rather than silently
+    accepting it — mirrors ``workflow_completion``'s ``return`` enforcement, but
+    on the *caller* side for a run/peer answer that bypassed the servicer's own
+    ``return`` schema gate. No retry hint: the CALLER doesn't own the answer, it
+    can't make the peer/run re-answer by retrying this call.
     """
     if schema is None:
         return None
-    errors = sorted(
-        jsonschema.Draft202012Validator(schema).iter_errors(value),
-        key=lambda e: list(e.absolute_path),
+    message = format_schema_violation(
+        value,
+        schema,
+        root="",
+        intro="output_schema_violation: the answer does not conform to output_schema.",
+        retry_hint=None,
+        site="invoke_session.call_output",
     )
-    if not errors:
+    if message is None:
         return None
-    detail = "; ".join(
-        f"at {'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}" for e in errors
-    )
-    return ToolResult(
-        content=f"output_schema_violation: the answer does not match output_schema ({detail})",
-        is_error=True,
-    )
+    return ToolResult(content=message, is_error=True)
 
 
 def _ok_result(result: Any) -> dict[str, Any]:

--- a/src/aios/tools/invoke_session.py
+++ b/src/aios/tools/invoke_session.py
@@ -65,7 +65,10 @@ from aios.services import tasks as tasks_service
 from aios.services import workflows as wf_service
 from aios.tools.invoke import ToolBail, current_tool_call_id
 from aios.tools.registry import ToolResult, registry
-from aios.tools.schema_errors import format_schema_violation, normalize_schema_value
+from aios.tools.schema_errors import (
+    format_schema_violation,
+    normalize_and_format_schema_violation,
+)
 
 # Per-park await budget. The tool task is fire-and-forget (implicit-async), so a
 # long park never blocks the caller's other turns; we re-poll in a loop so a
@@ -304,9 +307,17 @@ async def _park_and_resolve(
     if resp.outcome != "ok":
         return _error_result(resp.error)
     result = resp.result
-    if output_schema is not None:
-        result = normalize_schema_value(result, output_schema, site="invoke_session.call_output")
-    violation = _validate_output(result, output_schema)
+    if output_schema is None:
+        return _ok_result(result)
+    result, message = normalize_and_format_schema_violation(
+        result,
+        output_schema,
+        root="",
+        intro="output_schema_violation: the answer does not conform to output_schema.",
+        retry_hint=None,
+        site="invoke_session.call_output",
+    )
+    violation = ToolResult(content=message, is_error=True) if message is not None else None
     return violation if violation is not None else _ok_result(result)
 
 

--- a/src/aios/tools/invoke_session.py
+++ b/src/aios/tools/invoke_session.py
@@ -65,7 +65,7 @@ from aios.services import tasks as tasks_service
 from aios.services import workflows as wf_service
 from aios.tools.invoke import ToolBail, current_tool_call_id
 from aios.tools.registry import ToolResult, registry
-from aios.tools.schema_errors import format_schema_violation
+from aios.tools.schema_errors import format_schema_violation, normalize_schema_value
 
 # Per-park await budget. The tool task is fire-and-forget (implicit-async), so a
 # long park never blocks the caller's other turns; we re-poll in a loop so a
@@ -303,8 +303,11 @@ async def _park_and_resolve(
     )
     if resp.outcome != "ok":
         return _error_result(resp.error)
-    violation = _validate_output(resp.result, output_schema)
-    return violation if violation is not None else _ok_result(resp.result)
+    result = resp.result
+    if output_schema is not None:
+        result = normalize_schema_value(result, output_schema, site="invoke_session.call_output")
+    violation = _validate_output(result, output_schema)
+    return violation if violation is not None else _ok_result(result)
 
 
 def _caller(session_id: str) -> dict[str, Any]:

--- a/src/aios/tools/schema_errors.py
+++ b/src/aios/tools/schema_errors.py
@@ -1,0 +1,184 @@
+"""Shared JSON-Schema-violation formatter (#1769 spec v2).
+
+Three call sites format a jsonschema validation failure into a model-facing
+error string: :func:`aios.tools.invoke.validate_arguments` (every tool-call's
+arguments), :func:`aios.tools.workflow_completion._validate_value` (a
+``return``-tool answer against its request's ``output_schema``, plus
+:func:`aios.workflows.step._validate_output_against_schema` for a workflow
+run's terminal output), and :func:`aios.tools.invoke_session._validate_output`
+(a ``call_session``/``call_workflow`` caller checking a peer/run's answer).
+Before this module each site rolled its own message by reusing jsonschema's
+stock ``err.message``, which embeds a full ``repr()`` of the failing instance
+— and *also* echoed the whole argument/value payload a second time via
+``json.dumps`` up front. On a multi-KB payload (the incident this closes: a
+dev-implement session's ``return`` ``value`` was a ~3KB stringified-JSON blob)
+that is two multi-KB echoes bracketing a ~20-char type mismatch, and the
+replay eval (issue #1769 comment thread, "FINAL EVAL VERDICT") found the
+echo-heavy wording rescues 0/120 samples — so the mandate is architectural,
+not cosmetic: build every line from ``err.absolute_path`` / ``err.validator``
+/ ``err.validator_value`` — never ``err.message`` (which embeds the instance
+repr) — and never echo the full instance.
+
+Rules (ratified spec v2, issue #1769 comment 4918753010):
+
+1. No instance echo, ever. A scalar instance (str/int/float/bool/None) whose
+   ``json.dumps()`` is short (<= 100 chars) may appear verbatim where it IS the
+   diagnosis (``enum``/``const`` mismatches show the offending value). Anything
+   longer, or a container (dict/list), is described by its JSON type name only.
+2. Every ``type``-mismatch line reads ``expected <X>, got <json-type>`` — the
+   JSON type of the failing instance via a 7-branch isinstance ladder (null,
+   boolean, integer, number, string, array, object — boolean checked BEFORE
+   integer, since Python ``bool`` is an ``int`` subclass).
+3. The full schema is included when small (<= ~2KB serialized); otherwise only
+   the subschema at the failing path (``err.schema``) — still no instance data.
+4. A targeted hint fires when the failing top-level value is itself a JSON
+   string that would parse+validate cleanly against the schema: the caller
+   double-encoded its answer. This is detection + a short imperative hint
+   only — NOT silent coercion (the coercion shim was evaluated and dropped;
+   see #1769's final verdict comment — re-offering the tool schema fixed the
+   incident, not the message).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import jsonschema
+
+from aios.logging import get_logger
+
+log = get_logger(__name__)
+
+_SCALAR_ECHO_MAX = 100
+_SCHEMA_ECHO_MAX = 2000
+
+
+def json_type_name(value: Any) -> str:
+    """The JSON Schema type name of ``value`` (the 7-branch ladder).
+
+    ``bool`` MUST be checked before ``int`` — Python's ``bool`` is an ``int``
+    subclass, so ``isinstance(True, int)`` is ``True``.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__  # pragma: no cover - jsonschema instances are JSON-typed
+
+
+def _describe_instance(instance: Any) -> str:
+    """A short, safe description of a failing instance — never a full echo.
+
+    A short scalar is shown verbatim (it usually IS the diagnosis, e.g. an
+    ``enum``/``const`` mismatch); anything longer, or any container, collapses
+    to its JSON type name.
+    """
+    if instance is None or isinstance(instance, (str, int, float, bool)):
+        text = json.dumps(instance)
+        if len(text) <= _SCALAR_ECHO_MAX:
+            return text
+    return f"<{json_type_name(instance)}>"
+
+
+def _at(path: str, root: str) -> str:
+    """The reported location of an error: ``root``-scoped when ``root`` is set
+    (e.g. ``"value.answer"``, or bare ``"value"`` at the value's own root),
+    otherwise the bare path or ``"<root>"`` when the path itself is empty.
+    """
+    if root:
+        return f"{root}.{path}" if path else root
+    return path or "<root>"
+
+
+def _format_error_line(err: jsonschema.exceptions.ValidationError, *, root: str) -> str:
+    path = ".".join(str(p) for p in err.absolute_path)
+    at = _at(path, root)
+    if err.validator == "type":
+        expected = err.validator_value
+        expected_str = " or ".join(expected) if isinstance(expected, list) else str(expected)
+        return f"  - at {at}: expected {expected_str}, got {json_type_name(err.instance)}"
+    if err.validator in ("enum", "const", "required", "additionalProperties"):
+        # These jsonschema stock messages are already instance-free (they name
+        # the offending keys/allowed values, not a repr of the whole instance).
+        return f"  - at {at}: {err.message}"
+    # Generic fallback (minLength/maxLength/pattern/minimum/maximum/etc.):
+    # describe the failing instance safely rather than trust jsonschema's stock
+    # message, which embeds a full repr of the instance.
+    return f"  - at {at}: fails `{err.validator}: {err.validator_value}` (got {_describe_instance(err.instance)})"
+
+
+def _schema_snippet(err: jsonschema.exceptions.ValidationError, schema: dict[str, Any]) -> str:
+    """The schema to show: the full schema if small, else just the failing subschema."""
+    full = json.dumps(schema)
+    if len(full) <= _SCHEMA_ECHO_MAX:
+        return full
+    return json.dumps(err.schema)
+
+
+def _stringified_json_hint(instance: Any, schema: dict[str, Any], *, site: str) -> str | None:
+    """Detect the double-encoding quirk: ``instance`` is a JSON string that itself
+    parses to something conforming to ``schema``. Returns a short imperative hint,
+    or ``None`` if the quirk isn't present. Detection only — never coerces.
+    """
+    if not isinstance(instance, str):
+        return None
+    try:
+        parsed = json.loads(instance)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not jsonschema.Draft202012Validator(schema).is_valid(parsed):
+        return None
+    log.info("return_value_stringified_json", site=site)
+    return (
+        "the string you sent is itself JSON that parses to a conforming value — "
+        "pass that value directly, not wrapped in a string."
+    )
+
+
+def format_schema_violation(
+    instance: Any,
+    schema: dict[str, Any],
+    *,
+    root: str,
+    intro: str,
+    retry_hint: str | None,
+    site: str,
+) -> str | None:
+    """Validate ``instance`` against ``schema``; ``None`` on success.
+
+    On failure, returns a model-facing message: ``intro``, one no-echo line per
+    error (``root``-scoped path + expected/got), the schema (full if small, else
+    just the failing subschema), the stringified-JSON hint when detected, and
+    ``retry_hint`` as the closing instruction (omitted when ``None`` — a
+    fail-loud caller that does not bounce-and-retry). Never echoes the full
+    ``instance``. ``site`` tags the stringified-JSON telemetry marker so its
+    per-call-site frequency is distinguishable.
+    """
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.absolute_path))
+    if not errors:
+        return None
+
+    lines = [intro, "Errors:"]
+    for err in errors:
+        lines.append(_format_error_line(err, root=root))
+    lines.append(f"The required schema is: {_schema_snippet(errors[0], schema)}")
+
+    hint = _stringified_json_hint(instance, schema, site=site)
+    if hint is not None:
+        lines.append(hint)
+
+    if retry_hint is not None:
+        lines.append(retry_hint)
+    return "\n".join(lines)

--- a/src/aios/tools/schema_errors.py
+++ b/src/aios/tools/schema_errors.py
@@ -114,10 +114,7 @@ def _format_error_line(err: jsonschema.exceptions.ValidationError, *, root: str)
             # Preserve jsonschema's useful wording only when its instance echo is
             # independently known to satisfy the documented short-scalar rule.
             return f"  - at {at}: {err.message}"
-        return (
-            f"  - at {at}: expected `{err.validator}: {err.validator_value}` "
-            f"(got {instance})"
-        )
+        return f"  - at {at}: expected `{err.validator}: {err.validator_value}` (got {instance})"
     if err.validator in ("required", "additionalProperties"):
         # These stock messages name missing/unexpected keys without rendering
         # the containing instance.

--- a/src/aios/tools/schema_errors.py
+++ b/src/aios/tools/schema_errors.py
@@ -175,6 +175,33 @@ def _stringified_json_hint(instance: Any, schema: dict[str, Any], *, site: str) 
     )
 
 
+def normalize_and_format_schema_violation(
+    instance: Any,
+    schema: dict[str, Any],
+    *,
+    root: str,
+    intro: str,
+    retry_hint: str | None,
+    site: str,
+) -> tuple[Any, str | None]:
+    """Normalize an output-boundary value, then format any remaining violation.
+
+    This is the shared output-schema gate.  Keeping repair and validation in one
+    function prevents a new output boundary from accidentally selecting strict
+    validation while the existing session, workflow, and caller boundaries use
+    the stringified-JSON repair policy.
+    """
+    normalized = normalize_schema_value(instance, schema, site=site)
+    return normalized, format_schema_violation(
+        normalized,
+        schema,
+        root=root,
+        intro=intro,
+        retry_hint=retry_hint,
+        site=site,
+    )
+
+
 def format_schema_violation(
     instance: Any,
     schema: dict[str, Any],

--- a/src/aios/tools/schema_errors.py
+++ b/src/aios/tools/schema_errors.py
@@ -33,10 +33,10 @@ Rules (ratified spec v2, issue #1769 comment 4918753010):
    the subschema at the failing path (``err.schema``) — still no instance data.
 4. A targeted hint fires when the failing top-level value is itself a JSON
    string that would parse+validate cleanly against the schema: the caller
-   double-encoded its answer. This is detection + a short imperative hint
-   only — NOT silent coercion (the coercion shim was evaluated and dropped;
-   see #1769's final verdict comment — re-offering the tool schema fixed the
-   incident, not the message).
+   double-encoded its answer. The formatter only detects this condition. Output
+   boundaries apply :func:`normalize_schema_value` before formatting so the
+   same narrowly defined repair policy is used for session returns, workflow
+   terminal outputs, and caller-side validation.
 """
 
 from __future__ import annotations
@@ -108,9 +108,19 @@ def _format_error_line(err: jsonschema.exceptions.ValidationError, *, root: str)
         expected = err.validator_value
         expected_str = " or ".join(expected) if isinstance(expected, list) else str(expected)
         return f"  - at {at}: expected {expected_str}, got {json_type_name(err.instance)}"
-    if err.validator in ("enum", "const", "required", "additionalProperties"):
-        # These jsonschema stock messages are already instance-free (they name
-        # the offending keys/allowed values, not a repr of the whole instance).
+    if err.validator in ("enum", "const"):
+        instance = _describe_instance(err.instance)
+        if not instance.startswith("<"):
+            # Preserve jsonschema's useful wording only when its instance echo is
+            # independently known to satisfy the documented short-scalar rule.
+            return f"  - at {at}: {err.message}"
+        return (
+            f"  - at {at}: expected `{err.validator}: {err.validator_value}` "
+            f"(got {instance})"
+        )
+    if err.validator in ("required", "additionalProperties"):
+        # These stock messages name missing/unexpected keys without rendering
+        # the containing instance.
         return f"  - at {at}: {err.message}"
     # Generic fallback (minLength/maxLength/pattern/minimum/maximum/etc.):
     # describe the failing instance safely rather than trust jsonschema's stock
@@ -124,6 +134,28 @@ def _schema_snippet(err: jsonschema.exceptions.ValidationError, schema: dict[str
     if len(full) <= _SCHEMA_ECHO_MAX:
         return full
     return json.dumps(err.schema)
+
+
+def normalize_schema_value(value: Any, schema: dict[str, Any], *, site: str) -> Any:
+    """Apply the one permitted output-schema repair consistently.
+
+    An already-valid value is never rewritten. A failing top-level string is
+    parsed exactly once and substituted only when the parsed value validates
+    against the same schema. Invalid JSON, invalid parsed values, and
+    double-encoded strings remain unchanged and are rejected by normal
+    validation.
+    """
+    validator = jsonschema.Draft202012Validator(schema)
+    if not isinstance(value, str) or validator.is_valid(value):
+        return value
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return value
+    if not validator.is_valid(parsed):
+        return value
+    log.info("output_value_stringified_json_coerced", site=site)
+    return parsed
 
 
 def _stringified_json_hint(instance: Any, schema: dict[str, Any], *, site: str) -> str | None:

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -31,10 +31,7 @@ caller's harvest reads; the periodic ``wf_runs`` sweep is the lost-wake backstop
 
 from __future__ import annotations
 
-import json
 from typing import Any
-
-import jsonschema
 
 from aios.db import queries
 from aios.harness import runtime
@@ -42,6 +39,7 @@ from aios.jobs.app import defer_run_wake
 from aios.models.sessions import Err, Ok, Outcome
 from aios.services import sessions as sessions_service
 from aios.tools.registry import ToolResult, openai_tool_entry, registry
+from aios.tools.schema_errors import format_schema_violation
 
 RETURN_TOOL_NAME = "return"
 ERROR_TOOL_NAME = "error"
@@ -184,29 +182,23 @@ def _validate_value(value: Any, schema: dict[str, Any]) -> str | None:
     """Validate a ``return`` ``value`` against the request's ``output_schema``.
 
     ``None`` on success; otherwise a model-facing ``output_schema_violation`` error
-    enumerating every failure (mirrors :func:`aios.tools.invoke.validate_arguments`'
-    formatting) so the child self-corrects and calls ``return`` again through the
-    normal tool-error loop. This is the single servicer-side schema gate every
-    obligation answered with ``return`` passes — self-goals (opened by
+    built by the shared no-echo formatter
+    (:func:`aios.tools.schema_errors.format_schema_violation` — #1769 spec v2:
+    never echoes the full ``value``, states expected-vs-got JSON types, and
+    includes the schema) so the child self-corrects and calls ``return`` again
+    through the normal tool-error loop. This is the single servicer-side schema
+    gate every obligation answered with ``return`` passes — self-goals (opened by
     ``create_goal``) included, since their persisted ``output_schema`` is read off
     the same ``request_opened`` edge.
     """
-    errors = sorted(
-        jsonschema.Draft202012Validator(schema).iter_errors(value),
-        key=lambda e: list(e.absolute_path),
+    return format_schema_violation(
+        value,
+        schema,
+        root="value",
+        intro="output_schema_violation: `value` does not conform to the request's output_schema.",
+        retry_hint="Provide `value` as a conforming object and call `return` again.",
+        site="workflow_completion.return",
     )
-    if not errors:
-        return None
-    lines = [
-        "output_schema_violation: `value` does not match the request's required "
-        f"output_schema. You sent: {json.dumps(value)}",
-        "Errors:",
-    ]
-    for err in errors:
-        path = ".".join(str(p) for p in err.absolute_path)
-        lines.append(f"  - at {'value.' + path if path else 'value'}: {err.message}")
-    lines.append("Fix `value` to match the schema shown with the request and call return again.")
-    return "\n".join(lines)
 
 
 async def _enforce_output_schema(session_id: str, request_id: Any, value: Any) -> str | None:

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -31,10 +31,7 @@ caller's harvest reads; the periodic ``wf_runs`` sweep is the lost-wake backstop
 
 from __future__ import annotations
 
-import json
 from typing import Any
-
-import jsonschema
 
 from aios.db import queries
 from aios.harness import runtime
@@ -43,7 +40,7 @@ from aios.logging import get_logger
 from aios.models.sessions import Err, Ok, Outcome
 from aios.services import sessions as sessions_service
 from aios.tools.registry import ToolResult, openai_tool_entry, registry
-from aios.tools.schema_errors import format_schema_violation
+from aios.tools.schema_errors import format_schema_violation, normalize_schema_value
 
 log = get_logger(__name__)
 
@@ -235,16 +232,7 @@ async def _enforce_output_schema(
         schema = await queries.get_request_output_schema(conn, session_id, request_id=request_id)
     if schema is None:
         return value, None
-    validator = jsonschema.Draft202012Validator(schema)
-    if isinstance(value, str) and not validator.is_valid(value):
-        try:
-            parsed = json.loads(value)
-        except (json.JSONDecodeError, ValueError):
-            pass
-        else:
-            if validator.is_valid(parsed):
-                log.info("return_value_stringified_json_coerced", site="workflow_completion.return")
-                value = parsed
+    value = normalize_schema_value(value, schema, site="workflow_completion.return")
     return value, _validate_value(value, schema)
 
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -40,7 +40,10 @@ from aios.logging import get_logger
 from aios.models.sessions import Err, Ok, Outcome
 from aios.services import sessions as sessions_service
 from aios.tools.registry import ToolResult, openai_tool_entry, registry
-from aios.tools.schema_errors import format_schema_violation, normalize_schema_value
+from aios.tools.schema_errors import (
+    format_schema_violation,
+    normalize_and_format_schema_violation,
+)
 
 log = get_logger(__name__)
 
@@ -232,8 +235,14 @@ async def _enforce_output_schema(
         schema = await queries.get_request_output_schema(conn, session_id, request_id=request_id)
     if schema is None:
         return value, None
-    value = normalize_schema_value(value, schema, site="workflow_completion.return")
-    return value, _validate_value(value, schema)
+    return normalize_and_format_schema_violation(
+        value,
+        schema,
+        root="value",
+        intro="output_schema_violation: `value` does not conform to the request's output_schema.",
+        retry_hint="Fix `value` to match the required schema, then call `return` again.",
+        site="workflow_completion.return",
+    )
 
 
 def _closed_request_message(outcome: Outcome | None = None, closed_at: Any | None = None) -> str:

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -39,7 +39,14 @@ from aios.jobs.app import defer_run_wake
 from aios.models.sessions import Err, Ok, Outcome
 from aios.services import sessions as sessions_service
 from aios.tools.registry import ToolResult, openai_tool_entry, registry
+import json
+
+import jsonschema
+
+from aios.logging import get_logger
 from aios.tools.schema_errors import format_schema_violation
+
+log = get_logger(__name__)
 
 RETURN_TOOL_NAME = "return"
 ERROR_TOOL_NAME = "error"
@@ -201,20 +208,31 @@ def _validate_value(value: Any, schema: dict[str, Any]) -> str | None:
     )
 
 
-async def _enforce_output_schema(session_id: str, request_id: Any, value: Any) -> str | None:
-    """Validate ``value`` against the schema this request demands, if any.
+async def _enforce_output_schema(
+    session_id: str, request_id: Any, value: Any
+) -> tuple[Any, str | None]:
+    """Validate and, when safe, coerce ``value`` against the requested schema.
 
-    Returns a model-facing error string to bounce back (the child retries), or
-    ``None`` to proceed. A non-str ``request_id`` (or one matching no request) and a
-    non-child session resolve to no schema, leaving the rejection to
-    :func:`respond_to_request` (``unknown_request`` / ``not_a_child``); a request with
-    no ``output_schema`` (the common case) also passes.
+    A top-level JSON string is accepted as its parsed value only when that value
+    validates against the schema. The returned pair is the value to persist and
+    an optional model-facing validation error.
     """
     if not isinstance(request_id, str):
-        return None
+        return value, None
     async with runtime.require_pool().acquire() as conn:
         schema = await queries.get_request_output_schema(conn, session_id, request_id=request_id)
-    return None if schema is None else _validate_value(value, schema)
+    if schema is None:
+        return value, None
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        else:
+            if jsonschema.Draft202012Validator(schema).is_valid(parsed):
+                log.info("return_value_stringified_json_coerced", site="workflow_completion.return")
+                value = parsed
+    return value, _validate_value(value, schema)
 
 
 def _closed_request_message(outcome: Outcome | None = None, closed_at: Any | None = None) -> str:
@@ -302,13 +320,15 @@ async def return_handler(session_id: str, arguments: dict[str, Any]) -> dict[str
     # match it. A mismatch is a tool error the child retries on (no response written),
     # exactly like a malformed tool arg — so the workflow only ever harvests a
     # schema-valid value. error() is unconstrained (a child that can't conform bails).
-    schema_error = await _enforce_output_schema(session_id, request_id, arguments.get("value"))
+    value, schema_error = await _enforce_output_schema(
+        session_id, request_id, arguments.get("value")
+    )
     if schema_error is not None:
         return ToolResult(content=schema_error, is_error=True)
     return await _finish(
         session_id,
         request_id=request_id,
-        outcome=Ok(result=arguments.get("value")),
+        outcome=Ok(result=value),
     )
 
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -212,9 +212,22 @@ async def _enforce_output_schema(
 ) -> tuple[Any, str | None]:
     """Validate and, when safe, coerce ``value`` against the requested schema.
 
-    A top-level JSON string is accepted as its parsed value only when that value
-    validates against the schema. The returned pair is the value to persist and
-    an optional model-facing validation error.
+    A top-level JSON string is accepted as its parsed value only when the string
+    does NOT already conform AND the parsed value does. The returned pair is the
+    value to persist and an optional model-facing validation error — acceptance
+    and transformation stay together, so whatever this gate validated is exactly
+    what ``return_handler`` hands to :func:`_finish` (and thus to the awaiting
+    caller); a coercion that were accepted here but not propagated would report a
+    satisfied contract while the consumer got the wrong type.
+
+    The already-conforming check is load-bearing, not an optimization. Coercion
+    is a REPAIR of a value the schema would otherwise reject, never an
+    unconditional ``json.loads`` of every string: under a ``{"type": "string"}``
+    request the conforming value ``'"hello"'`` parses to ``'hello'`` — also
+    conforming — so parsing first would silently rewrite the caller's answer. The
+    same holds for any permissive schema (``{}`` accepts every string, so every
+    JSON-looking string would be mangled). Validate first; only a failing value is
+    a candidate for repair.
     """
     if not isinstance(request_id, str):
         return value, None
@@ -222,13 +235,14 @@ async def _enforce_output_schema(
         schema = await queries.get_request_output_schema(conn, session_id, request_id=request_id)
     if schema is None:
         return value, None
-    if isinstance(value, str):
+    validator = jsonschema.Draft202012Validator(schema)
+    if isinstance(value, str) and not validator.is_valid(value):
         try:
             parsed = json.loads(value)
         except (json.JSONDecodeError, ValueError):
             pass
         else:
-            if jsonschema.Draft202012Validator(schema).is_valid(parsed):
+            if validator.is_valid(parsed):
                 log.info("return_value_stringified_json_coerced", site="workflow_completion.return")
                 value = parsed
     return value, _validate_value(value, schema)

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -31,19 +31,18 @@ caller's harvest reads; the periodic ``wf_runs`` sweep is the lost-wake backstop
 
 from __future__ import annotations
 
+import json
 from typing import Any
+
+import jsonschema
 
 from aios.db import queries
 from aios.harness import runtime
 from aios.jobs.app import defer_run_wake
+from aios.logging import get_logger
 from aios.models.sessions import Err, Ok, Outcome
 from aios.services import sessions as sessions_service
 from aios.tools.registry import ToolResult, openai_tool_entry, registry
-import json
-
-import jsonschema
-
-from aios.logging import get_logger
 from aios.tools.schema_errors import format_schema_violation
 
 log = get_logger(__name__)

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -60,6 +60,7 @@ from aios.services.sessions import (
     write_gate_opened,
 )
 from aios.tools.registry import tool_executes_class
+from aios.tools.schema_errors import format_schema_violation
 from aios.workflows import run_llm, run_sandbox, run_tools
 from aios.workflows.child_id import child_session_id
 from aios.workflows.child_run_id import child_run_id
@@ -111,22 +112,22 @@ def _unresolvable_ref(schema: dict[str, Any]) -> str | None:
 def _validate_output_against_schema(value: Any, schema: dict[str, Any]) -> str | None:
     """Validate a run's terminal ``output`` against the request's ``output_schema``.
 
-    ``None`` on success; otherwise a human-readable message enumerating every
-    failure (the same shape the session ``return`` tool produces, minus the
-    self-correct hint — a run does NOT bounce-and-retry, it fails loud). Drives
-    the run-target ``output_schema_violation`` error-arm in :func:`_complete_run`.
+    ``None`` on success; otherwise a human-readable message built by the shared
+    no-echo formatter (:func:`aios.tools.schema_errors.format_schema_violation` —
+    #1769 spec v2: never echoes the full ``output``, states expected-vs-got JSON
+    types, and includes the schema), the same shape the session ``return`` tool
+    produces, minus the self-correct hint — a run does NOT bounce-and-retry, it
+    fails loud. Drives the run-target ``output_schema_violation`` error-arm in
+    :func:`_complete_run`.
     """
-    errors = sorted(
-        jsonschema.Draft202012Validator(schema).iter_errors(value),
-        key=lambda e: list(e.absolute_path),
+    return format_schema_violation(
+        value,
+        schema,
+        root="output",
+        intro="run output does not conform to the request's required schema.",
+        retry_hint=None,
+        site="workflows.step.run_output",
     )
-    if not errors:
-        return None
-    lines = [f"run output does not match the request's required schema: {json.dumps(value)}"]
-    for err in errors:
-        path = ".".join(str(p) for p in err.absolute_path)
-        lines.append(f"  - at {'output.' + path if path else 'output'}: {err.message}")
-    return "\n".join(lines)
 
 
 def _usage_payload(usage: wf_queries.RunChildrenUsage) -> dict[str, Any]:

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -60,7 +60,10 @@ from aios.services.sessions import (
     write_gate_opened,
 )
 from aios.tools.registry import tool_executes_class
-from aios.tools.schema_errors import format_schema_violation, normalize_schema_value
+from aios.tools.schema_errors import (
+    format_schema_violation,
+    normalize_and_format_schema_violation,
+)
 from aios.workflows import run_llm, run_sandbox, run_tools
 from aios.workflows.child_id import child_session_id
 from aios.workflows.child_run_id import child_run_id
@@ -1406,17 +1409,17 @@ async def _complete_run(
     # No bounce-and-retry — the script already ran (unlike an agent, which the
     # return-tool bounces). Only a *successful* output is schema-checked; an already-
     # errored completion passes through (the error already explains the outcome).
+    schema_error = None
     if not is_error and run.request_id is not None and run.request_output_schema is not None:
-        output = normalize_schema_value(
-            output, run.request_output_schema, site="workflows.step.run_output"
+        output, schema_error = normalize_and_format_schema_violation(
+            output,
+            run.request_output_schema,
+            root="output",
+            intro="run output does not conform to the request's required schema.",
+            retry_hint=None,
+            site="workflows.step.run_output",
         )
-    if (
-        not is_error
-        and run.request_id is not None
-        and run.request_output_schema is not None
-        and (schema_error := _validate_output_against_schema(output, run.request_output_schema))
-        is not None
-    ):
+    if schema_error is not None:
         output = schema_error
         is_error = True
         error_kind = "output_schema_violation"

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -60,7 +60,7 @@ from aios.services.sessions import (
     write_gate_opened,
 )
 from aios.tools.registry import tool_executes_class
-from aios.tools.schema_errors import format_schema_violation
+from aios.tools.schema_errors import format_schema_violation, normalize_schema_value
 from aios.workflows import run_llm, run_sandbox, run_tools
 from aios.workflows.child_id import child_session_id
 from aios.workflows.child_run_id import child_run_id
@@ -1406,6 +1406,10 @@ async def _complete_run(
     # No bounce-and-retry — the script already ran (unlike an agent, which the
     # return-tool bounces). Only a *successful* output is schema-checked; an already-
     # errored completion passes through (the error already explains the outcome).
+    if not is_error and run.request_id is not None and run.request_output_schema is not None:
+        output = normalize_schema_value(
+            output, run.request_output_schema, site="workflows.step.run_output"
+        )
     if (
         not is_error
         and run.request_id is not None

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -4265,8 +4265,11 @@ async def test_agent_output_schema_end_to_end(
             child_id, {"request_id": request_id, "value": {"answer": 7}}
         )
         assert isinstance(rejected, ToolResult) and rejected.is_error
+        # Providers sometimes double-encode a structured return value. If its
+        # parsed JSON conforms, return_handler must accept and persist the parsed
+        # object rather than reject the tool call into a retry loop.
         ok = await workflow_completion.return_handler(
-            child_id, {"request_id": request_id, "value": {"answer": "done"}}
+            child_id, {"request_id": request_id, "value": '{"answer":"done"}'}
         )
     assert ok == {"status": "returned"}
 

--- a/tests/unit/test_closed_request_liveness.py
+++ b/tests/unit/test_closed_request_liveness.py
@@ -124,7 +124,9 @@ class TestHandlerLivenessFirst:
             workflow_completion, "_closed_request_error", AsyncMock(return_value=None)
         )
         monkeypatch.setattr(
-            workflow_completion, "_enforce_output_schema", AsyncMock(return_value=None)
+            workflow_completion,
+            "_enforce_output_schema",
+            AsyncMock(return_value=({"answer": "x"}, None)),
         )
         finish = AsyncMock(return_value={"ok": True})
         monkeypatch.setattr(workflow_completion, "_finish", finish)

--- a/tests/unit/test_return_value_coercion.py
+++ b/tests/unit/test_return_value_coercion.py
@@ -1,0 +1,180 @@
+"""The ``return``-tool stringified-JSON coercion gate (#1769 / PR #2096).
+
+``_enforce_output_schema`` may accept a double-encoded ``value`` (a JSON string
+that parses to a conforming value) — but acceptance and transformation must not
+split: whatever the schema gate validated is what ``return_handler`` must hand
+to ``_finish`` (and therefore to the awaiting caller).
+
+Three properties, one per failure direction:
+
+* **Propagation** — a JSON-encoded object that parses to a conforming object is
+  accepted AND the value the consumer receives is the parsed ``dict``, never the
+  original ``str``.
+* **Positive control** — a value that ALREADY conforms passes through byte-for-byte
+  UNCHANGED. Coercion must be a *repair* of an otherwise-failing value, not an
+  unconditional ``json.loads`` of every string: for a ``{"type": "string"}`` schema
+  the conforming value ``'"hello"'`` must stay ``'"hello"'``, not become ``'hello'``.
+* **Regression guard** — a genuinely non-conforming value is still REJECTED.
+  "Accept coercions" must not degrade into "accept everything".
+
+The pool/queries calls are mocked out (the pattern in
+test_closed_request_liveness.py / test_workflow_output_schema.py); the DB-backed
+read itself is covered in tests/integration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+from aios.db import queries
+from aios.harness import runtime
+from aios.models.sessions import Ok
+from aios.tools import workflow_completion
+from aios.tools.registry import ToolResult
+from aios.tools.workflow_completion import _enforce_output_schema, return_handler
+
+_OBJ_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"n": {"type": "integer"}},
+    "required": ["n"],
+}
+_STR_SCHEMA: dict[str, Any] = {"type": "string"}
+_ANY_SCHEMA: dict[str, Any] = {}
+
+
+def _mock_schema(monkeypatch: Any, schema: dict[str, Any] | None) -> None:
+    """Point ``get_request_output_schema`` at ``schema`` with a stubbed pool."""
+    monkeypatch.setattr(queries, "get_request_output_schema", AsyncMock(return_value=schema))
+    pool = mock.MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock.MagicMock())
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(runtime, "require_pool", lambda: pool)
+
+
+class TestCoercionPropagates:
+    """Whatever the gate validated is what the consumer must receive."""
+
+    async def test_json_encoded_object_is_accepted_as_a_dict(self, monkeypatch: Any) -> None:
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+
+        value, error = await _enforce_output_schema("ses_1", "req_1", '{"n": 1}')
+
+        assert error is None, "a JSON-encoded conforming object must be accepted"
+        assert value == {"n": 1}
+        assert isinstance(value, dict), "the consumer must receive the PARSED value, not the string"
+
+    async def test_return_handler_persists_the_coerced_value(self, monkeypatch: Any) -> None:
+        """End of the propagation chain: the coerced dict reaches ``_finish``."""
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+        monkeypatch.setattr(
+            workflow_completion, "_closed_request_error", AsyncMock(return_value=None)
+        )
+        finish = AsyncMock(return_value={"status": "returned"})
+        monkeypatch.setattr(workflow_completion, "_finish", finish)
+
+        result = await return_handler("ses_1", {"request_id": "req_1", "value": '{"n": 1}'})
+
+        assert result == {"status": "returned"}
+        finish.assert_awaited_once()
+        assert finish.await_args is not None
+        outcome = finish.await_args.kwargs["outcome"]
+        assert outcome == Ok(result={"n": 1})
+        assert isinstance(outcome.result, dict), "a str here is the split-acceptance bug"
+
+
+class TestPositiveControlUnchanged:
+    """An ALREADY-conforming value must survive the gate byte-for-byte."""
+
+    async def test_conforming_dict_passes_through_unchanged(self, monkeypatch: Any) -> None:
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+        original = {"n": 1}
+
+        value, error = await _enforce_output_schema("ses_1", "req_1", original)
+
+        assert error is None
+        assert value == {"n": 1}
+
+    async def test_conforming_string_that_is_also_json_is_not_parsed(
+        self, monkeypatch: Any
+    ) -> None:
+        """A ``{"type": "string"}`` request whose value is the literal ``'"hello"'``.
+
+        That string ALREADY conforms. Parsing it yields ``'hello'`` — which also
+        conforms — so an unconditional ``json.loads`` silently rewrites the
+        caller's answer. Coercion must only fire to RESCUE a value the schema
+        would otherwise reject.
+        """
+        _mock_schema(monkeypatch, _STR_SCHEMA)
+
+        value, error = await _enforce_output_schema("ses_1", "req_1", '"hello"')
+
+        assert error is None
+        assert value == '"hello"', "an already-conforming value must not be rewritten"
+
+    async def test_permissive_schema_does_not_rewrite_a_json_looking_string(
+        self, monkeypatch: Any
+    ) -> None:
+        """A schema of ``{}`` accepts anything, so EVERY string already conforms."""
+        _mock_schema(monkeypatch, _ANY_SCHEMA)
+
+        for original in ('{"n": 1}', "42", "true", "null", '"hi"'):
+            value, error = await _enforce_output_schema("ses_1", "req_1", original)
+            assert error is None
+            assert value == original, f"{original!r} already conformed; it must not be parsed"
+
+
+class TestRegressionGuardStillRejects:
+    """Accepting coercions must not degrade into accepting everything."""
+
+    async def test_non_conforming_json_string_is_rejected(self, monkeypatch: Any) -> None:
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+
+        value, error = await _enforce_output_schema("ses_1", "req_1", '{"n": "not-an-int"}')
+
+        assert error is not None, "a value that conforms neither raw nor parsed must be REJECTED"
+        assert "output_schema_violation" in error
+        assert value == '{"n": "not-an-int"}', "a rejected value must not be silently rewritten"
+
+    async def test_non_json_string_is_rejected(self, monkeypatch: Any) -> None:
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+
+        value, error = await _enforce_output_schema("ses_1", "req_1", "not json at all")
+
+        assert error is not None
+        assert value == "not json at all"
+
+    async def test_wrong_typed_scalar_is_rejected(self, monkeypatch: Any) -> None:
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+
+        _value, error = await _enforce_output_schema("ses_1", "req_1", 123)
+
+        assert error is not None
+
+    async def test_return_handler_bounces_a_rejected_value(self, monkeypatch: Any) -> None:
+        """A rejection must reach the model as a tool error, with nothing persisted."""
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+        monkeypatch.setattr(
+            workflow_completion, "_closed_request_error", AsyncMock(return_value=None)
+        )
+        finish = AsyncMock()
+        monkeypatch.setattr(workflow_completion, "_finish", finish)
+
+        result = await return_handler("ses_1", {"request_id": "req_1", "value": "not json"})
+
+        assert isinstance(result, ToolResult)
+        assert result.is_error is True
+        finish.assert_not_called()
+
+
+class TestNoSchemaPassesThrough:
+    """No ``output_schema`` on the request → no validation and no coercion."""
+
+    async def test_schemaless_request_never_coerces(self, monkeypatch: Any) -> None:
+        _mock_schema(monkeypatch, None)
+
+        value, error = await _enforce_output_schema("ses_1", "req_1", '{"n": 1}')
+
+        assert error is None
+        assert value == '{"n": 1}', "with no schema there is nothing to coerce toward"

--- a/tests/unit/test_return_value_coercion.py
+++ b/tests/unit/test_return_value_coercion.py
@@ -32,8 +32,11 @@ from aios.db import queries
 from aios.harness import runtime
 from aios.models.sessions import Ok
 from aios.tools import workflow_completion
+from aios.tools.invoke_session import _validate_output
 from aios.tools.registry import ToolResult
+from aios.tools.schema_errors import normalize_schema_value
 from aios.tools.workflow_completion import _enforce_output_schema, return_handler
+from aios.workflows.step import _validate_output_against_schema
 
 _OBJ_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -166,6 +169,40 @@ class TestRegressionGuardStillRejects:
         assert isinstance(result, ToolResult)
         assert result.is_error is True
         finish.assert_not_called()
+
+
+class TestCrossPathConsistency:
+    """The same terminal payload receives the same verdict at every boundary."""
+
+    async def test_encoded_object_is_accepted_and_normalized_everywhere(
+        self, monkeypatch: Any
+    ) -> None:
+        encoded = '{"n": 1}'
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+
+        session_value, session_error = await _enforce_output_schema("ses_1", "req_1", encoded)
+        run_value = normalize_schema_value(encoded, _OBJ_SCHEMA, site="test.run")
+        caller_value = normalize_schema_value(encoded, _OBJ_SCHEMA, site="test.caller")
+
+        assert session_error is None
+        assert _validate_output_against_schema(run_value, _OBJ_SCHEMA) is None
+        assert _validate_output(caller_value, _OBJ_SCHEMA) is None
+        assert session_value == run_value == caller_value == {"n": 1}
+
+    async def test_double_encoded_object_is_rejected_everywhere(self, monkeypatch: Any) -> None:
+        encoded_twice = '"{\\"n\\": 1}"'
+        _mock_schema(monkeypatch, _OBJ_SCHEMA)
+
+        session_value, session_error = await _enforce_output_schema(
+            "ses_1", "req_1", encoded_twice
+        )
+        run_value = normalize_schema_value(encoded_twice, _OBJ_SCHEMA, site="test.run")
+        caller_value = normalize_schema_value(encoded_twice, _OBJ_SCHEMA, site="test.caller")
+
+        assert session_error is not None
+        assert _validate_output_against_schema(run_value, _OBJ_SCHEMA) is not None
+        assert _validate_output(caller_value, _OBJ_SCHEMA) is not None
+        assert session_value == run_value == caller_value == encoded_twice
 
 
 class TestNoSchemaPassesThrough:

--- a/tests/unit/test_return_value_coercion.py
+++ b/tests/unit/test_return_value_coercion.py
@@ -193,9 +193,7 @@ class TestCrossPathConsistency:
         encoded_twice = '"{\\"n\\": 1}"'
         _mock_schema(monkeypatch, _OBJ_SCHEMA)
 
-        session_value, session_error = await _enforce_output_schema(
-            "ses_1", "req_1", encoded_twice
-        )
+        session_value, session_error = await _enforce_output_schema("ses_1", "req_1", encoded_twice)
         run_value = normalize_schema_value(encoded_twice, _OBJ_SCHEMA, site="test.run")
         caller_value = normalize_schema_value(encoded_twice, _OBJ_SCHEMA, site="test.caller")
 

--- a/tests/unit/test_return_value_coercion.py
+++ b/tests/unit/test_return_value_coercion.py
@@ -24,19 +24,21 @@ read itself is covered in tests/integration.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock
 
 from aios.db import queries
+from aios.db.queries import workflows as wf_queries
 from aios.harness import runtime
 from aios.models.sessions import Ok
+from aios.models.tasks import AwaitResponse
+from aios.models.workflows import WfRun
 from aios.tools import workflow_completion
-from aios.tools.invoke_session import _validate_output
 from aios.tools.registry import ToolResult
-from aios.tools.schema_errors import normalize_schema_value
 from aios.tools.workflow_completion import _enforce_output_schema, return_handler
-from aios.workflows.step import _validate_output_against_schema
+from aios.workflows import step as workflow_step
 
 _OBJ_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -171,8 +173,60 @@ class TestRegressionGuardStillRejects:
         finish.assert_not_called()
 
 
+def _run_with_schema() -> WfRun:
+    now = datetime.now(UTC)
+    return WfRun(
+        id="wfr_1",
+        workflow_id="wf_1",
+        account_id="acc_1",
+        environment_id="env_1",
+        request_id="req_1",
+        caller={"kind": "run", "id": "wfr_parent"},
+        request_output_schema=_OBJ_SCHEMA,
+        script="async def main(input): return None",
+        script_sha="sha",
+        host_semantics_epoch=1,
+        status="running",
+        last_event_seq=0,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def _complete_workflow_output(monkeypatch: Any, value: Any) -> tuple[str, Any]:
+    monkeypatch.setattr(
+        wf_queries,
+        "run_children_usage",
+        AsyncMock(return_value=wf_queries.RunChildrenUsage(0, 0, 0, 0, 0)),
+    )
+    commit = AsyncMock()
+    monkeypatch.setattr(workflow_step, "_commit_terminal_and_dispatch", commit)
+    await workflow_step._complete_run(
+        mock.MagicMock(), _run_with_schema(), output=value, is_error=False
+    )
+    assert commit.await_args is not None
+    return commit.await_args.kwargs["status"], commit.await_args.kwargs["output"]
+
+
+async def _resolve_call_output(monkeypatch: Any, value: Any) -> Any:
+    monkeypatch.setattr(
+        "aios.tools.invoke_session._park_on_task",
+        AsyncMock(return_value=AwaitResponse(outcome="ok", result=value)),
+    )
+    from aios.tools.invoke_session import _park_and_resolve
+
+    return await _park_and_resolve(
+        object(),
+        servicer_kind="session",
+        servicer_id="ses_1",
+        request_id="req_1",
+        account_id="acc_1",
+        output_schema=_OBJ_SCHEMA,
+    )
+
+
 class TestCrossPathConsistency:
-    """The same terminal payload receives the same verdict at every boundary."""
+    """The same terminal payload receives the same verdict at all four boundaries."""
 
     async def test_encoded_object_is_accepted_and_normalized_everywhere(
         self, monkeypatch: Any
@@ -181,26 +235,39 @@ class TestCrossPathConsistency:
         _mock_schema(monkeypatch, _OBJ_SCHEMA)
 
         session_value, session_error = await _enforce_output_schema("ses_1", "req_1", encoded)
-        run_value = normalize_schema_value(encoded, _OBJ_SCHEMA, site="test.run")
-        caller_value = normalize_schema_value(encoded, _OBJ_SCHEMA, site="test.caller")
+        workflow_status, workflow_value = await _complete_workflow_output(monkeypatch, encoded)
+        call_session = await _resolve_call_output(monkeypatch, encoded)
+        call_workflow = await _resolve_call_output(monkeypatch, encoded)
 
         assert session_error is None
-        assert _validate_output_against_schema(run_value, _OBJ_SCHEMA) is None
-        assert _validate_output(caller_value, _OBJ_SCHEMA) is None
-        assert session_value == run_value == caller_value == {"n": 1}
+        assert session_value == {"n": 1}  # return / workflow_completion
+        assert (workflow_status, workflow_value) == ("completed", {"n": 1})
+        assert call_session == {"ok": {"n": 1}}
+        assert call_workflow == {"ok": {"n": 1}}
 
-    async def test_double_encoded_object_is_rejected_everywhere(self, monkeypatch: Any) -> None:
-        encoded_twice = '"{\\"n\\": 1}"'
+    async def test_parseable_nonconforming_object_is_rejected_everywhere(
+        self, monkeypatch: Any
+    ) -> None:
+        encoded_invalid = '{"n": "not-an-int"}'
         _mock_schema(monkeypatch, _OBJ_SCHEMA)
 
-        session_value, session_error = await _enforce_output_schema("ses_1", "req_1", encoded_twice)
-        run_value = normalize_schema_value(encoded_twice, _OBJ_SCHEMA, site="test.run")
-        caller_value = normalize_schema_value(encoded_twice, _OBJ_SCHEMA, site="test.caller")
+        session_value, session_error = await _enforce_output_schema(
+            "ses_1", "req_1", encoded_invalid
+        )
+        workflow_status, workflow_value = await _complete_workflow_output(
+            monkeypatch, encoded_invalid
+        )
+        call_session = await _resolve_call_output(monkeypatch, encoded_invalid)
+        call_workflow = await _resolve_call_output(monkeypatch, encoded_invalid)
 
         assert session_error is not None
-        assert _validate_output_against_schema(run_value, _OBJ_SCHEMA) is not None
-        assert _validate_output(caller_value, _OBJ_SCHEMA) is not None
-        assert session_value == run_value == caller_value == encoded_twice
+        assert session_value == encoded_invalid
+        assert workflow_status == "errored"
+        assert "does not conform" in workflow_value
+        for result in (call_session, call_workflow):
+            assert isinstance(result, ToolResult)
+            assert result.is_error
+            assert "output_schema_violation" in result.content
 
 
 class TestNoSchemaPassesThrough:

--- a/tests/unit/test_schema_errors.py
+++ b/tests/unit/test_schema_errors.py
@@ -1,0 +1,219 @@
+"""Unit tests for the shared schema-violation formatter (#1769).
+
+Covers the ratified spec-v2 rules directly against
+:func:`aios.tools.schema_errors.format_schema_violation`:
+
+* no instance echo — long/container instances never appear verbatim;
+* short scalar instances (<=100 chars) may appear where they ARE the
+  diagnosis (enum/const);
+* every ``type`` mismatch line reads ``expected <X>, got <json-type>``;
+* the schema is included (full when small, else the failing subschema);
+* the stringified-JSON quirk is detected (hint fires) without ever coercing —
+  the return value from :func:`format_schema_violation` on a match is the
+  human-facing string, the CALLER decides whether to accept (it never does);
+* a conforming instance returns ``None``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from aios.tools.schema_errors import format_schema_violation, json_type_name
+
+_OBJ_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
+    "additionalProperties": False,
+}
+
+
+class TestJsonTypeName:
+    def test_bool_before_int(self) -> None:
+        # The load-bearing ordering: bool is an int subclass in Python.
+        assert json_type_name(True) == "boolean"
+        assert json_type_name(False) == "boolean"
+
+    def test_ladder(self) -> None:
+        assert json_type_name(None) == "null"
+        assert json_type_name(3) == "integer"
+        assert json_type_name(3.5) == "number"
+        assert json_type_name("x") == "string"
+        assert json_type_name([1, 2]) == "array"
+        assert json_type_name({"a": 1}) == "object"
+
+
+class TestFormatSchemaViolation:
+    def test_conforming_value_returns_none(self) -> None:
+        assert (
+            format_schema_violation(
+                {"answer": "hi"},
+                _OBJ_SCHEMA,
+                root="value",
+                intro="bad",
+                retry_hint="retry",
+                site="test",
+            )
+            is None
+        )
+
+    def test_no_instance_echo_for_large_payload(self) -> None:
+        big_blob = json.dumps({"branch": "x" * 3000, "pr_title": "y" * 2000})
+        err = format_schema_violation(
+            big_blob,
+            _OBJ_SCHEMA,
+            root="value",
+            intro="output_schema_violation: `value` does not conform to the request's output_schema.",
+            retry_hint="Provide `value` as a conforming object and call `return` again.",
+            site="test",
+        )
+        assert err is not None
+        # The multi-KB payload must NOT appear verbatim anywhere in the message.
+        assert big_blob not in err
+        assert "x" * 3000 not in err
+        # The type mismatch line is present, no-echo style.
+        assert "expected object, got string" in err
+        assert "at value:" in err
+
+    def test_type_mismatch_reports_expected_and_got(self) -> None:
+        err = format_schema_violation(
+            {"answer": 1},
+            _OBJ_SCHEMA,
+            root="value",
+            intro="bad",
+            retry_hint="retry",
+            site="test",
+        )
+        assert err is not None
+        assert "at value.answer: expected string, got integer" in err
+
+    def test_missing_required_and_additional_property_both_surface(self) -> None:
+        err = format_schema_violation(
+            {"extra": 1},
+            _OBJ_SCHEMA,
+            root="value",
+            intro="bad",
+            retry_hint="retry",
+            site="test",
+        )
+        assert err is not None
+        assert "'answer' is a required property" in err
+        assert "'extra' was unexpected" in err
+
+    def test_short_scalar_enum_instance_shown_verbatim(self) -> None:
+        schema = {"enum": ["x", "y"]}
+        err = format_schema_violation(
+            "z", schema, root="value", intro="bad", retry_hint="retry", site="test"
+        )
+        assert err is not None
+        assert "'z' is not one of ['x', 'y']" in err  # short scalar: verbatim is fine
+
+    def test_long_string_pattern_mismatch_not_echoed(self) -> None:
+        schema = {"type": "string", "pattern": "^a"}
+        long_str = "b" * 500
+        err = format_schema_violation(
+            long_str, schema, root="value", intro="bad", retry_hint="retry", site="test"
+        )
+        assert err is not None
+        assert long_str not in err
+        assert "<string>" in err  # collapsed to type name, not the 500-char value
+
+    def test_schema_included_when_small(self) -> None:
+        err = format_schema_violation(
+            {"answer": 1}, _OBJ_SCHEMA, root="value", intro="bad", retry_hint="retry", site="test"
+        )
+        assert err is not None
+        assert '"answer"' in err  # the schema itself rendered
+
+    def test_large_schema_falls_back_to_failing_subschema(self) -> None:
+        big_schema = {
+            "type": "object",
+            "properties": {
+                "answer": {"type": "string"},
+                **{f"filler_{i}": {"type": "string", "description": "x" * 50} for i in range(60)},
+            },
+            "required": ["answer"],
+        }
+        assert len(json.dumps(big_schema)) > 2000
+        err = format_schema_violation(
+            {"answer": 1}, big_schema, root="value", intro="bad", retry_hint="retry", site="test"
+        )
+        assert err is not None
+        # Only the failing subschema `{"type": "string"}` should appear, not the
+        # full multi-KB schema (no `filler_` keys leaking through).
+        assert "filler_" not in err
+
+    def test_stringified_json_quirk_detected_with_hint(self) -> None:
+        payload = json.dumps({"answer": "hi"})
+        err = format_schema_violation(
+            payload, _OBJ_SCHEMA, root="value", intro="bad", retry_hint="retry", site="test"
+        )
+        assert err is not None
+        assert "pass that value directly, not wrapped in a string" in err
+
+    def test_non_json_string_no_hint(self) -> None:
+        err = format_schema_violation(
+            "not json at all",
+            _OBJ_SCHEMA,
+            root="value",
+            intro="bad",
+            retry_hint="retry",
+            site="test",
+        )
+        assert err is not None
+        assert "pass that value directly" not in err
+
+    def test_json_string_that_does_not_match_schema_no_hint(self) -> None:
+        payload = json.dumps({"answer": 1})  # parses, but still fails the schema
+        err = format_schema_violation(
+            payload, _OBJ_SCHEMA, root="value", intro="bad", retry_hint="retry", site="test"
+        )
+        assert err is not None
+        assert "pass that value directly" not in err
+
+    def test_retry_hint_appended_when_provided(self) -> None:
+        err = format_schema_violation(
+            {"answer": 1},
+            _OBJ_SCHEMA,
+            root="value",
+            intro="bad",
+            retry_hint="call return again",
+            site="test",
+        )
+        assert err is not None
+        assert err.rstrip().endswith("call return again")
+
+    def test_retry_hint_omitted_when_none(self) -> None:
+        """A fail-loud caller (workflow run output) passes no retry hint — the
+        message must not end with a stray retry instruction."""
+        err = format_schema_violation(
+            {"answer": 1}, _OBJ_SCHEMA, root="output", intro="bad", retry_hint=None, site="test"
+        )
+        assert err is not None
+        assert "call return again" not in err
+        assert "retry" not in err.lower()
+
+    def test_bare_root_uses_root_token_when_path_empty(self) -> None:
+        err = format_schema_violation(
+            "not-an-object",
+            {"type": "object"},
+            root="output",
+            intro="bad",
+            retry_hint=None,
+            site="test",
+        )
+        assert err is not None
+        assert "at output: expected object, got string" in err
+
+    def test_empty_root_uses_angle_root_token(self) -> None:
+        err = format_schema_violation(
+            "nope",
+            {"type": "object"},
+            root="",
+            intro="bad",
+            retry_hint=None,
+            site="test",
+        )
+        assert err is not None
+        assert "at <root>: expected object, got string" in err

--- a/tests/unit/test_schema_errors.py
+++ b/tests/unit/test_schema_errors.py
@@ -109,6 +109,27 @@ class TestFormatSchemaViolation:
         assert err is not None
         assert "'z' is not one of ['x', 'y']" in err  # short scalar: verbatim is fine
 
+    def test_long_enum_and_const_instances_are_not_echoed(self) -> None:
+        long_str = "rejected-secret-" * 40
+        for schema in ({"enum": ["allowed"]}, {"const": "allowed"}):
+            err = format_schema_violation(
+                long_str, schema, root="value", intro="bad", retry_hint="retry", site="test"
+            )
+            assert err is not None
+            assert long_str not in err
+            assert "<string>" in err
+
+    def test_container_enum_and_const_instances_are_not_echoed(self) -> None:
+        rejected = {"secret": ["do-not-echo", {"nested": True}]}
+        for schema in ({"enum": [{"allowed": True}]}, {"const": {"allowed": True}}):
+            err = format_schema_violation(
+                rejected, schema, root="value", intro="bad", retry_hint="retry", site="test"
+            )
+            assert err is not None
+            assert repr(rejected) not in err
+            assert "do-not-echo" not in err
+            assert "<object>" in err
+
     def test_long_string_pattern_mismatch_not_echoed(self) -> None:
         schema = {"type": "string", "pattern": "^a"}
         long_str = "b" * 500

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -67,11 +67,11 @@ class TestValidateArguments:
         assert "'target' was unexpected" in err
 
     def test_wrong_type_is_reported(self) -> None:
+        """#1769 spec v2: no instance echo — the diagnosis is expected-vs-got
+        JSON type names, not a repr of the sent value."""
         err = validate_arguments({"channel_id": 42}, _SCHEMA)
         assert err is not None
-        assert "42" in err  # what was sent
-        # jsonschema's message varies; just assert we got SOMETHING useful
-        assert "channel_id" in err or "type" in err.lower() or "42" in err
+        assert "expected string or null, got integer" in err
 
     def test_multi_error_accumulation(self) -> None:
         """Missing required + extra property → BOTH surface in a single
@@ -82,13 +82,14 @@ class TestValidateArguments:
         assert "'channel_id' is a required property" in err
         assert "'target' was unexpected" in err
 
-    def test_passed_arguments_echoed_for_context(self) -> None:
-        """The error includes the arguments the model sent so the model
-        can see exactly what shape it produced vs. what was expected.
-        """
+    def test_arguments_not_echoed(self) -> None:
+        """#1769: the shared no-echo formatter never dumps the full sent
+        arguments — only per-error expected/got lines plus the schema."""
         err = validate_arguments({"target": "oops"}, _SCHEMA)
         assert err is not None
-        assert '"target": "oops"' in err
+        assert '"target": "oops"' not in err
+        assert "'channel_id' is a required property" in err
+        assert "'target' was unexpected" in err
 
     def test_error_ends_with_hint_to_consult_schema(self) -> None:
         """Closing guidance points the model back at the tool's

--- a/tests/unit/test_workflow_output_schema.py
+++ b/tests/unit/test_workflow_output_schema.py
@@ -41,7 +41,7 @@ def test_validate_value_rejects_with_path_and_retry_hint() -> None:
     err = _validate_value({"answer": 1}, _SCHEMA)
     assert err is not None
     assert "value.answer" in err  # the failing path, scoped under `value`
-    assert "call return again" in err  # the model is told to retry
+    assert "call `return` again" in err  # the model is told to retry
     # A bare-scalar schema is honored too (output_schema replaces `value` wholesale).
     assert _validate_value("hi", {"type": "number"}) is not None
     assert _validate_value(3, {"type": "number"}) is None


### PR DESCRIPTION
Automated dev-pipeline build for issue #1769.