### PR TITLE
fix: allow metadata to be None in VaultCredential read model (closes #2135)

### DIFF
--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential.py
@@ -44,7 +44,7 @@ class VaultCredential:
     display_name: None | str
     target_url: None | str
     auth_type: VaultCredentialAuthType
-    metadata: VaultCredentialMetadata
+    metadata: None | VaultCredentialMetadata
     created_at: datetime.datetime
     updated_at: datetime.datetime
     secret_name: None | str | Unset = UNSET


### PR DESCRIPTION
## What
Vault credential metadata can be explicitly cleared, which writes a JSON null (not SQL NULL) into the `metadata` jsonb column. The read model declares `metadata` as non-optional `VaultCredentialMetadata`, causing pydantic/attrs validation errors when the decoder reads `None` from JSON null.

## Fix
Widen the `metadata` attribute type to `None | VaultCredentialMetadata` in the read model. The `to_dict()` method already returns the result of `metadata.to_dict()`, so when metadata is None, it will return None, which serializes to JSON null. This matches the write-side behavior and resolves the validation error.

Closes #2135