### PR TITLE
docs(ci): record why gvisor-validation stays hosted (ops#414)

### DIFF
--- a/.github/workflows/gvisor-validation.yml
+++ b/.github/workflows/gvisor-validation.yml
@@ -1,5 +1,12 @@
 name: gVisor Validation
 
+# HOSTED BY NECESSITY (not an off-substrate dead-man): this job installs runsc from
+# the gVisor apt repo, edits /etc/docker/daemon.json, restarts the Docker daemon, and
+# runs parallel container E2E. On the shared [self-hosted, watchdog] box that would
+# mutate global host state every other watchdog depends on. Assessed 2026-08-13 under
+# the eumemic-ops#414 GHA exit and deliberately LEFT on ubuntu-latest, where a clean
+# ephemeral VM per run is exactly what it needs.
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Docs-only. Records **why** `gvisor-validation` stays on `ubuntu-latest` while every other aios scheduled workflow moved to the self-hosted watchdog runner under eumemic-ops#414.

It installs `runsc` from the gVisor apt repo, rewrites `/etc/docker/daemon.json`, restarts the Docker daemon, and runs parallel container E2E. On the shared `[self-hosted, watchdog]` box that would mutate global host state every other watchdog depends on. A clean ephemeral VM per run is exactly what this job needs.

**Why bother writing it down:** the org now has four scheduled workflows left on GitHub-hosted runners, and each needs a *reason* a future sweep can read — otherwise the next agent "finishing the GHA exit" flips this one and breaks the watchdog host. Two of the four already carry `# OFF-SUBSTRATE BY DESIGN` markers (`seat-recovery`, `ceo-heartbeat`, per the doctrine ratified 2026-08-13); this is the third, with a different justification — hosted by *necessity*, not as a dead-man.

No logic, schedule, permission or step changes.