### PR TITLE
fix(test): make stale LiteLLM map scenario deterministic

### DIFF
--- a/tests/unit/test_agents_param_warning.py
+++ b/tests/unit/test_agents_param_warning.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock
 
+import litellm
 from fastapi import Response
 
 from aios.api.routers import agents as router
@@ -36,6 +37,13 @@ def _agent(**over: Any) -> Agent:
 
 
 async def test_update_warns_when_local_map_would_reject_param(monkeypatch: Any) -> None:
+    # Model metadata may refresh independently of the locked LiteLLM package. Pin the
+    # stale-map condition this warning is specifically intended to report.
+    monkeypatch.setattr(
+        litellm,
+        "get_supported_openai_params",
+        lambda _model: ["temperature"],
+    )
     current = _agent()
     updated = _agent(version=2, litellm_extra={"reasoning_effort": "high"})
     monkeypatch.setattr(agents_service, "get_agent", AsyncMock(return_value=current))

--- a/tests/unit/test_litellm_param_validation.py
+++ b/tests/unit/test_litellm_param_validation.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+from typing import Any
+
+import litellm
+
 from aios.services.litellm_params import unsupported_openai_params
 
 
-def test_stale_capability_map_is_reported_at_config_save() -> None:
+def test_stale_capability_map_is_reported_at_config_save(monkeypatch: Any) -> None:
+    # Model metadata may refresh independently of the locked LiteLLM package. Exercise a
+    # deliberately stale snapshot instead of depending on today's remote capability map.
+    monkeypatch.setattr(
+        litellm,
+        "get_supported_openai_params",
+        lambda _model: ["temperature"],
+    )
+
     assert unsupported_openai_params("xai/grok-4.6", {"reasoning_effort": "high"}) == [
         "reasoning_effort"
     ]


### PR DESCRIPTION
Emergency fix for red master. Both failing tests reproduce at 1793aa43 and its parent 387424aa, disproving the #2119 regression hypothesis. LiteLLM's model metadata refreshed independently and now advertises reasoning_effort for grok-4.6. The tests now pin a deliberately stale map while retaining the visible Warning assertions.