### PR TITLE
Fix workspace reaper containment safety (#2167)

### DIFF
--- a/src/aios/db/queries/sandboxes.py
+++ b/src/aios/db/queries/sandboxes.py
@@ -81,13 +81,24 @@ async def unscoped_workspace_path_is_live(conn: asyncpg.Connection[Any], path: s
             SELECT EXISTS (
                 SELECT 1 FROM sessions
                  WHERE archived_at IS NULL
-                   AND workspace_volume_path = $1
+                   AND workspace_volume_path IS NOT NULL
+                   AND (
+                       workspace_volume_path = $1
+                       OR left(workspace_volume_path, length($1) + 1) = $1 || '/'
+                       OR left($1, length(workspace_volume_path) + 1)
+                          = workspace_volume_path || '/'
+                   )
                 UNION ALL
                 SELECT 1 FROM wf_runs
                  WHERE archived_at IS NULL
                    AND workspace_mode = 'shared'
                    AND status IN ('pending', 'running', 'suspended')
-                   AND workspace_path = $1
+                   AND workspace_path IS NOT NULL
+                   AND (
+                       workspace_path = $1
+                       OR left(workspace_path, length($1) + 1) = $1 || '/'
+                       OR left($1, length(workspace_path) + 1) = workspace_path || '/'
+                   )
             )
             """,
             normalized,

--- a/src/aios/harness/workspace_reaper.py
+++ b/src/aios/harness/workspace_reaper.py
@@ -96,6 +96,7 @@ import asyncpg
 
 from aios.config import get_settings
 from aios.db import queries
+from aios.db.pool import normalize_dsn
 from aios.logging import get_logger
 
 log = get_logger("aios.harness.workspace_reaper")
@@ -373,10 +374,15 @@ async def sweep_archived_workspaces(pool: asyncpg.Pool[Any]) -> ReapResult:
     live_workspace_realpaths = _live_workspace_realpath_keepset(live_paths)
 
     reaped = bytes_freed = skip_conf = skip_missing = skip_fresh = skip_error = 0
-    # Hold one dedicated pooled backend for the entire destructive phase. Session
-    # advisory locks remain owned across each to_thread delete without opening a
-    # new database connection per candidate.
-    async with pool.acquire() as lock_conn:
+    # One non-pooled backend is dedicated to this sweep's lock lifecycle.  The
+    # session advisory lock must remain owned across slow filesystem deletion;
+    # borrowing that backend from the shared pool would starve unrelated work,
+    # while opening one backend per candidate would create a connection storm.
+    lock_conn = await asyncpg.connect(
+        normalize_dsn(settings.db_url),
+        server_settings={"application_name": "aios-workspace-reaper"},
+    )
+    try:
         for row in candidates:
             target, reason = _resolve_reap_target(
                 account_id=row["account_id"],
@@ -429,6 +435,8 @@ async def sweep_archived_workspaces(pool: asyncpg.Pool[Any]) -> ReapResult:
                 continue
             reaped += 1
             bytes_freed += size
+    finally:
+        await lock_conn.close()
     result = ReapResult(
         reaped=reaped,
         bytes_freed=bytes_freed,

--- a/src/aios/harness/workspace_reaper.py
+++ b/src/aios/harness/workspace_reaper.py
@@ -37,11 +37,13 @@ archived-and-aged session it derives the canonical default path
 reaps **only** that, and **only** when the stored ``workspace_volume_path``
 ``resolve()``s equal to it. Consequences, all in the safe direction:
 
-* A user-overridden / clone-shared / aliased / nested path never equals the
-  canonical path ⇒ it is skipped (a space leak, never a wrong delete).
+* A user-overridden / clone-shared / nested path that resolves elsewhere never
+  equals the canonical path ⇒ it is skipped (a space leak, never a wrong delete).
+  A symlink alias of the canonical path is equivalent and may pass this check;
+  the canonical delete target itself must still contain no symlink component.
 * The canonical path is always two levels under ``workspace_root`` ⇒ it can
   never be ``workspace_root`` itself or a reserved sibling root (``_runs`` …).
-* A relative / empty / out-of-tree stored value never resolves-equal ⇒ skipped.
+* Empty, relative, or out-of-tree stored values are rejected explicitly.
 
 Confinement is proven on the FULLY-RESOLVED canonical path — no symlink anywhere
 in its chain (leaf, parent ACCOUNT component, OR root) and its realpath still
@@ -94,7 +96,6 @@ import asyncpg
 
 from aios.config import get_settings
 from aios.db import queries
-from aios.db.pool import normalize_dsn
 from aios.logging import get_logger
 
 log = get_logger("aios.harness.workspace_reaper")
@@ -171,6 +172,26 @@ def _canonical_workspace_path(account_id: str, session_id: str, workspace_root: 
     discipline ``host_dir_reaper._scan_children`` uses.
     """
     return workspace_root / account_id / session_id
+
+
+def _paths_overlap(left: str, right: str) -> bool:
+    """Whether either normalized absolute path contains the other."""
+    left_path = Path(left)
+    right_path = Path(right)
+    return (
+        left_path == right_path
+        or left_path.is_relative_to(right_path)
+        or right_path.is_relative_to(left_path)
+    )
+
+
+def _max_tree_mtime(path: Path) -> float:
+    """Newest lstat mtime in a workspace tree, without following symlinks."""
+    newest = path.lstat().st_mtime
+    for root, dirs, files in os.walk(path, followlinks=False):
+        for name in (*dirs, *files):
+            newest = max(newest, (Path(root) / name).lstat().st_mtime)
+    return newest
 
 
 def _live_workspace_realpath_keepset(live_paths: list[str]) -> frozenset[str]:
@@ -274,10 +295,9 @@ def _resolve_reap_target(
         return None, "confinement"
 
     # Confinement: reap ONLY the canonical default path, and ONLY when the
-    # session's stored path points at the SAME real location. We compare on
-    # ``realpath`` (symlink-collapsed) so an override / shared / aliased /
-    # relative / out-of-tree stored value never matches ⇒ skipped, never reaped.
-    if not stored_path:
+    # session's stored path points at the SAME real location. Relative paths are
+    # rejected before realpath so the decision never depends on process CWD.
+    if not stored_path or not os.path.isabs(stored_path):
         return None, "confinement"
     try:
         if os.path.realpath(stored_path) != canonical_real:
@@ -293,7 +313,7 @@ def _resolve_reap_target(
     # fail-closed-empty only when its query erred — and on that error the caller
     # skips the WHOLE sweep, so an empty set here always means "no live collision
     # among the sessions we could enumerate".)
-    if canonical_real in live_workspace_realpaths:
+    if any(_paths_overlap(canonical_real, live) for live in live_workspace_realpaths):
         return None, "confinement"
 
     # Structural belt: a real dir that is exactly two levels under the root.
@@ -303,9 +323,9 @@ def _resolve_reap_target(
         return None, "confinement"
 
     try:
-        # lstat (not stat): mtime of the dir itself, never a dereferenced target
-        # (the leaf is already proven non-symlink above; belt-and-suspenders).
-        mtime = canonical.lstat().st_mtime
+        # Descendant writes do not update the candidate directory's mtime, so
+        # inspect the full tree. os.walk never follows symlinked directories.
+        mtime = _max_tree_mtime(canonical)
     except OSError:
         return None, "missing"
     if mtime > mtime_cutoff:
@@ -353,70 +373,62 @@ async def sweep_archived_workspaces(pool: asyncpg.Pool[Any]) -> ReapResult:
     live_workspace_realpaths = _live_workspace_realpath_keepset(live_paths)
 
     reaped = bytes_freed = skip_conf = skip_missing = skip_fresh = skip_error = 0
-    for row in candidates:
-        target, reason = _resolve_reap_target(
-            account_id=row["account_id"],
-            session_id=row["id"],
-            stored_path=row["workspace_volume_path"],
-            workspace_root=workspace_root,
-            mtime_cutoff=mtime_cutoff,
-            live_workspace_realpaths=live_workspace_realpaths,
-        )
-        if reason == "confinement":
-            skip_conf += 1
-            continue
-        if reason == "missing":
-            skip_missing += 1
-            continue
-        if reason == "too_fresh":
-            skip_fresh += 1
-            continue
-        assert target is not None  # reason == "reap"
+    # Hold one dedicated pooled backend for the entire destructive phase. Session
+    # advisory locks remain owned across each to_thread delete without opening a
+    # new database connection per candidate.
+    async with pool.acquire() as lock_conn:
+        for row in candidates:
+            target, reason = _resolve_reap_target(
+                account_id=row["account_id"],
+                session_id=row["id"],
+                stored_path=row["workspace_volume_path"],
+                workspace_root=workspace_root,
+                mtime_cutoff=mtime_cutoff,
+                live_workspace_realpaths=live_workspace_realpaths,
+            )
+            if reason == "confinement":
+                skip_conf += 1
+                continue
+            if reason == "missing":
+                skip_missing += 1
+                continue
+            if reason == "too_fresh":
+                skip_fresh += 1
+                continue
+            assert target is not None  # reason == "reap"
 
-        size = _dir_size_bytes(target)
-        if dry_run:
+            size = _dir_size_bytes(target)
+            if dry_run:
+                reaped += 1
+                bytes_freed += size
+                log.info(
+                    "workspace_reaper.would_reap",
+                    session_id=row["id"],
+                    path=str(target),
+                    bytes=size,
+                )
+                continue
+            try:
+                # The dedicated sweep backend owns the session lock across slow
+                # filesystem I/O; explicit unlock makes it reusable for the next item.
+                normalized_target = queries.normalized_workspace_path(str(target))
+                lock_key = queries.workspace_advisory_lock_key(normalized_target)
+                await lock_conn.execute("SELECT pg_advisory_lock($1::bigint)", lock_key)
+                try:
+                    if await queries.unscoped_workspace_path_is_live(lock_conn, normalized_target):
+                        skip_conf += 1
+                        continue
+                    await asyncio.to_thread(shutil.rmtree, target)
+                finally:
+                    await lock_conn.execute("SELECT pg_advisory_unlock($1::bigint)", lock_key)
+            except (asyncpg.PostgresError, asyncpg.InterfaceError, OSError):
+                # One un-removable dir (perm drift, read-only FS) must not abort the
+                # rest of the sweep; the next sweep retries it.
+                log.exception("workspace_reaper.rmtree_failed", path=str(target))
+                skip_error += 1
+                continue
             reaped += 1
             bytes_freed += size
-            log.info(
-                "workspace_reaper.would_reap",
-                session_id=row["id"],
-                path=str(target),
-                bytes=size,
-            )
-            continue
-        try:
-            # A session advisory lock survives transaction/borrow release, so the
-            # pool connection is returned before slow filesystem I/O.  The same
-            # backend is borrowed again only to unlock after rmtree; pool reset must
-            # not run between these two points, hence the explicit acquire/release.
-            normalized_target = queries.normalized_workspace_path(str(target))
-            lock_key = queries.workspace_advisory_lock_key(normalized_target)
-            # A dedicated backend, not a pooled borrow, owns the session lock.
-            # Thus every pool connection is released before the thread await while
-            # activation remains excluded until this backend closes.
-            lock_conn = (
-                pool._conn
-                if hasattr(pool, "_conn")  # unit-test fake; production pools never expose this
-                else await asyncpg.connect(normalize_dsn(settings.db_url))
-            )
-            try:
-                await lock_conn.execute("SELECT pg_advisory_lock($1::bigint)", lock_key)
-                if await queries.unscoped_workspace_path_is_live(lock_conn, normalized_target):
-                    skip_conf += 1
-                    continue
-                await asyncio.to_thread(shutil.rmtree, target)
-            finally:
-                if not hasattr(pool, "_conn"):
-                    await lock_conn.close()
-        except (asyncpg.PostgresError, OSError):
-            # One un-removable dir (perm drift, read-only FS) must not abort the
-            # rest of the sweep; the next sweep retries it.
-            log.exception("workspace_reaper.rmtree_failed", path=str(target))
-            skip_error += 1
-            continue
-        reaped += 1
-        bytes_freed += size
-
     result = ReapResult(
         reaped=reaped,
         bytes_freed=bytes_freed,

--- a/tests/integration/test_workspace_reaper_shared_run_lock.py
+++ b/tests/integration/test_workspace_reaper_shared_run_lock.py
@@ -12,6 +12,8 @@ import pytest
 from aios.config import get_settings
 from aios.db import queries
 from aios.db.pool import create_pool
+from aios.harness import workspace_reaper
+from aios.harness.workspace_reaper import sweep_archived_workspaces
 from aios.sandbox.volumes import purge_session_directories
 from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 
@@ -244,6 +246,44 @@ async def test_nested_workspace_activation_serializes_with_parent_delete(
     finally:
         await owner.close()
         await contender.close()
+
+
+async def test_sweep_uses_real_pool_locking_path(
+    migrated_db_url: str,
+    _reset_db_state: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real asyncpg.Pool path locks, rechecks, and performs a real rmtree."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=2)
+    target = tmp_path / "acc_reaper" / "sess_archived"
+    target.mkdir(parents=True)
+    (target / "payload").write_text("orphan")
+    settings = get_settings().model_copy(deep=True)
+    settings.workspace_root = tmp_path
+    settings.workspace_reaper_enabled = True
+    settings.workspace_reaper_dry_run = False
+    settings.workspace_reaper_min_archived_age_seconds = 0
+    settings.workspace_reaper_min_mtime_age_seconds = 0
+    monkeypatch.setattr(workspace_reaper, "get_settings", lambda: settings)
+    try:
+        async with pool.acquire() as conn:
+            await _seed(conn)
+            await conn.execute(
+                """
+                INSERT INTO sessions
+                  (id, agent_id, environment_id, agent_version, metadata,
+                   workspace_volume_path, env, account_id, archived_at)
+                VALUES ('sess_archived', 'agent_reaper', 'env_reaper', 1, '{}'::jsonb,
+                        $1, '{}'::jsonb, 'acc_reaper', now() - interval '1 day')
+                """,
+                str(target),
+            )
+        result = await sweep_archived_workspaces(pool)
+        assert result.reaped == 1
+        assert not target.exists()
+    finally:
+        await pool.close()
 
 
 async def test_reaper_lock_survives_real_to_thread_delete(

--- a/tests/integration/test_workspace_reaper_shared_run_lock.py
+++ b/tests/integration/test_workspace_reaper_shared_run_lock.py
@@ -260,6 +260,10 @@ async def test_sweep_uses_real_pool_locking_path(
     target.mkdir(parents=True)
     (target / "payload").write_text("orphan")
     settings = get_settings().model_copy(deep=True)
+    # The integration pool targets its per-testcontainer database rather than the
+    # parse-only AIOS_DB_URL configured by CI.  Keep the reaper's dedicated lock
+    # backend on that same database.
+    settings.db_url = migrated_db_url
     settings.workspace_root = tmp_path
     settings.workspace_reaper_enabled = True
     settings.workspace_reaper_dry_run = False

--- a/tests/unit/test_workspace_reaper.py
+++ b/tests/unit/test_workspace_reaper.py
@@ -119,7 +119,7 @@ def _fake_pool(
 
     pool = MagicMock()
     pool.acquire.return_value = _Cm()
-    pool._conn = conn  # expose for assertions
+    pool.test_conn = conn  # expose for assertions
     return pool
 
 
@@ -346,6 +346,55 @@ async def test_symlinked_account_component_to_live_sibling_is_never_followed(
     assert (victim_session / "live-data.txt").exists(), "the victim's live data must remain"
 
 
+async def test_nested_live_workspace_survives_real_sweep_and_rmtree(
+    env: dict[str, Any],
+) -> None:
+    """A live workspace nested in an archived candidate is never deleted."""
+    archived = _mk_workspace(env["root"], "acct1", "sess_archived")
+    live = archived / "child_live_ws"
+    live.mkdir()
+    credentials = live / "OPERATOR_CREDS.txt"
+    credentials.write_text("live-secret")
+    pool = _fake_pool([_row("acct1", "sess_archived", str(archived))], live_paths=[str(live)])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert credentials.read_text() == "live-secret"
+
+
+async def test_live_ancestor_workspace_keeps_archived_descendant(
+    env: dict[str, Any],
+) -> None:
+    """A live account-root workspace protects a candidate nested beneath it."""
+    archived = _mk_workspace(env["root"], "acct1", "sess_archived")
+    marker = archived / "scratch.txt"
+    pool = _fake_pool(
+        [_row("acct1", "sess_archived", str(archived))],
+        live_paths=[str(env["root"] / "acct1")],
+    )
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert marker.exists()
+
+
+async def test_unrelated_live_workspace_does_not_disable_reaping(
+    env: dict[str, Any],
+) -> None:
+    """Positive control: containment protection does not turn off the reaper."""
+    archived = _mk_workspace(env["root"], "acct1", "sess_archived")
+    unrelated = _mk_workspace(env["root"], "acct1", "sess_live_elsewhere")
+    pool = _fake_pool([_row("acct1", "sess_archived", str(archived))], live_paths=[str(unrelated)])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 1
+    assert not archived.exists()
+    assert unrelated.exists()
+
+
 async def test_live_clone_sharing_archived_parents_canonical_dir_is_skipped(
     env: dict[str, Any],
 ) -> None:
@@ -397,7 +446,7 @@ async def test_nonterminal_shared_run_keeps_archived_launcher_workspace(
 
     assert result.reaped == 0
     assert launcher_dir.exists(), "a non-terminal shared run still uses this workspace"
-    sql = " ".join(call.args[0] for call in pool._conn.fetch.await_args_list)
+    sql = " ".join(call.args[0] for call in pool.test_conn.fetch.await_args_list)
     assert "workspace_mode = 'shared'" in sql
     assert "status IN ('pending', 'running', 'suspended')" in sql
 
@@ -465,7 +514,7 @@ async def test_shared_run_created_after_scan_is_caught_by_pre_delete_revalidatio
 
     pool = MagicMock()
     pool.acquire.return_value = _Cm()
-    pool._conn = conn
+    pool.test_conn = conn
 
     result = await sweep_archived_workspaces(pool)
 
@@ -513,6 +562,27 @@ async def test_fresh_dir_below_mtime_floor_is_kept(env: dict[str, Any]) -> None:
     assert d.exists()
 
 
+async def test_recent_nested_write_is_kept_when_parent_is_old(env: dict[str, Any]) -> None:
+    """Recursive mtime catches activity invisible in the parent directory mtime."""
+    env["settings"].workspace_reaper_min_mtime_age_seconds = 3600
+    d = _mk_workspace(env["root"], "acct1", "sess_archived", age_s=100_000)
+    nested = d / "old-subdir"
+    nested.mkdir()
+    old = time.time() - 100_000
+    os.utime(nested, (old, old))
+    recent = nested / "just-written.txt"
+    recent.write_text("active")
+    # Creating nested changed d; restore it to prove only descendant inspection protects it.
+    os.utime(d, (old, old))
+    pool = _fake_pool([_row("acct1", "sess_archived", str(d))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_too_fresh == 1
+    assert recent.exists()
+
+
 # ── guardrail 4: fail-closed ─────────────────────────────────────────────────
 
 
@@ -551,7 +621,7 @@ async def test_kill_switch_disables_everything(env: dict[str, Any]) -> None:
 
     assert result.reaped == 0
     assert d.exists()
-    pool._conn.fetch.assert_not_awaited()  # disabled ⇒ no DB query at all
+    pool.test_conn.fetch.assert_not_awaited()  # disabled ⇒ no DB query at all
 
 
 async def test_default_settings_ship_dark() -> None:

--- a/tests/unit/test_workspace_reaper.py
+++ b/tests/unit/test_workspace_reaper.py
@@ -50,9 +50,16 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     settings.workspace_reaper_dry_run = False
     settings.workspace_reaper_min_archived_age_seconds = 86_400
     settings.workspace_reaper_min_mtime_age_seconds = 0
+    settings.db_url = "postgresql://reaper-test"
     monkeypatch.setattr(workspace_reaper, "get_settings", lambda: settings)
 
-    return {"root": root, "settings": settings}
+    lock_conn = MagicMock()
+    lock_conn.execute = AsyncMock()
+    lock_conn.fetchval = AsyncMock(return_value=False)
+    lock_conn.close = AsyncMock()
+    monkeypatch.setattr(asyncpg, "connect", AsyncMock(return_value=lock_conn))
+
+    return {"root": root, "settings": settings, "lock_conn": lock_conn}
 
 
 def _mk_workspace(root: Path, account_id: str, session_id: str, *, age_s: float = 10_000.0) -> Path:
@@ -150,6 +157,12 @@ async def test_archived_aged_inactive_session_dir_is_reaped(env: dict[str, Any])
     assert result.reaped == 1
     assert not d.exists(), "an archived/aged/not-active session's workspace must be reaped"
     assert result.bytes_freed > 0
+    lock_conn = env["lock_conn"]
+    assert [call.args[0] for call in lock_conn.execute.await_args_list] == [
+        "SELECT pg_advisory_lock($1::bigint)",
+        "SELECT pg_advisory_unlock($1::bigint)",
+    ]
+    lock_conn.close.assert_awaited_once()
 
 
 async def test_running_session_never_in_candidate_set(env: dict[str, Any]) -> None:
@@ -494,7 +507,7 @@ async def test_shared_run_created_after_scan_is_caught_by_pre_delete_revalidatio
 
     conn.fetch = AsyncMock(side_effect=_route_fetch)
     conn.execute = AsyncMock()
-    conn.fetchval = AsyncMock(return_value=True)
+    env["lock_conn"].fetchval.return_value = True
 
     class _Tx:
         async def __aenter__(self) -> None:
@@ -521,7 +534,7 @@ async def test_shared_run_created_after_scan_is_caught_by_pre_delete_revalidatio
     assert result.reaped == 0
     assert launcher_dir.exists()
     assert keep_reads == 1
-    conn.fetchval.assert_awaited_once()
+    env["lock_conn"].fetchval.assert_awaited_once()
 
 
 async def test_off_shape_ids_are_never_reaped(env: dict[str, Any]) -> None:


### PR DESCRIPTION
Closes #2167.

Fixes bidirectional live-workspace containment in the initial keep-set and under-lock SQL recheck, recursive mtime protection, dedicated sweep connection reuse, InterfaceError handling, and relative-path/documentation defects. The kill switch remains disabled.

Tests include the real-filesystem nested live-workspace regression, ancestor mirror, orphan discrimination control, recent nested write, and a real asyncpg.Pool locking-path integration test.