### PR TITLE
revert(ci): un-flip the 3 aios schedules — no self-hosted runner is registered in this repo

### DIFF
--- a/.github/workflows/phantom-ref-canary.yml
+++ b/.github/workflows/phantom-ref-canary.yml
@@ -42,8 +42,11 @@ permissions:
 
 jobs:
   canary:
-    # runs-on: self-hosted per eumemic-ops#414 (GitHub Actions is for CI only)
-    runs-on: [self-hosted, watchdog]
+    # HOSTED PENDING A RUNNER: eumemic-ops#414 flipped this to [self-hosted, watchdog]
+# on 2026-08-13 and it QUEUED FOREVER — watchdog-hil-01 is registered to the
+# eumemic-ops repo only, so no runner in THIS repo matches that label. Reverted
+# the same day. Re-flip only after the runner is registered org-wide (or to aios).
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/retirement-aging-sla.yml
+++ b/.github/workflows/retirement-aging-sla.yml
@@ -46,8 +46,11 @@ permissions:
 
 jobs:
   aging-sla:
-    # runs-on: self-hosted per eumemic-ops#414 (GitHub Actions is for CI only)
-    runs-on: [self-hosted, watchdog]
+    # HOSTED PENDING A RUNNER: eumemic-ops#414 flipped this to [self-hosted, watchdog]
+# on 2026-08-13 and it QUEUED FOREVER — watchdog-hil-01 is registered to the
+# eumemic-ops repo only, so no runner in THIS repo matches that label. Reverted
+# the same day. Re-flip only after the runner is registered org-wide (or to aios).
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       # Full history: the aging core dates each migration file by its earliest

--- a/.github/workflows/retirement-residue-rescan.yml
+++ b/.github/workflows/retirement-residue-rescan.yml
@@ -41,8 +41,11 @@ permissions:
 
 jobs:
   residue-rescan:
-    # runs-on: self-hosted per eumemic-ops#414 (GitHub Actions is for CI only)
-    runs-on: [self-hosted, watchdog]
+    # HOSTED PENDING A RUNNER: eumemic-ops#414 flipped this to [self-hosted, watchdog]
+# on 2026-08-13 and it QUEUED FOREVER — watchdog-hil-01 is registered to the
+# eumemic-ops repo only, so no runner in THIS repo matches that label. Reverted
+# the same day. Re-flip only after the runner is registered org-wide (or to aios).
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Reverts the three `runs-on` flips from #2110.

## Why
#2110 pointed `retirement-aging-sla`, `retirement-residue-rescan` and `phantom-ref-canary` at `[self-hosted, watchdog]`. **Verification after merge showed all three sitting `queued` indefinitely.**

Cause: `watchdog-hil-01` is registered to the **eumemic-ops repository**, not the organisation. Measured:

| repo | runners |
|---|---|
| `eumemic/eumemic-ops` | `watchdog-hil-01` (online) |
| `eumemic/aios` | **none** |
| `eumemic/eumemic-company` | **none** |

So no runner in this repo can ever match that label. The net effect of #2110 was to convert three *working* scheduled jobs into three *permanently stalled* ones — strictly worse than leaving them hosted, and silent: a queued run raises no alarm.

## How it slipped through
The review checked the right things (doctrine, diff scope, `gh`/`jq` availability on the host) and I verified `gh`/`jq` empirically — but nobody checked the prerequisite underneath: **is there a runner in THIS repo at all?** The eumemic-ops flips worked, which made the aios flips look equally safe.

## What this PR does
- Restores `runs-on: ubuntu-latest` on all three.
- Replaces the ops#414 provenance comment with an inline note recording *why* they are hosted and what must happen first, so the next GHA-exit sweep doesn't repeat the mistake.

## Unblocking the real work
Register `watchdog-hil-01` at the **org** level (or add it to `aios`), then re-flip. Tracked on eumemic-ops#414.