### PR TITLE
Prevent upload GC data loss for unknown live files

### DIFF
--- a/src/aios/db/queries/files.py
+++ b/src/aios/db/queries/files.py
@@ -16,7 +16,7 @@ from aios.errors import (
 )
 from aios.models.files import File
 
-# ─── files ───────────────────────────────────────────────────────────────────
+# ─── files ───────────────────────────────────────────────────────────────
 
 
 def _row_to_file(row: asyncpg.Record) -> File:
@@ -83,12 +83,13 @@ async def insert_file(
 
 async def list_upload_paths_for_sessions(
     conn: asyncpg.Connection[Any], session_ids: list[str]
-) -> dict[str, set[str]]:
-    """Return referenced upload host paths, including empty sets for live sessions.
+) -> dict[str, set[str] | None]:
+    """Return referenced upload host paths for requested live sessions.
 
-    Missing keys identify session directories whose owning row is gone.  The
-    startup filesystem reconciler uses that distinction to remove the whole
-    directory rather than applying the per-file in-flight grace period.
+    A missing key identifies a deleted session. ``None`` identifies a live
+    session with no file rows, where the database cannot determine whether
+    on-disk files are orphaned. A non-empty set authoritatively identifies the
+    known files and permits per-file reconciliation.
     """
     if not session_ids:
         return {}
@@ -101,9 +102,16 @@ async def list_upload_paths_for_sessions(
         """,
         session_ids,
     )
-    result: dict[str, set[str]] = {}
+    result: dict[str, set[str] | None] = {}
     for row in rows:
-        paths = result.setdefault(row["session_id"], set())
-        if row["host_path"] is not None:
-            paths.add(row["host_path"])
+        session_id = row["session_id"]
+        host_path = row["host_path"]
+        if host_path is None:
+            result.setdefault(session_id, None)
+            continue
+        paths = result.get(session_id)
+        if paths is None:
+            paths = set()
+            result[session_id] = paths
+        paths.add(host_path)
     return result

--- a/src/aios/harness/attachment_gc.py
+++ b/src/aios/harness/attachment_gc.py
@@ -128,6 +128,12 @@ async def sweep_orphan_attachments(pool: asyncpg.Pool[Any]) -> int:
 async def sweep_orphan_uploads(pool: asyncpg.Pool[Any]) -> int:
     """Reconcile ``_uploads`` with live sessions and rows in ``files``.
 
+    WARNING: Do not call this function (aios#2161, aios#2140). Live-session
+    reconciliation from ``files`` rows is unsafe because operator-placed files
+    are intentionally unregistered. In the mixed case, a live session with
+    registered rows plus an unregistered file, that unregistered file is still
+    deleted.
+
     Directories for deleted sessions are removed wholesale.  For live sessions,
     unreferenced files older than the staging grace are removed; recent files
     may still be between their atomic rename and DB insert.

--- a/src/aios/harness/attachment_gc.py
+++ b/src/aios/harness/attachment_gc.py
@@ -156,6 +156,8 @@ async def sweep_orphan_uploads(pool: asyncpg.Pool[Any]) -> int:
                 failures.append((session_dir, err))
             continue
         retained = referenced[session_dir.name]
+        if retained is None:
+            continue
         for file_path in session_dir.rglob("*"):
             if not file_path.is_file() or str(file_path) in retained:
                 continue

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -45,7 +45,7 @@ from aios.db.listen import (
 )
 from aios.db.pool import LISTENER_TCP_KEEPALIVE_SETTINGS, create_pool, normalize_dsn
 from aios.harness import runtime
-from aios.harness.attachment_gc import sweep_orphan_attachments, sweep_orphan_uploads
+from aios.harness.attachment_gc import sweep_orphan_attachments
 from aios.harness.exit_diagnostics import install_exit_diagnostics
 from aios.harness.host_dir_reaper import sweep_host_dirs
 from aios.harness.inflight_tool_registry import InflightToolRegistry
@@ -486,9 +486,6 @@ async def worker_main() -> None:
         deleted_attachments = await sweep_orphan_attachments(pool)
         if deleted_attachments:
             log.info("worker.reaped_orphan_attachments", count=deleted_attachments)
-        deleted_uploads = await sweep_orphan_uploads(pool)
-        if deleted_uploads:
-            log.info("worker.reaped_orphan_uploads", count=deleted_uploads)
 
         log.info(
             "worker.startup",

--- a/tests/integration/test_upload_gc_query_contract.py
+++ b/tests/integration/test_upload_gc_query_contract.py
@@ -12,10 +12,10 @@ from aios.db import queries
 pytestmark = [pytest.mark.integration, pytest.mark.docker]
 
 
-async def test_live_session_without_files_is_present_in_upload_keep_map(
+async def test_live_session_without_files_is_indeterminate_in_upload_keep_map(
     migrated_db_url: str, _reset_db_state: None
 ) -> None:
-    """A missing key authorizes wholesale rmtree, so zero-file live rows must emit one."""
+    """Live zero-row sessions must differ from deleted and authoritative sessions."""
     conn: asyncpg.Connection[Any] = await asyncpg.connect(migrated_db_url)
     try:
         await conn.execute(
@@ -41,6 +41,6 @@ async def test_live_session_without_files_is_present_in_upload_keep_map(
 
         assert await queries.list_upload_paths_for_sessions(
             conn, ["sess_upload_contract", "sess_deleted"]
-        ) == {"sess_upload_contract": set()}
+        ) == {"sess_upload_contract": None}
     finally:
         await conn.close()

--- a/tests/unit/test_upload_gc.py
+++ b/tests/unit/test_upload_gc.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
+import ast
+import inspect
 import os
+import textwrap
 import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aios.harness import worker
 from aios.harness.attachment_gc import sweep_orphan_uploads
+
+
+def test_worker_startup_does_not_call_upload_reconciliation() -> None:
+    """Pin the call graph, not a coincidentally empty filesystem outcome."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(worker.worker_main)))
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+
+    assert "sweep_orphan_uploads" not in called_names
 
 
 class _AsyncContext:

--- a/tests/unit/test_upload_gc.py
+++ b/tests/unit/test_upload_gc.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 import inspect
 import os
-import textwrap
 import time
 from pathlib import Path
 from typing import Any
@@ -14,12 +13,12 @@ from aios.harness.attachment_gc import sweep_orphan_uploads
 
 
 def test_worker_startup_does_not_call_upload_reconciliation() -> None:
-    """Pin the call graph, not a coincidentally empty filesystem outcome."""
-    tree = ast.parse(textwrap.dedent(inspect.getsource(worker.worker_main)))
+    """Pin the worker module's call graph, including periodic helper loops."""
+    tree = ast.parse(inspect.getsource(worker))
     called_names = {
-        node.func.id
+        node.func.id if isinstance(node.func, ast.Name) else node.func.attr
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        if isinstance(node, ast.Call) and isinstance(node.func, (ast.Name, ast.Attribute))
     }
 
     assert "sweep_orphan_uploads" not in called_names

--- a/tests/unit/test_upload_gc.py
+++ b/tests/unit/test_upload_gc.py
@@ -17,16 +17,40 @@ class _AsyncContext:
         return None
 
 
+def _write_old(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("bytes")
+    old = time.time() - 3600
+    os.utime(path, (old, old))
+
+
+async def test_sweep_skips_live_session_with_no_file_rows(tmp_path: Path) -> None:
+    root = tmp_path / "_uploads"
+    operator_placed = root / "sess_live" / "credentials" / "operator.pem"
+    _write_old(operator_placed)
+
+    pool = MagicMock()
+    pool.acquire.return_value = _AsyncContext()
+    with (
+        patch("aios.harness.attachment_gc.uploads_root", return_value=root),
+        patch(
+            "aios.harness.attachment_gc.queries.list_upload_paths_for_sessions",
+            AsyncMock(return_value={"sess_live": None}),
+        ),
+    ):
+        deleted = await sweep_orphan_uploads(pool)
+
+    assert deleted == 0
+    assert operator_placed.exists()
+
+
 async def test_sweep_reaps_orphan_upload_and_gone_session_directory(tmp_path: Path) -> None:
     root = tmp_path / "_uploads"
     orphan = root / "sess_live" / "file_orphan" / "orphan.txt"
     retained = root / "sess_live" / "file_kept" / "kept.txt"
     gone = root / "sess_gone" / "file_old" / "old.txt"
     for path in (orphan, retained, gone):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("bytes")
-        old = time.time() - 3600
-        os.utime(path, (old, old))
+        _write_old(path)
 
     pool = MagicMock()
     pool.acquire.return_value = _AsyncContext()


### PR DESCRIPTION
Fixes #2161.

Worker startup no longer invokes upload reconciliation. DB inference cannot safely distinguish intentionally unregistered operator files from genuine orphans when a live session also has registered uploads, and read-committed visibility also permits an uncommitted live session to be mistaken for a deleted one. Removing the startup caller eliminates both destructive paths.

The explicit synchronous session-delete directory purge remains unchanged and tested. `sweep_orphan_attachments()` remains active because it operates on the separate attachment root. `sweep_orphan_uploads()` remains defined but uncalled to preserve the real orphan-disk-usage implementation for any future explicitly safe/operated mechanism; a call-graph regression test prevents worker startup from reaching it.

Validation: affected suites pass (23 passed); the PostgreSQL integration contract was skipped locally because Docker is unavailable. Mutation checks prove restoring the startup call fails the call-graph test and disabling explicit session-delete purge fails its directory-removal test.