### PR TITLE
fix(ci): one parser for pooled-await exemptions — the check was blind to an em-dash for two months

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -152,9 +152,28 @@ jobs:
           # appears; the linter is now the single source of truth.
           uv run python scripts/pooled_connection_lint.py --list-exemptions src \
             | sort -u > /tmp/exemptions.tsv
+
+          # FAIL CLOSED ON AN EMPTY ENUMERATION. If the linter crashes, the path is
+          # wrong, or every file is unreadable, zero rows come back -- and treating
+          # that as "all clear" would make total enumeration failure indistinguishable
+          # from a clean result. That is precisely the defect this step exists to fix
+          # (aios#2138: a predicate that reads "I could not check" as "it is fine"),
+          # so the fix must not reintroduce it one layer up. The repo is known to
+          # carry exemptions; zero means the enumerator broke, not that they vanished.
+          if [[ ! -s /tmp/exemptions.tsv ]]; then
+            echo "::error::pooled-await exemption enumeration returned NOTHING. The repo carries known exemptions, so an empty result means the enumerator failed -- it does NOT mean there are none. Refusing to report all-clear."
+            exit 1
+          fi
+
           fail=0
           while IFS=$'\t' read -r site ref; do
-            [[ -z "$ref" ]] && continue
+            [[ -z "$site$ref" ]] && continue
+            # A row we cannot parse is an exemption we cannot check. Never skip it.
+            if [[ -z "$ref" || "$site" != *:* ]]; then
+              echo "::error::unparseable exemption row from the enumerator: '${site}\t${ref}' -- refusing to skip it, because a skipped row is an unchecked exemption."
+              fail=1
+              continue
+            fi
             issue=${ref##*#}
             state=$(gh api "repos/eumemic/aios/issues/$issue" --jq .state 2>/dev/null || echo missing)
             if [[ "$state" != "open" ]]; then

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -144,14 +144,28 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          refs=$(grep -RhoE 'pooled-connection-await: allow eumemic/aios#[0-9]+' src \
-            | grep -oE 'eumemic/aios#[0-9]+' | sort -u || true)
-          while read -r ref; do
+          # Ask the LINTER what an exemption marker is -- never re-implement the parse
+          # here (aios#2143). An inline grep requiring the ref to follow `allow`
+          # IMMEDIATELY silently skipped `allow -- eumemic/aios#919`, so that exemption
+          # pointed at a CLOSED issue for two months while this step reported success.
+          # Two mechanisms parsing one syntax with different rules is how a blind spot
+          # appears; the linter is now the single source of truth.
+          uv run python scripts/pooled_connection_lint.py --list-exemptions src \
+            | sort -u > /tmp/exemptions.tsv
+          fail=0
+          while IFS=$'\t' read -r site ref; do
             [[ -z "$ref" ]] && continue
             issue=${ref##*#}
-            state=$(gh api "repos/eumemic/aios/issues/$issue" --jq .state)
-            [[ "$state" == "open" ]] || { echo "$ref does not exist or is not open"; exit 1; }
-          done <<< "$refs"
+            state=$(gh api "repos/eumemic/aios/issues/$issue" --jq .state 2>/dev/null || echo missing)
+            if [[ "$state" != "open" ]]; then
+              # Name the EXEMPTION and its file:line, not just the issue number: the
+              # reader's next action is to edit that marker, and a bare issue number
+              # makes every occurrence a fresh investigation.
+              echo "::error file=${site%%:*},line=${site##*:}::pooled-await exemption at ${site} cites ${ref}, which is ${state} (must be open). Re-anchor it to a live tracking issue, or remove the exemption."
+              fail=1
+            fi
+          done < /tmp/exemptions.tsv
+          exit $fail
 
       - name: Lint (ruff)
         # ``packages/aios-sdk/aios_sdk`` carries hand-written modules

--- a/scripts/pooled_connection_lint.py
+++ b/scripts/pooled_connection_lint.py
@@ -528,10 +528,61 @@ def check_paths(paths: list[Path]) -> list[Violation]:
     return violations
 
 
+def iter_exemption_refs(root: str = "src") -> list[tuple[str, int, int]]:
+    """Every pooled-await exemption marker under ``root``, as (path, lineno, issue).
+
+    THE SINGLE SOURCE OF TRUTH for "what is an exemption marker", so CI cannot
+    disagree with the linter about it.
+
+    WHY THIS EXISTS (aios#2143, 2026-08-14): the CI workflow re-implemented this
+    parse as an inline grep requiring the reference to follow ``allow``
+    IMMEDIATELY::
+
+        grep -RhoE 'pooled-connection-await: allow eumemic/aios#[0-9]+' src
+
+    One real marker read ``allow — eumemic/aios#919`` (em-dash). The grep never
+    matched it, so that exemption pointed at a CLOSED issue for two months while
+    the check reported success -- a governance check blind to the formatting it
+    did not anticipate, whose silence was indistinguishable from a clean bill of
+    health. Meanwhile a legitimately-closed issue (#1945) turned lint red on
+    every PR that rebased onto master.
+
+    Two mechanisms parsing one syntax with different rules is how the blind spot
+    appeared. This function is the fix: the workflow calls it instead of guessing
+    again.
+    """
+    out: list[tuple[str, int, int]] = []
+    for path in sorted(Path(root).rglob("*.py")):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for lineno, line in enumerate(lines, start=1):
+            if _PRAGMA not in line:
+                continue
+            match = _ISSUE_REF.search(line)
+            if match is not None:
+                out.append((str(path), lineno, int(match.group(1))))
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument(
+        "--list-exemptions",
+        action="store_true",
+        help=(
+            "print every pooled-await exemption marker as 'path:line\\teumemic/aios#N'. "
+            "CI uses this instead of re-implementing the parse (aios#2143)."
+        ),
+    )
     args = parser.parse_args()
+    if args.list_exemptions:
+        for path in args.paths:
+            for _p, _ln, _issue in iter_exemption_refs(str(path)):
+                print(f"{_p}:{_ln}\teumemic/aios#{_issue}")
+        return 0
     violations = check_paths(args.paths)
     for violation in violations:
         print(violation)

--- a/scripts/pooled_connection_lint.py
+++ b/scripts/pooled_connection_lint.py
@@ -567,8 +567,7 @@ def iter_exemption_refs(root: str = "src") -> list[tuple[str, int, int]]:
     # onerror, which we escalate rather than swallow.
     def _fail(exc: OSError) -> None:
         raise RuntimeError(
-            f"cannot enumerate {getattr(exc, 'filename', '?')} while discovering "
-            f"exemptions: {exc}"
+            f"cannot enumerate {getattr(exc, 'filename', '?')} while discovering exemptions: {exc}"
         ) from exc
 
     discovered: list[Path] = []

--- a/scripts/pooled_connection_lint.py
+++ b/scripts/pooled_connection_lint.py
@@ -555,8 +555,12 @@ def iter_exemption_refs(root: str = "src") -> list[tuple[str, int, int]]:
     for path in sorted(Path(root).rglob("*.py")):
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
-        except OSError:
-            continue
+        except OSError as exc:
+            # NEVER swallow this. A file we cannot read is a file whose exemptions we
+            # do not know about -- reporting "no markers here" would make partial
+            # enumeration failure indistinguishable from a clean result, which is the
+            # exact class this whole change exists to kill (aios#2138).
+            raise RuntimeError(f"cannot read {path} while enumerating exemptions: {exc}") from exc
         for lineno, line in enumerate(lines, start=1):
             if _PRAGMA not in line:
                 continue

--- a/scripts/pooled_connection_lint.py
+++ b/scripts/pooled_connection_lint.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -552,7 +553,31 @@ def iter_exemption_refs(root: str = "src") -> list[tuple[str, int, int]]:
     again.
     """
     out: list[tuple[str, int, int]] = []
-    for path in sorted(Path(root).rglob("*.py")):
+    root_path = Path(root)
+    if not root_path.is_dir():
+        # A root that is not a directory yields zero markers from rglob -- silently,
+        # and indistinguishably from "this tree has no exemptions".
+        raise RuntimeError(f"exemption root {root!r} is not a directory")
+
+    # Walk EXPLICITLY rather than with Path.rglob: rglob SUPPRESSES OSErrors raised
+    # while scanning directories, so an unreadable subtree simply does not appear in
+    # its results. That makes partial discovery failure indistinguishable from "that
+    # subtree has no exemptions" -- the exact class this function exists to kill
+    # (aios#2138), one level below the per-file read. os.walk surfaces the error via
+    # onerror, which we escalate rather than swallow.
+    def _fail(exc: OSError) -> None:
+        raise RuntimeError(
+            f"cannot enumerate {getattr(exc, 'filename', '?')} while discovering "
+            f"exemptions: {exc}"
+        ) from exc
+
+    discovered: list[Path] = []
+    for dirpath, _dirnames, filenames in os.walk(root_path, onerror=_fail):
+        for name in filenames:
+            if name.endswith(".py"):
+                discovered.append(Path(dirpath) / name)
+
+    for path in sorted(discovered):
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
         except OSError as exc:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -2857,7 +2857,7 @@ class SandboxRegistry:
             ):
                 return False
 
-            if not await self._backend.remove_image(  # pooled-connection-await: allow — eumemic/aios#919
+            if not await self._backend.remove_image(  # pooled-connection-await: allow eumemic/aios#2145
                 verdict.removal_ref
             ):
                 return False

--- a/src/aios/tools/list_vault_credentials.py
+++ b/src/aios/tools/list_vault_credentials.py
@@ -32,7 +32,7 @@ async def list_vault_credentials_handler(
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     async with pool.acquire() as conn:
-        rows = await queries.list_session_vault_credentials(  # pooled-connection-await: allow eumemic/aios#1945
+        rows = await queries.list_session_vault_credentials(  # pooled-connection-await: allow eumemic/aios#2144
             conn, session_id, account_id=account_id
         )
     return {

--- a/tests/unit/test_pooled_connection_lint.py
+++ b/tests/unit/test_pooled_connection_lint.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 from scripts.pooled_connection_lint import check_source
 
 
@@ -194,3 +196,81 @@ def test_iter_exemption_refs_sees_markers_the_old_ci_grep_missed(tmp_path: Path)
     }
     assert 222 not in old_found, "the em-dash case must be what the old grep missed"
     assert old_found < found, "the new parser must strictly dominate the old grep"
+
+
+def test_enumeration_refuses_to_report_clean_when_it_cannot_look(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Partial discovery failure must RAISE, never return a short list.
+
+    The per-file read guard was necessary and NOT sufficient: it covers files that
+    were discovered but unreadable. ``Path.rglob`` SUPPRESSES OSErrors raised while
+    scanning directories, so an unreadable subtree simply does not appear in its
+    results -- making partial discovery failure indistinguishable from "that subtree
+    has no exemptions".
+
+    That is aios#2138's class one level below the read: a non-empty result is not
+    evidence of a COMPLETE result. The non-empty guard in CI cannot catch it, because
+    the list is non-empty -- just short.
+    """
+    import os
+
+    from scripts.pooled_connection_lint import iter_exemption_refs
+
+    # A root that is not a directory yields zero markers from rglob, silently.
+    not_a_dir = tmp_path / "file.py"
+    not_a_dir.write_text("x = 1\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="not a directory"):
+        iter_exemption_refs(str(not_a_dir))
+
+    # A directory that cannot be scanned must escalate, not be skipped.
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "ok.py").write_text(
+        "async def f(pool):\n"
+        "    async with pool.acquire() as conn:\n"
+        "        return await conn.fetch('x')  # pooled-connection-await: allow eumemic/aios#1\n",
+        encoding="utf-8",
+    )
+    real_walk = os.walk
+
+    def exploding_walk(top, **kwargs):  # type: ignore[no-untyped-def]
+        onerror = kwargs.get("onerror")
+        if onerror is not None:
+            onerror(OSError(13, "Permission denied", str(src / "locked")))
+        return iter(())
+
+    monkeypatch.setattr(os, "walk", exploding_walk)
+    with pytest.raises(RuntimeError, match="cannot enumerate"):
+        iter_exemption_refs(str(src))
+
+
+def test_unreadable_file_raises_rather_than_reporting_no_markers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file we cannot READ is a file whose exemptions we do not know about.
+
+    Committed because the original verification induced the OSError by hand and was
+    correctly judged insufficient: it proved the handler propagates, not that the
+    behaviour is pinned. ``chmod 000`` is useless here -- the test may run as root,
+    and root can read anything, so the guard would appear to pass while never firing.
+    """
+    from pathlib import Path as _Path
+
+    from scripts.pooled_connection_lint import iter_exemption_refs
+
+    src = tmp_path / "src"
+    src.mkdir()
+    target = src / "unreadable.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    real_read_text = _Path.read_text
+
+    def boom(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if self.name == "unreadable.py":
+            raise OSError(13, "Permission denied")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(_Path, "read_text", boom)
+    with pytest.raises(RuntimeError, match="cannot read"):
+        iter_exemption_refs(str(src))

--- a/tests/unit/test_pooled_connection_lint.py
+++ b/tests/unit/test_pooled_connection_lint.py
@@ -4,7 +4,6 @@ import ast
 from pathlib import Path
 
 import pytest
-
 from scripts.pooled_connection_lint import check_source
 
 
@@ -232,9 +231,8 @@ def test_enumeration_refuses_to_report_clean_when_it_cannot_look(
         "        return await conn.fetch('x')  # pooled-connection-await: allow eumemic/aios#1\n",
         encoding="utf-8",
     )
-    real_walk = os.walk
 
-    def exploding_walk(top, **kwargs):  # type: ignore[no-untyped-def]
+    def exploding_walk(top, **kwargs):
         onerror = kwargs.get("onerror")
         if onerror is not None:
             onerror(OSError(13, "Permission denied", str(src / "locked")))
@@ -266,7 +264,7 @@ def test_unreadable_file_raises_rather_than_reporting_no_markers(
 
     real_read_text = _Path.read_text
 
-    def boom(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def boom(self, *args, **kwargs):
         if self.name == "unreadable.py":
             raise OSError(13, "Permission denied")
         return real_read_text(self, *args, **kwargs)

--- a/tests/unit/test_pooled_connection_lint.py
+++ b/tests/unit/test_pooled_connection_lint.py
@@ -143,7 +143,7 @@ async def work(pool):
 """)
 
 
-def test_iter_exemption_refs_sees_markers_the_old_ci_grep_missed(tmp_path) -> None:
+def test_iter_exemption_refs_sees_markers_the_old_ci_grep_missed(tmp_path: Path) -> None:
     """The em-dash blind spot: aios#2143.
 
     CI used to enumerate exemptions with an inline grep requiring the issue ref to

--- a/tests/unit/test_pooled_connection_lint.py
+++ b/tests/unit/test_pooled_connection_lint.py
@@ -141,3 +141,56 @@ async def work(pool):
     async with pool.acquire() as conn:
         await {call}
 """)
+
+
+def test_iter_exemption_refs_sees_markers_the_old_ci_grep_missed(tmp_path) -> None:
+    """The em-dash blind spot: aios#2143.
+
+    CI used to enumerate exemptions with an inline grep requiring the issue ref to
+    follow ``allow`` IMMEDIATELY::
+
+        grep -RhoE 'pooled-connection-await: allow eumemic/aios#[0-9]+' src
+
+    A real marker read ``allow — eumemic/aios#919``. The grep never matched it, so
+    that exemption cited a CLOSED issue for two months while the check reported
+    success. This pins the parser against every punctuation variant, so the check
+    can never again be blind to the formatting it did not anticipate.
+    """
+    import re
+
+    from scripts.pooled_connection_lint import iter_exemption_refs
+
+    variants = [
+        ("plain", "allow eumemic/aios#111"),
+        ("em_dash", "allow — eumemic/aios#222"),
+        ("hyphen", "allow - eumemic/aios#333"),
+        ("colon", "allow: eumemic/aios#444"),
+        ("parens", "allow (eumemic/aios#555)"),
+        ("trailing_prose", "allow eumemic/aios#666 — load-bearing, see thread"),
+    ]
+    src = tmp_path / "src"
+    src.mkdir()
+    for name, marker in variants:
+        (src / f"{name}.py").write_text(
+            "async def f(pool):\n"
+            "    async with pool.acquire() as conn:\n"
+            f"        return await conn.fetch('x')  # pooled-connection-await: {marker}\n",
+            encoding="utf-8",
+        )
+
+    found = {issue for _path, _line, issue in iter_exemption_refs(str(src))}
+    assert found == {111, 222, 333, 444, 555, 666}, (
+        f"parser missed a marker variant: got {sorted(found)}"
+    )
+
+    # And prove the OLD grep semantics really were blind, so this test documents the
+    # bug rather than merely asserting current behaviour.
+    old_grep = re.compile(r"pooled-connection-await: allow eumemic/aios#(\d+)")
+    old_found = {
+        int(m.group(1))
+        for _n, marker in variants
+        for m in [old_grep.search(f"# pooled-connection-await: {marker}")]
+        if m
+    }
+    assert 222 not in old_found, "the em-dash case must be what the old grep missed"
+    assert old_found < found, "the new parser must strictly dominate the old grep"


### PR DESCRIPTION
Fixes #2143.

## The bug had two halves and the second one is worse

**Half 1 (the visible one):** aios#1945 was closed on 2026-08-14 when its own PR merged — **correctly** — and that turned `lint` **RED on every PR that rebases onto master**, because CI requires each pooled-await exemption to cite an **open** issue. aios#2073 hit it while being updated for a merge.

**Half 2 (the one nobody saw):** the CI step re-implemented the linter's parse as an inline grep requiring the reference to follow `allow` **immediately**:

```bash
grep -RhoE 'pooled-connection-await: allow eumemic/aios#[0-9]+' src
```

A real marker in `registry.py:2860` read **`allow — eumemic/aios#919`** (em-dash). **The grep never matched it, so that exemption pointed at a CLOSED issue for two months while the check reported success.**

> **A governance check that only sees the formatting it expects is reporting on its own regex, not on the codebase — and its silence is indistinguishable from a clean bill of health.**

## The fix

**One definition of "an exemption marker", owned by the linter.** `scripts/pooled_connection_lint.py` gains `iter_exemption_refs()` + a `--list-exemptions` flag, reusing the `_PRAGMA` / `_ISSUE_REF` pair the linter **already parsed correctly**. The workflow **calls it** instead of guessing again. *Two mechanisms parsing one syntax with different rules is how the blind spot appeared.*

**The error now names the EXEMPTION, not just the issue.** It emits a GitHub `::error` with `file=`/`line=`, so the annotation lands on the offending marker:

```
::error file=src/aios/sandbox/registry.py,line=2860::pooled-await exemption at
  src/aios/sandbox/registry.py:2860 cites eumemic/aios#2145, which is closed
  (must be open). Re-anchor it to a live tracking issue, or remove the exemption.
```

Previously you got `#1945 does not exist or is not open` and had to go find which exemption, in which file. **An error that names the symptom and not the site makes every future occurrence a fresh investigation.**

**Both stale markers re-anchored** onto live tracking issues — **#2144** (`list_vault_credentials`) and **#2145** (`remove_image`) — and the em-dash marker normalised.

> **A FEATURE issue is the wrong anchor for a standing exemption: it closes when the feature ships, while the exemption outlives it.** Each tracking issue says "do not close while the marker exists" and states the open question — for #2144, whether the exemption is needed at all or the linter is over-matching a single read on an already-held connection.

## Evidence

**Mutation test, both directions.** With the parser regressed to the old grep semantics:

```
FAILED test_iter_exemption_refs_sees_markers_the_old_ci_grep_missed
1 failed, 12 passed
```

Restored: `13 passed`.

The new test pins **six punctuation variants** (plain, em-dash, hyphen, colon, parens, trailing prose) **and asserts the old grep semantics missed the em-dash case** — so it **documents the bug** rather than merely asserting current behaviour, and `old_found < found` proves the new parser strictly dominates.

**Workflow logic exercised locally** with a stubbed `gh`: a closed reference produces the annotation above and `exit 1`; all-open produces `exit 0`.

**Declared unverified:** the full unit suite was **not** run here — `tests/conftest.py` imports `structlog`, absent from this sandbox — so the new test was executed in isolation against the real module (13 passed). **CI is the check.** The workflow change itself can only be proven by CI running it.