### PR TITLE
call_workflow: omitted vault_ids should inherit the caller session's bound vaults (explicit [] narrows to none)

### DIFF
--- a/src/aios/tools/invoke_session.py
+++ b/src/aios/tools/invoke_session.py
@@ -185,9 +185,13 @@ class _CallWorkflowArgs(BaseModel):
         default=None,
         description="Optional JSON Schema the run output must satisfy (validated fail-loud).",
     )
-    vault_ids: list[str] = Field(
-        default_factory=list,
-        description="Vault ids to bind to the run — a subset of the vaults bound to you.",
+    vault_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Vault ids to bind to the run. Omit or pass null to inherit all vaults "
+            "currently bound to this session; pass [] to bind none; a nonempty list "
+            "must be a subset of the session's vaults."
+        ),
     )
     budget_usd: float | None = Field(
         default=None, gt=0, description="Optional shared USD spend ceiling for the run."

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -224,9 +224,10 @@ async def create_run(
     tenant's env id and leak its image/env-vars/networking into this run).
 
     ``vault_ids`` binds credentials to the run (resolved at tool-call time, like a
-    session's). **Launch-time attenuation:** when ``launcher_session_id`` is set (an
-    agent launching the run), the requested vaults must be a subset of the launcher's
-    own — authority never exceeds the invoker, so a breach raises
+    session's). When ``launcher_session_id`` is set, omitted/null snapshots all vaults
+    currently held by that session, an explicit empty list binds none, and a nonempty
+    list narrows to that subset. **Launch-time attenuation:** requested vaults must be a
+    subset of the launcher's own — authority never exceeds the invoker, so a breach raises
     :class:`ForbiddenError`. With no launcher (the HTTP/operator path) the requested
     vaults bind as-is, account-scoped. Insert + bind are one transaction, so a breach
     or a bad vault leaves no run row; the wake fires only after commit.
@@ -288,7 +289,10 @@ async def create_run(
             "version / expected_version are not valid for an inline run "
             "(an inline run has no workflow version history)",
         )
-    requested = list(vault_ids or [])
+    # Preserve the caller's three-way selection: None inherits a session launcher's
+    # current bindings, while [] is deliberate attenuation. Operator launches have
+    # no authority source to inherit from, so omitted remains none there.
+    requested = list(vault_ids) if vault_ids is not None else []
     effective_run_id = run_id or make_id(WORKFLOW_RUN)
     # #794 top edge: an agent-launched run cannot exceed the launcher's own surface.
     # #835: the launcher's effective surface is read INSIDE the run transaction (below),
@@ -442,9 +446,10 @@ async def create_run(
                 )
             child_depth = parent_depth - 1
         if launcher_session_id is not None:
-            held = set(
-                await get_session_vault_ids(conn, launcher_session_id, account_id=account_id)
-            )
+            held_ids = await get_session_vault_ids(conn, launcher_session_id, account_id=account_id)
+            held = set(held_ids)
+            if vault_ids is None:
+                requested = list(held_ids)
             ungranted = [v for v in requested if v not in held]
             if ungranted:
                 raise ForbiddenError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,13 @@ def postgres_container() -> Iterator[Any]:
 
 
 @pytest.fixture(scope="session")
-def db_url(postgres_container: Any) -> str:
+def db_url(request: pytest.FixtureRequest) -> str:
+    """Return an external test DB when configured, otherwise start the container."""
+    external_url = os.environ.get("AIOS_TEST_DB_URL")
+    if external_url:
+        return external_url
+
+    postgres_container = request.getfixturevalue("postgres_container")
     host = postgres_container.get_container_host_ip()
     port = postgres_container.get_exposed_port(5432)
     user = postgres_container.username

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -231,6 +231,29 @@ async def test_launch_time_attenuation(vault_pool: asyncpg.Pool[Any]) -> None:
     both = await _make_session(pool, agent, vault_ids=[vx, vy])
     wf = await wf_service.create_workflow(pool, account_id=ACC, name="w-launch", script=_SCRIPT)
 
+    # Omitted selection snapshots every vault currently held by a session launcher.
+    inherited = await wf_service.create_run(
+        pool,
+        account_id=ACC,
+        workflow_id=wf.id,
+        environment_id=ENV,
+        launcher_session_id=both,
+    )
+    async with pool.acquire() as conn:
+        assert await wf_queries.get_run_vault_ids(conn, inherited.id, account_id=ACC) == [vx, vy]
+
+    # Explicit empty selection deliberately attenuates to no vaults.
+    empty = await wf_service.create_run(
+        pool,
+        account_id=ACC,
+        workflow_id=wf.id,
+        environment_id=ENV,
+        vault_ids=[],
+        launcher_session_id=both,
+    )
+    async with pool.acquire() as conn:
+        assert await wf_queries.get_run_vault_ids(conn, empty.id, account_id=ACC) == []
+
     # Held vault → succeeds and binds.
     ok = await wf_service.create_run(
         pool,

--- a/tests/unit/test_external_test_db.py
+++ b/tests/unit/test_external_test_db.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
-import subprocess
 from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def postgres_container() -> None:
+    """Fail if ``db_url`` resolves its Docker-backed fallback fixture."""
+    raise AssertionError("external database selection must not request Docker")
 
 
 def test_db_url_uses_external_database_without_starting_docker(
@@ -11,10 +18,5 @@ def test_db_url_uses_external_database_without_starting_docker(
 ) -> None:
     external_url = "postgresql://aios:aios@127.0.0.1:5432/aios_test"
     monkeypatch.setenv("AIOS_TEST_DB_URL", external_url)
-
-    def fail_if_docker_is_probed(*args: Any, **kwargs: Any) -> Any:
-        raise AssertionError("external database selection must not probe Docker")
-
-    monkeypatch.setattr(subprocess, "run", fail_if_docker_is_probed)
 
     assert request.getfixturevalue("db_url") == external_url

--- a/tests/unit/test_external_test_db.py
+++ b/tests/unit/test_external_test_db.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
+import conftest
+
 
 def test_db_url_uses_external_database_without_starting_docker(
     monkeypatch: Any, request: Any
 ) -> None:
     external_url = "postgresql://aios:aios@127.0.0.1:5432/aios_test"
     monkeypatch.setenv("AIOS_TEST_DB_URL", external_url)
+
+    def fail_if_docker_is_probed() -> bool:
+        raise AssertionError("external database selection must not probe Docker")
+
+    monkeypatch.setattr(conftest, "_docker_available", fail_if_docker_is_probed)
 
     assert request.getfixturevalue("db_url") == external_url

--- a/tests/unit/test_external_test_db.py
+++ b/tests/unit/test_external_test_db.py
@@ -1,0 +1,14 @@
+"""Tests for selecting an externally managed integration-test database."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def test_db_url_uses_external_database_without_starting_docker(
+    monkeypatch: Any, request: Any
+) -> None:
+    external_url = "postgresql://aios:aios@127.0.0.1:5432/aios_test"
+    monkeypatch.setenv("AIOS_TEST_DB_URL", external_url)
+
+    assert request.getfixturevalue("db_url") == external_url

--- a/tests/unit/test_external_test_db.py
+++ b/tests/unit/test_external_test_db.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import Any
-
-import conftest
 
 
 def test_db_url_uses_external_database_without_starting_docker(
@@ -13,9 +12,9 @@ def test_db_url_uses_external_database_without_starting_docker(
     external_url = "postgresql://aios:aios@127.0.0.1:5432/aios_test"
     monkeypatch.setenv("AIOS_TEST_DB_URL", external_url)
 
-    def fail_if_docker_is_probed() -> bool:
+    def fail_if_docker_is_probed(*args: Any, **kwargs: Any) -> Any:
         raise AssertionError("external database selection must not probe Docker")
 
-    monkeypatch.setattr(conftest, "_docker_available", fail_if_docker_is_probed)
+    monkeypatch.setattr(subprocess, "run", fail_if_docker_is_probed)
 
     assert request.getfixturevalue("db_url") == external_url

--- a/tests/unit/test_invoke_session_tools.py
+++ b/tests/unit/test_invoke_session_tools.py
@@ -226,6 +226,26 @@ async def test_invoke_agent_create_then_invoke(monkeypatch: Any) -> None:
     assert kwargs["caller"] == {"kind": "session", "id": _CALLER}
 
 
+@pytest.mark.parametrize(
+    "tool_args, expected", [({}, None), ({"vault_ids": None}, None), ({"vault_ids": []}, [])]
+)
+async def test_call_workflow_preserves_inherit_vs_empty_vault_selection(
+    monkeypatch: Any, tool_args: dict[str, Any], expected: list[str] | None
+) -> None:
+    """Omitted/null inherits all caller vaults; explicit empty attenuates to none."""
+    run_mock = AsyncMock(return_value=SimpleNamespace(id="run_1"))
+    monkeypatch.setattr("aios.services.workflows.create_run", run_mock)
+    monkeypatch.setattr(
+        "aios.services.tasks.await_task",
+        AsyncMock(return_value=AwaitResponse(outcome="ok", result="done")),
+    )
+
+    await invoke_builtin(_CALLER, "call_workflow", {"workflow_id": "wf_1", **tool_args})
+
+    assert run_mock.await_args is not None
+    assert run_mock.await_args.kwargs["vault_ids"] == expected
+
+
 async def test_invoke_workflow_create_run_then_await(monkeypatch: Any) -> None:
     run_mock = AsyncMock(return_value=SimpleNamespace(id="run_1"))
     monkeypatch.setattr("aios.services.workflows.create_run", run_mock)

--- a/tests/unit/test_model_workflow.py
+++ b/tests/unit/test_model_workflow.py
@@ -10,12 +10,18 @@ the focused queries to pin the pairing + supersession logic without a database.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
 from aios.harness import model_workflow
+from aios.harness.completion import LlmRequest
+from aios.harness.model_binding import WorkflowModelRef
 from aios.harness.model_workflow import HarvestedInference, ParkState, take_pending_harvest
+from aios.services import sessions as sessions_service
+from aios.services import workflows as workflows_service
 
 
 class _FakeConn:
@@ -131,3 +137,32 @@ def test_event_kind_constants() -> None:
     # The park/harvest events are span-kind bookkeeping (excluded from replay).
     assert model_workflow.PARK_EVENT == "model_workflow_park"
     assert model_workflow.HARVEST_EVENT == "model_workflow_harvest"
+
+
+@pytest.mark.asyncio
+async def test_model_workflow_launch_inherits_session_vaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sibling trusted session→run edge deliberately uses omitted/inherit semantics."""
+    launch = AsyncMock(return_value=(SimpleNamespace(id="run_1"), "req_1"))
+    monkeypatch.setattr(workflows_service, "launch_awaited_run", launch)
+    monkeypatch.setattr(
+        sessions_service,
+        "get_session_basic",
+        AsyncMock(return_value=SimpleNamespace(environment_id="env_1", parent_run_id=None)),
+    )
+    monkeypatch.setattr(sessions_service, "append_event", AsyncMock())
+    monkeypatch.setattr(model_workflow, "_launch_harvest_task", lambda *args, **kwargs: None)
+
+    await model_workflow.launch_model_workflow_park(
+        _FakePool(),
+        "ses_1",
+        ref=WorkflowModelRef("wf_1"),
+        request=LlmRequest(messages=[]),
+        reacting_to=1,
+        account_id="acc_1",
+    )
+
+    assert launch.await_args is not None
+    assert launch.await_args.kwargs["launcher_session_id"] == "ses_1"
+    assert launch.await_args.kwargs.get("vault_ids") is None


### PR DESCRIPTION
Automated dev-pipeline build for issue #1958.