### PR TITLE
Typed egress-provision lifecycle events on the session record — a skipped/failed interception install must never be silent

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -573,6 +573,12 @@ class Settings(BaseSettings):
         "forbids per bash call; this runs occasionally, off the hot path, as "
         "a correctness backstop, not a real-time gate).",
     )
+    fleet_egress_audit_interval_seconds: float = Field(
+        default=3600.0,
+        gt=0.0,
+        description="Interval for the fleet-wide audit of adverse sandbox egress "
+        "provisioning events. An immediate sweep runs at worker startup.",
+    )
 
     tool_broker_socket_path: Path | None = Field(
         default=None,

--- a/src/aios/harness/fleet_egress_audit.py
+++ b/src/aios/harness/fleet_egress_audit.py
@@ -1,0 +1,91 @@
+"""Fleet-wide audit of sandbox egress provisioning outcomes.
+
+The durable ``events`` table is the authoritative source.  This audit deliberately
+reads it directly (including archived sessions) rather than relying on worker-local
+sandbox state, which can disappear with a worker or container restart.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import asyncpg
+
+from aios.logging import get_logger
+
+log = get_logger("aios.harness.fleet_egress_audit")
+
+
+@dataclass(frozen=True)
+class EgressAuditFinding:
+    event_id: str
+    session_id: str
+    account_id: str
+    created_at: datetime
+    event: str
+    data: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class EgressAuditResult:
+    events_examined: int
+    findings: tuple[EgressAuditFinding, ...]
+
+
+# Keep the time predicate in Postgres.  Worker clocks are not authoritative for
+# event timestamps, and passing a Python cutoff can introduce clock-skew gaps.
+_FLEET_EGRESS_FINDINGS_SQL = """
+SELECT id, session_id, account_id, created_at, data
+  FROM events
+ WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '24 hours'
+   AND kind = 'lifecycle'
+   AND (
+       data->>'event' = 'egress_provision_failed'
+       OR (
+           data->>'event' = 'egress_provisioned'
+           AND jsonb_typeof(data->'hosts_skipped') = 'array'
+           AND jsonb_array_length(data->'hosts_skipped') > 0
+       )
+   )
+ ORDER BY created_at, session_id, seq
+"""
+
+
+async def run_fleet_egress_audit(pool: asyncpg.Pool[Any]) -> EgressAuditResult:
+    """Read and alert on every adverse fleet egress outcome in the last 24h.
+
+    Read errors intentionally propagate.  In particular, this function never
+    emits the completion/health log unless the authoritative event query has
+    succeeded; the scheduling loop records a distinct ``tick_failed`` alert and
+    retries on its next tick.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(_FLEET_EGRESS_FINDINGS_SQL)
+
+    findings = tuple(
+        EgressAuditFinding(
+            event_id=row["id"],
+            session_id=row["session_id"],
+            account_id=row["account_id"],
+            created_at=row["created_at"],
+            event=row["data"]["event"],
+            data=dict(row["data"]),
+        )
+        for row in rows
+    )
+    for finding in findings:
+        log.warning(
+            "fleet_egress_audit.finding",
+            event_id=finding.event_id,
+            session_id=finding.session_id,
+            account_id=finding.account_id,
+            created_at=finding.created_at.isoformat(),
+            outcome_event=finding.event,
+            reason=finding.data.get("reason"),
+            hosts_skipped=finding.data.get("hosts_skipped"),
+        )
+
+    log.info("fleet_egress_audit.swept", findings=len(findings), window_hours=24)
+    return EgressAuditResult(events_examined=len(rows), findings=findings)

--- a/src/aios/harness/fleet_egress_audit.py
+++ b/src/aios/harness/fleet_egress_audit.py
@@ -31,24 +31,26 @@ class EgressAuditFinding:
 @dataclass(frozen=True)
 class EgressAuditResult:
     events_examined: int
+    healthy_events_observed: int
     findings: tuple[EgressAuditFinding, ...]
 
 
-# Keep the time predicate in Postgres.  Worker clocks are not authoritative for
+class EgressLifecycleWriterSilentError(RuntimeError):
+    """No fully healthy provision proves the lifecycle writer is live."""
+
+
+# Keep the time predicate in Postgres. Worker clocks are not authoritative for
 # event timestamps, and passing a Python cutoff can introduce clock-skew gaps.
-_FLEET_EGRESS_FINDINGS_SQL = """
+#
+# This intentionally reads *all* provision outcomes rather than only findings.
+# Healthy provisions are the audit's positive dead-man signal: without one, a
+# successful empty query is indistinguishable from a silent lifecycle writer.
+_FLEET_EGRESS_EVENTS_SQL = """
 SELECT id, session_id, account_id, created_at, data
   FROM events
  WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '24 hours'
    AND kind = 'lifecycle'
-   AND (
-       data->>'event' = 'egress_provision_failed'
-       OR (
-           data->>'event' = 'egress_provisioned'
-           AND jsonb_typeof(data->'hosts_skipped') = 'array'
-           AND jsonb_array_length(data->'hosts_skipped') > 0
-       )
-   )
+   AND data->>'event' IN ('egress_provisioned', 'egress_provision_failed')
  ORDER BY created_at, session_id, seq
 """
 
@@ -62,8 +64,18 @@ async def run_fleet_egress_audit(pool: asyncpg.Pool[Any]) -> EgressAuditResult:
     retries on its next tick.
     """
     async with pool.acquire() as conn:
-        rows = await conn.fetch(_FLEET_EGRESS_FINDINGS_SQL)
+        rows = await conn.fetch(_FLEET_EGRESS_EVENTS_SQL)
 
+    adverse_rows = [
+        row
+        for row in rows
+        if row["data"]["event"] == "egress_provision_failed"
+        or bool(row["data"].get("hosts_skipped"))
+    ]
+    healthy_events_observed = sum(
+        row["data"]["event"] == "egress_provisioned" and row["data"].get("hosts_skipped") == []
+        for row in rows
+    )
     findings = tuple(
         EgressAuditFinding(
             event_id=row["id"],
@@ -73,7 +85,7 @@ async def run_fleet_egress_audit(pool: asyncpg.Pool[Any]) -> EgressAuditResult:
             event=row["data"]["event"],
             data=dict(row["data"]),
         )
-        for row in rows
+        for row in adverse_rows
     )
     for finding in findings:
         log.warning(
@@ -87,5 +99,19 @@ async def run_fleet_egress_audit(pool: asyncpg.Pool[Any]) -> EgressAuditResult:
             hosts_skipped=finding.data.get("hosts_skipped"),
         )
 
-    log.info("fleet_egress_audit.swept", findings=len(findings), window_hours=24)
-    return EgressAuditResult(events_examined=len(rows), findings=findings)
+    if not healthy_events_observed:
+        raise EgressLifecycleWriterSilentError(
+            "no healthy egress_provisioned event observed in the last 24 hours"
+        )
+
+    log.info(
+        "fleet_egress_audit.swept",
+        findings=len(findings),
+        healthy_events_observed=healthy_events_observed,
+        window_hours=24,
+    )
+    return EgressAuditResult(
+        events_examined=len(rows),
+        healthy_events_observed=healthy_events_observed,
+        findings=findings,
+    )

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -561,6 +561,14 @@ async def worker_main() -> None:
         )
         _supervise(memory_reconcile_audit_task, latch=supervised_latch, fatal=supervised_failure)
 
+        # Audit the authoritative event stream for every failed or partial
+        # sandbox-egress provisioning outcome in the preceding 24 hours.
+        fleet_egress_audit_task = asyncio.create_task(
+            _fleet_egress_audit_loop(pool),
+            name="fleet_egress_audit",
+        )
+        _supervise(fleet_egress_audit_task, latch=supervised_latch, fatal=supervised_failure)
+
         # Start the archived-session workspace reaper (#40 — the 45G hole): GC
         # the per-session ``/workspace`` host dir of archived sessions, which
         # the #1192 reaper does NOT cover. Ships DARK
@@ -982,6 +990,29 @@ async def _memory_reconcile_audit_loop(pool: asyncpg.Pool[Any]) -> None:
             )
         except Exception:
             log.exception("memory_reconcile_audit.tick_failed")
+
+
+async def _fleet_egress_audit_loop(pool: asyncpg.Pool[Any]) -> None:
+    """Run the fleet egress audit immediately and then at its configured cadence.
+
+    A failed authoritative read is an alert, never a healthy tick.  The inner
+    audit logs health only after a successful query; this loop logs failures
+    distinctly and keeps retrying rather than silently losing the auditor.
+    """
+    log = get_logger("aios.worker.fleet_egress_audit")
+    from aios.harness.fleet_egress_audit import run_fleet_egress_audit
+
+    interval = get_settings().fleet_egress_audit_interval_seconds
+    first = True
+    while True:
+        try:
+            if not first:
+                await asyncio.sleep(interval)
+            first = False
+            result = await run_fleet_egress_audit(pool)
+            log.info("fleet_egress_audit.tick", findings=len(result.findings))
+        except Exception:
+            log.exception("fleet_egress_audit.tick_failed")
 
 
 async def _reclaimable_prune_loop(pool: asyncpg.Pool[Any]) -> None:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -66,6 +66,7 @@ from aios.sandbox.git_proxy import GitProxy
 from aios.sandbox.network import WORKER_NETWORK_ALIAS
 from aios.sandbox.setup import (
     PACKAGE_REGISTRY_HOSTS,
+    EgressProvisionResult,
     apply_network_lockdown,
     apply_secret_egress_dnat,
     build_egress_dump_script,
@@ -335,6 +336,7 @@ class SandboxRegistry:
         self._reaper_task: asyncio.Task[None] | None = None
         self._gc_task: asyncio.Task[None] | None = None
         self._egress_refresh_task: asyncio.Task[None] | None = None
+        self._egress_provision_results: dict[str, EgressProvisionResult] = {}
         self._egress_states: dict[str, EgressRefreshState] = {}
         self._provisioning_pressure = GcPressureResult()
         # Consecutive salvage failures keyed by full corpse id. The value is
@@ -545,7 +547,9 @@ class SandboxRegistry:
         account_id: str | None = None,
     ) -> SandboxHandle:
         if pool is None:
-            return await self._provision(session_id)
+            provisioned = await self._provision(session_id)
+            self._egress_provision_results.pop(session_id)
+            return provisioned
 
         from aios.services import sessions as sessions_service
 
@@ -558,9 +562,33 @@ class SandboxRegistry:
         handle: SandboxHandle | None = None
         try:
             handle = await self._provision(session_id)
+            outcome = self._egress_provision_results.pop(session_id)
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "lifecycle",
+                {
+                    "event": "egress_provisioned",
+                    "hosts_installed": list(outcome.hosts_installed),
+                    "hosts_skipped": [
+                        {"host": item.host, "reason": item.reason} for item in outcome.hosts_skipped
+                    ],
+                },
+                account_id=account_id,
+            )
             return handle
-        except Exception:
+        except Exception as err:
             is_error = True
+            self._egress_provision_results.pop(session_id, None)
+            if handle is not None:
+                await self._destroy_quietly(handle, session_id)
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "lifecycle",
+                {"event": "egress_provision_failed", "reason": str(err)},
+                account_id=account_id,
+            )
             raise
         finally:
             end_payload: dict[str, Any] = {
@@ -658,7 +686,9 @@ class SandboxRegistry:
             if not await self._prewarmed_setup_satisfied(spec):
                 await install_egress_ca(self._backend, handle)
                 await install_packages(self._backend, handle, plan.env_config)
-            await self._apply_egress_rules(handle, plan)
+            self._egress_provision_results[session_id] = await self._apply_egress_rules(
+                handle, plan
+            )
         except BaseException:
             await self._destroy_quietly(handle, session_id)
             raise
@@ -852,7 +882,9 @@ class SandboxRegistry:
                     dnat_hosts.append(host)
         return dnat_hosts, dnat_target
 
-    async def _apply_egress_rules(self, handle: SandboxHandle, plan: ProvisioningPlan) -> None:
+    async def _apply_egress_rules(
+        self, handle: SandboxHandle, plan: ProvisioningPlan
+    ) -> EgressProvisionResult:
         """Wire the sandbox's egress rules from the provisioning plan.
 
         Three cases (#1153):
@@ -884,7 +916,7 @@ class SandboxRegistry:
                 # Open the filter OUTPUT for the rewritten (post-DNAT) flow to
                 # the proxy endpoint — mirrors the git_proxy precedent. (#878)
                 extra_host_ports.append((WORKER_NETWORK_ALIAS, dnat_target[1]))
-            await apply_network_lockdown(
+            outcome = await apply_network_lockdown(
                 self._backend,
                 handle,
                 networking,
@@ -899,13 +931,15 @@ class SandboxRegistry:
         elif dnat_target is not None:
             # Unrestricted (or no networking config) WITH env-var credentials:
             # install the DNAT-only swap chokepoint, leaving general egress open.
-            await apply_secret_egress_dnat(
+            outcome = await apply_secret_egress_dnat(
                 self._backend,
                 handle,
                 dnat_hosts=dnat_hosts,
                 dnat_target=dnat_target,
                 runtime=plan.spec.runtime,
             )
+        else:
+            outcome = EgressProvisionResult()
         # else: Unrestricted, no credentials → nothing (today's early return).
         if dnat_target is not None:
             limited_hosts: set[str] = set()
@@ -920,6 +954,7 @@ class SandboxRegistry:
                 fallback_proxy_port=dnat_target[1],
                 runtime=plan.spec.runtime,
             )
+        return outcome
 
     async def _stamp_egress_state(
         self,

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -44,6 +44,7 @@ the registry and the orchestrator backend-agnostic.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from aios.config import get_settings
 from aios.logging import get_logger
@@ -53,6 +54,41 @@ from aios.sandbox.egress_ca import CA_CERT_SANDBOX_PATH, get_egress_ca
 from aios.sandbox.env_keys import PATH_ENV_KEY
 
 log = get_logger("aios.sandbox.setup")
+
+
+@dataclass(frozen=True)
+class HostSkip:
+    host: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class EgressProvisionResult:
+    hosts_installed: tuple[str, ...] = ()
+    hosts_skipped: tuple[HostSkip, ...] = ()
+
+
+_EGRESS_INSTALLED_PREFIX = "AIOS_EGRESS_INSTALLED "
+_EGRESS_SKIPPED_PREFIX = "AIOS_EGRESS_SKIPPED "
+
+
+def _parse_egress_provision_result(stdout: str) -> EgressProvisionResult:
+    installed: set[str] = set()
+    skipped: dict[str, HostSkip] = {}
+    for line in stdout.splitlines():
+        if line.startswith(_EGRESS_INSTALLED_PREFIX):
+            host = line.removeprefix(_EGRESS_INSTALLED_PREFIX)
+            installed.add(host)
+            skipped.pop(host, None)
+        elif line.startswith(_EGRESS_SKIPPED_PREFIX):
+            value = line.removeprefix(_EGRESS_SKIPPED_PREFIX)
+            host, reason = value.split("\t", 1)
+            if host not in installed:
+                skipped[host] = HostSkip(host=host, reason=reason)
+    return EgressProvisionResult(
+        hosts_installed=tuple(sorted(installed)),
+        hosts_skipped=tuple(skipped[host] for host in sorted(skipped)),
+    )
 
 
 # Hardcoded absolute system PATH because docker --env doesn't expand $PATH;
@@ -378,12 +414,24 @@ def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> 
         'if [ -n "$PROXY_IP" ]; then',
     ]
     for host in sorted(dnat_hosts):
-        lines.append(f"  for ip in $(resolve_ipv4 {host}); do")
+        lines.append(f"  ips=$(resolve_ipv4 {host})")
+        lines.append(
+            f"  if [ -z \"$ips\" ]; then printf '%s\\t%s\\n' "
+            f"'{_EGRESS_SKIPPED_PREFIX}{host}' 'no IPv4 address'; "
+            f"else echo '{_EGRESS_INSTALLED_PREFIX}{host}'; fi"
+        )
+        lines.append("  for ip in $ips; do")
         lines.append(
             '    "$IPT" -t nat -A OUTPUT -d "$ip" -p tcp --dport 443 '
             f'-j DNAT --to-destination "$PROXY_IP:{proxy_port}"'
         )
         lines.append("  done")
+    lines.append("else")
+    for host in sorted(dnat_hosts):
+        lines.append(
+            f"  printf '%s\\t%s\\n' '{_EGRESS_SKIPPED_PREFIX}{host}' "
+            f"'proxy alias {proxy_alias} has no IPv4 address'"
+        )
     lines.append("fi")
     return lines
 
@@ -607,7 +655,12 @@ def build_iptables_script(
     for host in sorted(allowed_hosts):
         lines.append("")
         lines.append(f"# Allow {host}")
-        lines.append(f"for ip in $(resolve_ipv4 {host}); do")
+        lines.append(f"ips=$(resolve_ipv4 {host})")
+        lines.append(
+            f"if [ -z \"$ips\" ]; then printf '%s\\t%s\\n' '{_EGRESS_SKIPPED_PREFIX}{host}' 'no IPv4 address'; "
+            f"else echo '{_EGRESS_INSTALLED_PREFIX}{host}'; fi"
+        )
+        lines.append("for ip in $ips; do")
         lines.append('  "$IPT" -A OUTPUT -d "$ip" -p tcp --dport 80 -j ACCEPT')
         lines.append('  "$IPT" -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT')
         lines.append("done")
@@ -777,7 +830,7 @@ async def apply_network_lockdown(
     dnat_hosts: Sequence[str] = (),
     dnat_target: tuple[str, int] | None = None,
     runtime: str | None = None,
-) -> None:
+) -> EgressProvisionResult:
     """Apply + verify iptables egress rules via an ephemeral operator-image sidecar.
 
     Called after package installation so ``pip install`` etc. can reach
@@ -889,6 +942,7 @@ async def apply_network_lockdown(
         extra_host_port_count=len(extra_host_ports),
         dnat_host_count=len(dnat_hosts),
     )
+    return _parse_egress_provision_result(result.stdout)
 
 
 async def apply_secret_egress_dnat(
@@ -898,7 +952,7 @@ async def apply_secret_egress_dnat(
     dnat_hosts: Sequence[str],
     dnat_target: tuple[str, int],
     runtime: str | None = None,
-) -> None:
+) -> EgressProvisionResult:
     """Install the credential-host → proxy DNAT in an OPEN-egress sandbox (#1153).
 
     The Unrestricted sibling of :func:`apply_network_lockdown`: for an
@@ -988,3 +1042,4 @@ async def apply_secret_egress_dnat(
         owner_id=handle.owner_id,
         dnat_host_count=len(dnat_hosts),
     )
+    return _parse_egress_provision_result(result.stdout)

--- a/tests/integration/test_fleet_egress_audit.py
+++ b/tests/integration/test_fleet_egress_audit.py
@@ -44,7 +44,6 @@ def _plan(session_id: str) -> ProvisioningPlan:
 async def _provision_with_outcome(
     pool: object,
     session_id: str,
-    account_id: str,
     outcome: EgressProvisionResult | BaseException,
 ) -> None:
     """Run the production lifecycle producer while faking only its sandbox I/O."""
@@ -65,9 +64,9 @@ async def _provision_with_outcome(
     ):
         if isinstance(outcome, BaseException):
             with pytest.raises(type(outcome), match=str(outcome)):
-                await registry.get_or_provision(session_id, pool=pool, account_id=account_id)
+                await registry.get_or_provision(session_id, pool=pool)
         else:
-            await registry.get_or_provision(session_id, pool=pool, account_id=account_id)
+            await registry.get_or_provision(session_id, pool=pool)
 
 
 async def test_production_egress_events_persist_and_auditor_alerts_each_adverse_outcome(
@@ -94,11 +93,10 @@ async def test_production_egress_events_persist_and_auditor_alerts_each_adverse_
             sessions.append(session)
         healthy, skipped, failed = sessions
 
-        await _provision_with_outcome(pool, healthy.id, account_id, EgressProvisionResult())
+        await _provision_with_outcome(pool, healthy.id, EgressProvisionResult())
         await _provision_with_outcome(
             pool,
             skipped.id,
-            account_id,
             EgressProvisionResult(
                 hosts_installed=("api.example.com",),
                 hosts_skipped=(HostSkip(host="missing.example.com", reason="no IPv4 address"),),
@@ -107,7 +105,6 @@ async def test_production_egress_events_persist_and_auditor_alerts_each_adverse_
         await _provision_with_outcome(
             pool,
             failed.id,
-            account_id,
             RuntimeError("sidecar unavailable"),
         )
 

--- a/tests/integration/test_fleet_egress_audit.py
+++ b/tests/integration/test_fleet_egress_audit.py
@@ -1,0 +1,126 @@
+"""Production persistence-boundary test for the fleet egress audit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.db.pool import create_pool
+from aios.harness import fleet_egress_audit as audit
+from aios.models.environments import UnrestrictedNetworking
+from aios.sandbox.backends.base import Mount, SandboxSpec
+from aios.sandbox.registry import SandboxRegistry
+from aios.sandbox.setup import EgressProvisionResult, HostSkip
+from aios.sandbox.spec import ProvisioningPlan
+from tests.helpers.sandbox import FakeBackend
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.docker
+
+
+def _plan(session_id: str) -> ProvisioningPlan:
+    return ProvisioningPlan(
+        spec=SandboxSpec(
+            session_id=session_id,
+            instance_id=f"inst_{session_id}",
+            workspace=Mount(host_path=Path("/tmp/w"), sandbox_path="/workspace"),
+            extra_mounts=(),
+            environment={},
+            labels={},
+            network_policy=UnrestrictedNetworking(),
+            host_gateway_alias=None,
+            image="aios-sandbox:test",
+        ),
+        env_config=None,
+        memory_echoes=[],
+        github_echoes=[],
+        git_proxy=None,
+        env_var_credentials=(),
+    )
+
+
+async def _provision_with_outcome(
+    pool: object,
+    session_id: str,
+    account_id: str,
+    outcome: EgressProvisionResult | BaseException,
+) -> None:
+    """Run the production lifecycle producer while faking only its sandbox I/O."""
+    registry = SandboxRegistry(backend=FakeBackend())
+    apply = (
+        AsyncMock(side_effect=outcome)
+        if isinstance(outcome, BaseException)
+        else AsyncMock(return_value=outcome)
+    )
+    with (
+        patch(
+            "aios.sandbox.registry.build_spec_from_session",
+            AsyncMock(return_value=_plan(session_id)),
+        ),
+        patch("aios.sandbox.registry.install_egress_ca", AsyncMock()),
+        patch("aios.sandbox.registry.install_packages", AsyncMock()),
+        patch.object(registry, "_apply_egress_rules", apply),
+    ):
+        if isinstance(outcome, BaseException):
+            with pytest.raises(type(outcome), match=str(outcome)):
+                await registry.get_or_provision(session_id, pool=pool, account_id=account_id)
+        else:
+            await registry.get_or_provision(session_id, pool=pool, account_id=account_id)
+
+
+async def test_production_egress_events_persist_and_auditor_alerts_each_adverse_outcome(
+    migrated_db_url: str,
+    _reset_db_state: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cross the real writer -> events table -> fleet-reader boundary."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    account_id = "acc_fleet_egress"
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, display_name) VALUES ($1, $2)",
+                account_id,
+                "fleet egress test",
+            )
+
+        sessions = []
+        for prefix in ("healthy", "skipped", "failed"):
+            _, _, session = await seed_agent_env_session(
+                pool, account_id=account_id, prefix=f"fleet-{prefix}"
+            )
+            sessions.append(session)
+        healthy, skipped, failed = sessions
+
+        await _provision_with_outcome(pool, healthy.id, account_id, EgressProvisionResult())
+        await _provision_with_outcome(
+            pool,
+            skipped.id,
+            account_id,
+            EgressProvisionResult(
+                hosts_installed=("api.example.com",),
+                hosts_skipped=(HostSkip(host="missing.example.com", reason="no IPv4 address"),),
+            ),
+        )
+        await _provision_with_outcome(
+            pool,
+            failed.id,
+            account_id,
+            RuntimeError("sidecar unavailable"),
+        )
+
+        warning = MagicMock()
+        monkeypatch.setattr(audit.log, "warning", warning)
+        result = await audit.run_fleet_egress_audit(pool)
+
+        assert result.events_examined == 3
+        assert result.healthy_events_observed == 1
+        assert [(finding.session_id, finding.event) for finding in result.findings] == [
+            (skipped.id, "egress_provisioned"),
+            (failed.id, "egress_provision_failed"),
+        ]
+        assert warning.call_count == 2
+    finally:
+        await pool.close()

--- a/tests/unit/test_fleet_egress_audit.py
+++ b/tests/unit/test_fleet_egress_audit.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.harness import fleet_egress_audit as audit
+
+
+class _Acquire:
+    def __init__(self, conn: MagicMock) -> None:
+        self.conn = conn
+
+    async def __aenter__(self) -> MagicMock:
+        return self.conn
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+def _pool(conn: MagicMock) -> MagicMock:
+    pool = MagicMock()
+    pool.acquire.return_value = _Acquire(conn)
+    return pool
+
+
+async def test_audit_reads_24h_authoritative_stream_and_alerts_every_finding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(UTC)
+    rows = [
+        {"id": "fail", "session_id": "s1", "account_id": "a1", "created_at": now,
+         "data": {"event": "egress_provision_failed", "reason": "down"}},
+        {"id": "skip", "session_id": "s2", "account_id": "a2", "created_at": now,
+         "data": {"event": "egress_provisioned", "hosts_skipped": [{"host": "x"}]}},
+    ]
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    warning = MagicMock()
+    monkeypatch.setattr(audit.log, "warning", warning)
+
+    result = await audit.run_fleet_egress_audit(_pool(conn))
+
+    sql = conn.fetch.await_args.args[0]
+    assert "FROM events" in sql
+    assert "INTERVAL '24 hours'" in sql
+    assert "egress_provision_failed" in sql
+    assert "jsonb_array_length" in sql
+    assert [finding.event_id for finding in result.findings] == ["fail", "skip"]
+    assert warning.call_count == 2
+
+
+async def test_read_failure_propagates_and_never_reports_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=RuntimeError("event stream unavailable"))
+    healthy = MagicMock()
+    monkeypatch.setattr(audit.log, "info", healthy)
+
+    with pytest.raises(RuntimeError, match="event stream unavailable"):
+        await audit.run_fleet_egress_audit(_pool(conn))
+
+    healthy.assert_not_called()

--- a/tests/unit/test_fleet_egress_audit.py
+++ b/tests/unit/test_fleet_egress_audit.py
@@ -31,6 +31,13 @@ async def test_audit_reads_24h_authoritative_stream_and_alerts_every_finding(
     now = datetime.now(UTC)
     rows = [
         {
+            "id": "healthy",
+            "session_id": "s0",
+            "account_id": "a0",
+            "created_at": now,
+            "data": {"event": "egress_provisioned", "hosts_skipped": []},
+        },
+        {
             "id": "fail",
             "session_id": "s1",
             "account_id": "a1",
@@ -56,9 +63,23 @@ async def test_audit_reads_24h_authoritative_stream_and_alerts_every_finding(
     assert "FROM events" in sql
     assert "INTERVAL '24 hours'" in sql
     assert "egress_provision_failed" in sql
-    assert "jsonb_array_length" in sql
+    assert "egress_provisioned" in sql
+    assert result.events_examined == 3
+    assert result.healthy_events_observed == 1
     assert [finding.event_id for finding in result.findings] == ["fail", "skip"]
     assert warning.call_count == 2
+
+
+async def test_silent_writer_never_reports_health(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[])
+    healthy = MagicMock()
+    monkeypatch.setattr(audit.log, "info", healthy)
+
+    with pytest.raises(audit.EgressLifecycleWriterSilentError, match="no healthy"):
+        await audit.run_fleet_egress_audit(_pool(conn))
+
+    healthy.assert_not_called()
 
 
 async def test_read_failure_propagates_and_never_reports_health(

--- a/tests/unit/test_fleet_egress_audit.py
+++ b/tests/unit/test_fleet_egress_audit.py
@@ -30,10 +30,20 @@ async def test_audit_reads_24h_authoritative_stream_and_alerts_every_finding(
 ) -> None:
     now = datetime.now(UTC)
     rows = [
-        {"id": "fail", "session_id": "s1", "account_id": "a1", "created_at": now,
-         "data": {"event": "egress_provision_failed", "reason": "down"}},
-        {"id": "skip", "session_id": "s2", "account_id": "a2", "created_at": now,
-         "data": {"event": "egress_provisioned", "hosts_skipped": [{"host": "x"}]}},
+        {
+            "id": "fail",
+            "session_id": "s1",
+            "account_id": "a1",
+            "created_at": now,
+            "data": {"event": "egress_provision_failed", "reason": "down"},
+        },
+        {
+            "id": "skip",
+            "session_id": "s2",
+            "account_id": "a2",
+            "created_at": now,
+            "data": {"event": "egress_provisioned", "hosts_skipped": [{"host": "x"}]},
+        },
     ]
     conn = MagicMock()
     conn.fetch = AsyncMock(return_value=rows)

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -415,7 +415,8 @@ class TestIPv4OnlyResolution:
 
     def test_allowed_host_loop_uses_helper(self) -> None:
         script = build_iptables_script(allowed_hosts={"api.example.com"})
-        assert "for ip in $(resolve_ipv4 api.example.com); do" in script
+        assert "ips=$(resolve_ipv4 api.example.com)" in script
+        assert "for ip in $ips; do" in script
         assert "getent ahostsv4" in script
 
     def test_extra_host_ports_loop_uses_helper(self) -> None:
@@ -431,7 +432,8 @@ class TestIPv4OnlyResolution:
             dnat_target=("aios-worker", 49152),
         )
         assert "PROXY_IP=$(resolve_ipv4 aios-worker | head -n1)" in script
-        assert "for ip in $(resolve_ipv4 api.secret.com); do" in script
+        assert "ips=$(resolve_ipv4 api.secret.com)" in script
+        assert "for ip in $ips; do" in script
 
     def test_dnat_only_script_defines_and_uses_helper(self) -> None:
         script = build_secret_egress_dnat_script(
@@ -439,7 +441,8 @@ class TestIPv4OnlyResolution:
         )
         assert "resolve_ipv4()" in script
         assert "getent ahostsv4" in script
-        assert "for ip in $(resolve_ipv4 api.secret.com); do" in script
+        assert "ips=$(resolve_ipv4 api.secret.com)" in script
+        assert "for ip in $ips; do" in script
 
     def test_helper_defined_before_first_use(self) -> None:
         """The helper definition must precede every call so the script runs

--- a/tests/unit/test_sandbox_provision_span.py
+++ b/tests/unit/test_sandbox_provision_span.py
@@ -14,6 +14,7 @@ from aios.sandbox.backends.base import (
     SandboxSpec,
 )
 from aios.sandbox.registry import SandboxRegistry
+from aios.sandbox.setup import EgressProvisionResult, HostSkip
 from aios.sandbox.spec import ProvisioningPlan
 from tests.helpers.sandbox import FakeBackend, make_handle
 
@@ -60,14 +61,74 @@ class TestSandboxProvisionSpan:
         ):
             await registry.get_or_provision("sess_01TEST", pool=pool)
 
-        assert append_event.await_count == 2
+        assert append_event.await_count == 3
         start_data = append_event.await_args_list[0].args[3]
-        end_data = append_event.await_args_list[1].args[3]
+        end_data = append_event.await_args_list[2].args[3]
         assert start_data == {"event": "sandbox_provision_start"}
         assert end_data["event"] == "sandbox_provision_end"
         assert end_data["sandbox_provision_start_id"] == "ev_span_start"
         assert end_data["is_error"] is False
         assert end_data["container_id"] == "abc123def456"  # 12-char short id
+
+    async def test_cold_start_emits_typed_egress_outcome(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        pool = MagicMock()
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_span_start"))
+        outcome = EgressProvisionResult(
+            hosts_installed=("api.example.com",),
+            hosts_skipped=(HostSkip(host="missing.example.com", reason="no IPv4 address"),),
+        )
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=_make_plan()),
+            ),
+            patch("aios.sandbox.registry.install_egress_ca", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch.object(registry, "_apply_egress_rules", AsyncMock(return_value=outcome)),
+            patch("aios.services.sessions.append_event", append_event),
+        ):
+            await registry.get_or_provision("sess_01TEST", pool=pool)
+
+        lifecycle = [c for c in append_event.await_args_list if c.args[2] == "lifecycle"]
+        assert len(lifecycle) == 1
+        assert lifecycle[0].args[3] == {
+            "event": "egress_provisioned",
+            "hosts_installed": ["api.example.com"],
+            "hosts_skipped": [{"host": "missing.example.com", "reason": "no IPv4 address"}],
+        }
+
+    async def test_failure_emits_typed_egress_failure(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        pool = MagicMock()
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_span_start"))
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=_make_plan()),
+            ),
+            patch("aios.sandbox.registry.install_egress_ca", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch.object(
+                registry,
+                "_apply_egress_rules",
+                AsyncMock(side_effect=RuntimeError("sidecar unavailable")),
+            ),
+            patch("aios.services.sessions.append_event", append_event),
+            pytest.raises(RuntimeError),
+        ):
+            await registry.get_or_provision("sess_01TEST", pool=pool)
+
+        lifecycle = [c for c in append_event.await_args_list if c.args[2] == "lifecycle"]
+        assert len(lifecycle) == 1
+        assert lifecycle[0].args[3] == {
+            "event": "egress_provision_failed",
+            "reason": "sidecar unavailable",
+        }
 
     async def test_warm_hit_emits_no_span(self) -> None:
         backend = FakeBackend()
@@ -131,8 +192,8 @@ class TestSandboxProvisionSpan:
         ):
             await registry.get_or_provision("sess_01TEST", pool=pool)
 
-        assert append_event.await_count == 2
-        end_data = append_event.await_args_list[1].args[3]
+        assert append_event.await_count == 3
+        end_data = append_event.await_args_list[2].args[3]
         assert end_data["event"] == "sandbox_provision_end"
         assert end_data["is_error"] is True
         assert "container_id" not in end_data


### PR DESCRIPTION
Automated dev-pipeline build for issue #2021.