### PR TITLE
fix(connector-http): tolerate 403 on tools_schema publish — a non-root connector must still boot

### DIFF
--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import inspect
 import json
 import os
@@ -895,7 +896,21 @@ class HttpConnector:
         """Derive a ToolSpec from each ``@tool`` method and PUT the catalog.
 
         Replaces ``connectors.tools_schema`` for this type wholesale on
-        every startup — the runtime container is the source of truth.
+        every startup when the runtime token is root-scoped.
+
+        Schema publication is a root-plane write (``PUT
+        /v1/connectors/{connector}/tools_schema`` is reserved for the
+        root account): a tenant-authed runtime container is *expected*
+        to be refused, tolerates the 403, and serves under the stored
+        catalog — IaC owns schema updates.  Raising here instead would
+        couple container boot to a root-only write and brick every
+        connector on a non-root account (the 2026-08-17/18 fleet-wide
+        connector outage: migration 0154 re-homed the fleet off root and
+        every subsequent connector start died at this call).
+
+        Any other ≥400 still raises: 401 means runtime auth is broken
+        and serving would be futile; 5xx crashloops until the api is
+        healthy, which is the desired dependency-wait behavior.
         """
         client = self._require_client()
         specs = [derive_tool_spec(name, meta.fn) for name, meta in self._tools.items()]
@@ -903,6 +918,23 @@ class HttpConnector:
             tools=[ToolsSchemaUpdateToolsItem.from_dict(spec) for spec in specs]
         )
         response = await _put_tools_schema(client=client, connector=self.connector, body=body)
+        if response.status_code == 403:
+            # Log the derived catalog's identity (hash + names, never the
+            # full spec bodies) so an operator can diff it against the
+            # stored ``connectors.tools_schema`` when reconciling drift.
+            derived_sha256 = hashlib.sha256(
+                json.dumps(specs, sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest()
+            log.warning(
+                "connector.tools.publish_forbidden",
+                connector=self.connector,
+                status_code=response.status_code,
+                tool_count=len(specs),
+                tool_names=sorted(self._tools.keys()),
+                derived_sha256=derived_sha256,
+                body=response.content.decode(errors="replace")[:2000],
+            )
+            return
         if response.status_code >= 400:
             raise RuntimeError(
                 f"failed to publish tools schema: {response.status_code} {response.content!r}"

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -965,6 +965,126 @@ class TestEmitInbound4xxDrop:
             )
 
 
+class TestPublishToolsSchema:
+    """Publishing the tool catalog is a root-plane write.  A tenant-authed
+    container is *expected* to be refused and must tolerate the 403 and
+    serve under the stored catalog; every other >=400 still fails boot.
+
+    Regression guard for the 2026-08-17/18 fleet-wide connector outage:
+    migration 0154 re-homed the fleet off the root account, and because
+    this call raised on any >=400, every connector container died at
+    startup on every build — telegram, whatsapp and signal alike.
+    """
+
+    async def test_403_is_tolerated_and_logged(self, probe: _ProbeConnector) -> None:
+        forbidden_body = (
+            '{"error":{"type":"forbidden","message":"publishing a connector\'s '
+            'tools_schema is reserved for the root account",'
+            '"detail":{"connector":"probe"}}}'
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.content = forbidden_body.encode()
+        with (
+            patch(
+                "aios_connector_http.runner._put_tools_schema",
+                AsyncMock(return_value=mock_response),
+            ),
+            structlog.testing.capture_logs() as records,
+        ):
+            await probe._publish_tools_schema()
+
+        forbidden = [r for r in records if r.get("event") == "connector.tools.publish_forbidden"]
+        assert len(forbidden) == 1, "expected one connector.tools.publish_forbidden record"
+        rec = forbidden[0]
+        assert rec["status_code"] == 403
+        assert rec["connector"] == "probe"
+        assert rec["tool_names"] == sorted(probe._tools.keys())
+        # The derived-catalog hash is what an operator diffs against the
+        # stored schema when reconciling drift.
+        assert len(rec["derived_sha256"]) == 64
+        assert "reserved for the root account" in rec["body"]
+        assert not [r for r in records if r.get("event") == "connector.tools.published"]
+
+    @pytest.mark.parametrize("status_code", [401, 422, 500])
+    async def test_other_errors_still_raise(self, probe: _ProbeConnector, status_code: int) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock_response.content = b"nope"
+        with (
+            patch(
+                "aios_connector_http.runner._put_tools_schema",
+                AsyncMock(return_value=mock_response),
+            ),
+            pytest.raises(RuntimeError, match="failed to publish tools schema"),
+        ):
+            await probe._publish_tools_schema()
+
+    async def test_success_logs_published(self, probe: _ProbeConnector) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        with (
+            patch(
+                "aios_connector_http.runner._put_tools_schema",
+                AsyncMock(return_value=mock_response),
+            ),
+            structlog.testing.capture_logs() as records,
+        ):
+            await probe._publish_tools_schema()
+        published = [r for r in records if r.get("event") == "connector.tools.published"]
+        assert len(published) == 1
+        assert published[0]["tool_count"] == len(probe._tools)
+
+    async def test_run_reaches_setup_when_publish_is_forbidden(self) -> None:
+        """The boot-path claim: a 403 must not stop the container from
+        serving.  ``_publish_tools_schema`` is called outside ``run``'s
+        try block, so raising there skipped ``setup`` and every loop —
+        which is precisely how the fleet went dark."""
+        setup_reached = asyncio.Event()
+
+        class _BootConnector(HttpConnector):
+            connector = "bootprobe"
+
+            @tool()
+            async def ping(self) -> str:
+                return "pong"
+
+            async def setup(self, tg: asyncio.TaskGroup) -> None:
+                setup_reached.set()
+
+            async def load_answered(self) -> dict[str, str | None]:
+                return {}
+
+            async def _discovery_loop(self, tg: asyncio.TaskGroup) -> None:
+                return
+
+            async def _tool_loop(self) -> None:
+                return
+
+            async def _management_call_loop(self) -> None:
+                return
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.content = b"forbidden"
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_client_cm.__aexit__ = AsyncMock(return_value=False)
+
+        c = _BootConnector(base_url="http://x", token="aios_runtime_x")
+        with (
+            patch("aios_connector_http.runner.Client", return_value=mock_client_cm),
+            patch(
+                "aios_connector_http.runner._put_tools_schema",
+                AsyncMock(return_value=mock_response),
+            ),
+        ):
+            await c.run()
+
+        assert setup_reached.is_set(), "a forbidden publish must not abort the boot path"
+
+
 class TestFocalChannelHelper:
     async def test_returns_canonical_string(self, probe: _ProbeConnector) -> None:
         assert probe.focal_channel("account-x", "chat-42") == "probe/account-x/chat-42"


### PR DESCRIPTION
## The defect

`HttpConnector._publish_tools_schema` PUTs the derived tool catalog at startup and raises on **any** `>=400`. The call sits **outside** `run()`'s `try` block, so the raise skips `setup()` and all three loops — the container dies before serving anything, then crashlooping forever.

`PUT /v1/connectors/{connector}/tools_schema` is reserved for the root account (#605). Those two facts were compatible only while connector runtime tokens resolved to root.

Migration `0154` re-homed the fleet off the platform root into a child account, by design — *"the platform root must remain credentialless."* From that commit onward, **every connector container, on every build, old or new, is guaranteed to die at boot.**

The failure is invisible until a restart: a container already running keeps running. Ours didn't restart for 17 days. When they finally did, they entered permanent crashloops and took multiple live channels dark simultaneously. Rolling back the connector image does not help — the same publish-and-raise exists in every prior build.

## The fix

A tenant-authed runtime container being refused this write is the **expected steady state, not an error**. Schema publication belongs to the root plane; IaC owns updates. So:

- **403** → log `connector.tools.publish_forbidden` and return. The container serves under the stored catalog. The record carries the derived catalog's `sha256` and tool names (never the full spec bodies) so an operator can diff it against the stored schema when reconciling drift.
- **Every other `>=400`** → unchanged raise. `401` means runtime auth is broken and serving would be futile; `5xx` should crashloop until the api is healthy, which is the desired dependency-wait.

Only the "you are not root" case is tolerated.

## Tests

`TestPublishToolsSchema` covers both polarities and the boot-path claim itself:

- `test_403_is_tolerated_and_logged` — no raise; one warning with status/connector/tool_names/sha256/body; no `connector.tools.published`
- `test_other_errors_still_raise` — parametrized 401 / 422 / 500
- `test_success_logs_published` — unchanged happy path
- `test_run_reaches_setup_when_publish_is_forbidden` — **the regression guard**: `run()` reaches `setup()` when the publish is forbidden. This is the actual failure that took the fleet down, and no prior test asserted it.

Verified the two behavior-change tests **fail against unpatched `runner.py`** (`RuntimeError: failed to publish tools schema: 403`) and the four preserved-behavior tests pass either way.

Package suite: 148 passed. `ruff check` / `ruff format` clean. `mypy` at exact parity with master's baseline (11 pre-existing errors in the test file, **zero** in `runner.py`).

## Follow-ups (not in this PR)

- The sibling `PUT /{connector}/capabilities` has the identical raise-on-4xx shape and would fail the same way if a connector ever publishes it at boot.
- There is no `GET` route for a connector's stored `tools_schema`, so drift between the stored catalog and a container's derived one can't be checked over HTTP — only via direct DB read. A read route (or a root-plane reconcile step) would close that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)