### PR TITLE
gha-exit: flip 3 aios scheduled workflows to the self-hosted runner (ops#414)

### DIFF
--- a/.github/workflows/phantom-ref-canary.yml
+++ b/.github/workflows/phantom-ref-canary.yml
@@ -42,7 +42,8 @@ permissions:
 
 jobs:
   canary:
-    runs-on: ubuntu-latest
+    # runs-on: self-hosted per eumemic-ops#414 (GitHub Actions is for CI only)
+    runs-on: [self-hosted, watchdog]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/retirement-aging-sla.yml
+++ b/.github/workflows/retirement-aging-sla.yml
@@ -46,7 +46,8 @@ permissions:
 
 jobs:
   aging-sla:
-    runs-on: ubuntu-latest
+    # runs-on: self-hosted per eumemic-ops#414 (GitHub Actions is for CI only)
+    runs-on: [self-hosted, watchdog]
     timeout-minutes: 10
     steps:
       # Full history: the aging core dates each migration file by its earliest

--- a/.github/workflows/retirement-residue-rescan.yml
+++ b/.github/workflows/retirement-residue-rescan.yml
@@ -41,7 +41,8 @@ permissions:
 
 jobs:
   residue-rescan:
-    runs-on: ubuntu-latest
+    # runs-on: self-hosted per eumemic-ops#414 (GitHub Actions is for CI only)
+    runs-on: [self-hosted, watchdog]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Per the standing chairman order, **GitHub Actions is for CI only**. This moves three scheduled retirement/canary jobs from `ubuntu-latest` to `[self-hosted, watchdog]`:

- `retirement-aging-sla.yml`
- `retirement-residue-rescan.yml`
- `phantom-ref-canary.yml`

The ratified doctrine remains that **OFF-SUBSTRATE DEAD-MEN stay on GitHub-hosted runners**: a watcher must not run on the substrate it monitors. These three workflows are **not dead-men**; they are retirement/canary jobs, so moving them to the watchdog runner is correct.

## gvisor-validation assessment

`gvisor-validation.yml` was assessed and deliberately left unchanged. It does not appear to require nested virtualization or a particular hardware virtualization extension. It does require a privileged Linux runner capable of:

- using `sudo` to install `runsc` from the gVisor apt repository;
- writing `/etc/docker/daemon.json` and restarting Docker through `systemctl`;
- registering and executing Docker containers with `--runtime=runsc`;
- building local Docker images and running Docker/testcontainers-based E2E tests (four parallel workers, with corresponding CPU/memory capacity).

In other words, the special requirement is host-level Docker daemon/runtime administration plus a working gVisor `runsc` installation and adequate resources, not nested virtualization. A generic watchdog host may not permit those daemon mutations or provide the required runtime/kernel compatibility, so it was not flipped.

## Scope and validation

Only the three requested `runs-on` selections changed, together with the required one-line ops#414 provenance comment above each. No workflow logic, permissions, secrets, schedules, or steps changed; `gvisor-validation.yml` is untouched.

Validation passed:

```text
YAML OK
```