### PR TITLE
fix(vaults): accept cleared credential metadata on read

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -18595,8 +18595,15 @@
             "title": "Allowed Hosts"
           },
           "metadata": {
-            "additionalProperties": true,
-            "type": "object",
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Metadata"
           },
           "created_at": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -298,7 +298,7 @@ from .vault_credential_auth_type import VaultCredentialAuthType
 from .vault_credential_create import VaultCredentialCreate
 from .vault_credential_create_auth_type import VaultCredentialCreateAuthType
 from .vault_credential_create_metadata import VaultCredentialCreateMetadata
-from .vault_credential_metadata import VaultCredentialMetadata
+from .vault_credential_metadata_type_0 import VaultCredentialMetadataType0
 from .vault_credential_update import VaultCredentialUpdate
 from .vault_credential_update_metadata_type_0 import VaultCredentialUpdateMetadataType0
 from .vault_metadata import VaultMetadata
@@ -618,7 +618,7 @@ __all__ = (
     "VaultCredentialCreate",
     "VaultCredentialCreateAuthType",
     "VaultCredentialCreateMetadata",
-    "VaultCredentialMetadata",
+    "VaultCredentialMetadataType0",
     "VaultCredentialUpdate",
     "VaultCredentialUpdateMetadataType0",
     "VaultMetadata",

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential.py
@@ -12,7 +12,7 @@ from ..models.vault_credential_auth_type import VaultCredentialAuthType
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
-    from ..models.vault_credential_metadata import VaultCredentialMetadata
+    from ..models.vault_credential_metadata_type_0 import VaultCredentialMetadataType0
 
 
 T = TypeVar("T", bound="VaultCredential")
@@ -31,7 +31,7 @@ class VaultCredential:
             display_name (None | str):
             target_url (None | str):
             auth_type (VaultCredentialAuthType):
-            metadata (VaultCredentialMetadata):
+            metadata (None | VaultCredentialMetadataType0):
             created_at (datetime.datetime):
             updated_at (datetime.datetime):
             secret_name (None | str | Unset):
@@ -44,7 +44,7 @@ class VaultCredential:
     display_name: None | str
     target_url: None | str
     auth_type: VaultCredentialAuthType
-    metadata: VaultCredentialMetadata
+    metadata: None | VaultCredentialMetadataType0
     created_at: datetime.datetime
     updated_at: datetime.datetime
     secret_name: None | str | Unset = UNSET
@@ -53,6 +53,10 @@ class VaultCredential:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.vault_credential_metadata_type_0 import (
+            VaultCredentialMetadataType0,
+        )
+
         id = self.id
 
         vault_id = self.vault_id
@@ -65,7 +69,11 @@ class VaultCredential:
 
         auth_type = self.auth_type.value
 
-        metadata = self.metadata.to_dict()
+        metadata: dict[str, Any] | None
+        if isinstance(self.metadata, VaultCredentialMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
 
         created_at = self.created_at.isoformat()
 
@@ -119,7 +127,9 @@ class VaultCredential:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.vault_credential_metadata import VaultCredentialMetadata
+        from ..models.vault_credential_metadata_type_0 import (
+            VaultCredentialMetadataType0,
+        )
 
         d = dict(src_dict)
         id = d.pop("id")
@@ -142,7 +152,20 @@ class VaultCredential:
 
         auth_type = VaultCredentialAuthType(d.pop("auth_type"))
 
-        metadata = VaultCredentialMetadata.from_dict(d.pop("metadata"))
+        def _parse_metadata(data: object) -> None | VaultCredentialMetadataType0:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = VaultCredentialMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | VaultCredentialMetadataType0, data)
+
+        metadata = _parse_metadata(d.pop("metadata"))
 
         created_at = isoparse(d.pop("created_at"))
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_metadata_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_metadata_type_0.py
@@ -6,11 +6,11 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="VaultCredentialMetadata")
+T = TypeVar("T", bound="VaultCredentialMetadataType0")
 
 
 @_attrs_define
-class VaultCredentialMetadata:
+class VaultCredentialMetadataType0:
     """ """
 
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -25,10 +25,10 @@ class VaultCredentialMetadata:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        vault_credential_metadata = cls()
+        vault_credential_metadata_type_0 = cls()
 
-        vault_credential_metadata.additional_properties = d
-        return vault_credential_metadata
+        vault_credential_metadata_type_0.additional_properties = d
+        return vault_credential_metadata_type_0
 
     @property
     def additional_keys(self) -> list[str]:

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -342,7 +342,7 @@ class VaultCredential(BaseModel):
     auth_type: AuthType
     secret_name: str | None = None
     allowed_hosts: list[str] | None = None
-    metadata: dict[str, Any]
+    metadata: dict[str, Any] | None
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None

--- a/tests/unit/test_vault_credential_metadata_read.py
+++ b/tests/unit/test_vault_credential_metadata_read.py
@@ -1,0 +1,37 @@
+"""Regression coverage for vault credential metadata read semantics (#2135)."""
+
+from datetime import UTC, datetime
+
+from aios.db.queries.vaults import _row_to_vault_credential
+
+
+def _credential_row(metadata: object) -> dict[str, object]:
+    now = datetime.now(UTC)
+    return {
+        "id": "vcr_test",
+        "vault_id": "vlt_test",
+        "display_name": "test",
+        "target_url": "https://example.com",
+        "auth_type": "bearer_header",
+        "secret_name": None,
+        "allowed_hosts": None,
+        "metadata": metadata,
+        "created_at": now,
+        "updated_at": now,
+        "archived_at": None,
+    }
+
+
+def test_cleared_credential_metadata_round_trips_as_none() -> None:
+    """The jsonb decoder returns Python None for a stored JSON null."""
+    credential = _row_to_vault_credential(_credential_row(None))
+
+    assert credential.metadata is None
+
+
+def test_credential_metadata_round_trips_unchanged() -> None:
+    metadata = {"owner": "platform", "nested": {"enabled": True}}
+
+    credential = _row_to_vault_credential(_credential_row(metadata))
+
+    assert credential.metadata == metadata


### PR DESCRIPTION
Fixes #2135.

Makes the server response model preserve the existing write contract's distinction between JSON null (explicitly cleared) and an empty metadata object, then regenerates OpenAPI and the SDK from that canonical model. Adds regression and control coverage for both null and populated metadata.