### PR TITLE
fix(ci): master is RED — repoint pooled-await annotation from merged PR #1974 to open issue #2097

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -2684,7 +2684,7 @@ class SandboxRegistry:
                         )
                         if not _archive_eligible(fresh, now, grace):
                             continue
-                    if await self._store.remove(  # pooled-connection-await: allow eumemic/aios#1974
+                    if await self._store.remove(  # pooled-connection-await: allow eumemic/aios#2097
                         ref
                     ):
                         removed += 1


### PR DESCRIPTION
**Master lint is currently failing.** PR #1974 shipped code annotated `# pooled-connection-await: allow eumemic/aios#1974` — pointing at its own PR. The CI check requires the referenced item to be OPEN, so the merge that shipped the code closed its own exemption and turned master red.

This repoints the annotation to #2097, a new OPEN tracking issue that documents why the await is deliberate (the GC's session-row `FOR UPDATE` lock must span lifecycle recheck → artifact removal → exact-ref CAS) and what would close it.

One-line change; unblocks master and every PR rebased onto it (including #1938, which hit this on its rebase).

**Follow-up worth doing:** the CI check should reject annotations that reference a PR rather than an issue — a self-closing exemption is a footgun that will recur.