### PR TITLE
feat(harness): append lifecycle/tool_requested when a call is held

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1807,10 +1807,12 @@ async def _run_session_step_body(
             # "this call is now waiting on an external party". ``kind``
             # mirrors the awaiting view's vocabulary (mcp/builtin for
             # confirmation gates, custom for client-executed tools).
-            # Lifecycle events are not stimuli (events.py: ``is_stimulus``)
-            # and are invisible to context builds and the confirmed-dispatch
-            # SQL (both filter on other kinds/values), so this append wakes
-            # nothing. No idempotency guard: fresh ``offered_calls`` are
+            # Lifecycle events are not stimuli (db/queries/events.py:
+            # ``is_stimulus``) and are invisible to context builds and the
+            # confirmed-dispatch SQL (both filter on other kinds/values), so
+            # these appends schedule no step. They can notify event-stream
+            # subscribers, but the markers remain advisory. No idempotency
+            # guard: fresh ``offered_calls`` are
             # partitioned exactly once per completion — re-wakes never
             # re-offer prior calls — and a crash landing between the
             # assistant append and this one merely omits the marker while
@@ -1820,18 +1822,29 @@ async def _run_session_step_body(
             ] + [(tc, "custom") for tc in custom]:
                 if not tc.get("id"):
                     continue
-                await sessions_service.append_event(
-                    pool,
-                    session_id,
-                    "lifecycle",
-                    {
-                        "event": "tool_requested",
-                        "tool_call_id": tc["id"],
-                        "name": _tc_name(tc),
-                        "kind": held_kind,
-                    },
-                    account_id=account_id,
-                )
+                try:
+                    await sessions_service.append_event(
+                        pool,
+                        session_id,
+                        "lifecycle",
+                        {
+                            "event": "tool_requested",
+                            "tool_call_id": tc["id"],
+                            "name": _tc_name(tc),
+                            "kind": held_kind,
+                        },
+                        account_id=account_id,
+                    )
+                except Exception:
+                    # The awaiting view is the actionable state. Marker writes
+                    # are best-effort so an archive fence or one bad marker
+                    # cannot fail the turn or suppress later markers.
+                    log.warning(
+                        "step.tool_requested_marker_failed",
+                        session_id=session_id,
+                        tool_call_id=tc["id"],
+                        exc_info=True,
+                    )
             log.info(
                 "step.external_tools_pending",
                 session_id=session_id,

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -74,6 +74,7 @@ from aios.logging import get_logger
 from aios.models.agents import (
     McpServerSpec,
     StepSurface,
+    is_mcp_tool_name,
 )
 from aios.models.events import (
     ERRORED_LIFECYCLE_STATUS,
@@ -1798,6 +1799,39 @@ async def _run_session_step_body(
             )
 
         if needs_confirm or custom:
+            # Record the hold durably: ``lifecycle/tool_requested``, the
+            # request-side twin of ``tool_confirmed``. The awaiting view is
+            # derived per read (and shifts under policy edits), so without
+            # this event the log shows confirmations that were never visibly
+            # requested — stream consumers had to re-derive policy to learn
+            # "this call is now waiting on an external party". ``kind``
+            # mirrors the awaiting view's vocabulary (mcp/builtin for
+            # confirmation gates, custom for client-executed tools).
+            # Lifecycle events are not stimuli (events.py: ``is_stimulus``)
+            # and are invisible to context builds and the confirmed-dispatch
+            # SQL (both filter on other kinds/values), so this append wakes
+            # nothing. No idempotency guard: fresh ``offered_calls`` are
+            # partitioned exactly once per completion — re-wakes never
+            # re-offer prior calls — and a crash landing between the
+            # assistant append and this one merely omits the marker while
+            # ``awaiting`` stays the actionable truth.
+            for tc, held_kind in [
+                (tc, "mcp" if is_mcp_tool_name(_tc_name(tc)) else "builtin") for tc in needs_confirm
+            ] + [(tc, "custom") for tc in custom]:
+                if not tc.get("id"):
+                    continue
+                await sessions_service.append_event(
+                    pool,
+                    session_id,
+                    "lifecycle",
+                    {
+                        "event": "tool_requested",
+                        "tool_call_id": tc["id"],
+                        "name": _tc_name(tc),
+                        "kind": held_kind,
+                    },
+                    account_id=account_id,
+                )
             log.info(
                 "step.external_tools_pending",
                 session_id=session_id,

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -1045,6 +1045,20 @@ class TestCustomTools:
         assert {a.tool_call_id for a in s.awaiting} == {"call_w1"}
         assert s.awaiting[0].kind == "custom"
 
+        # The hold is durable, not just derived: ``lifecycle/tool_requested``
+        # with the awaiting view's ``custom`` kind.
+        events = await harness.all_events(session.id)
+        requested = [
+            e for e in events if e.kind == "lifecycle" and e.data.get("event") == "tool_requested"
+        ]
+        assert len(requested) == 1
+        assert requested[0].data == {
+            "event": "tool_requested",
+            "tool_call_id": "call_w1",
+            "name": "get_weather",
+            "kind": "custom",
+        }
+
     async def test_custom_tool_result_resumes_session(self, harness: Harness) -> None:
         """Submitting a custom tool result via the API resumes the session."""
         account_id = "acc_test_stub"  # PR 3 scaffolding
@@ -1332,6 +1346,96 @@ class TestPermissionPolicies:
         s = await harness.session(session.id)
         assert s.status == "idle"
         assert s.stop_reason == {"type": "end_turn"}
+
+    async def test_hold_appends_tool_requested_lifecycle(self, harness: Harness) -> None:
+        """Holding an always_ask call appends ``lifecycle/tool_requested``.
+
+        The request-side twin of ``tool_confirmed``: awaiting is derived per
+        read (and shifts under policy edits), so the log must record that the
+        harness held this call, ordered after the assistant message that
+        offered it and before the step's ``turn_ended``.
+        """
+        from aios.models.agents import ToolSpec
+
+        async def fake_glob(
+            session_id: str, arguments: dict[str, Any], **kwargs: Any
+        ) -> dict[str, Any]:
+            return {"matches": ["a.txt"]}
+
+        self._override_tool("glob", fake_glob)
+
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[tool_call("glob", {"pattern": "*.txt"}, call_id="call_req1")]
+                ),
+            ]
+        )
+        session = await harness.start(
+            "list files",
+            tool_specs=[ToolSpec(type="glob", permission="always_ask")],
+        )
+        await harness.run_step(session.id)
+
+        events = await harness.all_events(session.id)
+        requested = [
+            e for e in events if e.kind == "lifecycle" and e.data.get("event") == "tool_requested"
+        ]
+        assert len(requested) == 1
+        assert requested[0].data == {
+            "event": "tool_requested",
+            "tool_call_id": "call_req1",
+            "name": "glob",
+            "kind": "builtin",
+        }
+        offer_seq = next(
+            e.seq for e in events if e.kind == "message" and e.data.get("role") == "assistant"
+        )
+        turn_end_seq = next(
+            e.seq for e in events if e.kind == "lifecycle" and e.data.get("event") == "turn_ended"
+        )
+        assert offer_seq < requested[0].seq < turn_end_seq
+
+    async def test_tool_requested_not_duplicated_across_steps(self, harness: Harness) -> None:
+        """The full hold → allow → dispatch → respond flow appends exactly one
+        ``tool_requested`` — re-wakes never re-offer prior calls."""
+        from aios.models.agents import ToolSpec
+
+        async def fake_glob(
+            session_id: str, arguments: dict[str, Any], **kwargs: Any
+        ) -> dict[str, Any]:
+            return {"matches": ["found.txt"]}
+
+        self._override_tool("glob", fake_glob)
+
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[tool_call("glob", {"pattern": "*.txt"}, call_id="call_req2")]
+                ),
+                assistant("Found found.txt"),
+            ]
+        )
+        session = await harness.start(
+            "list files",
+            tool_specs=[ToolSpec(type="glob", permission="always_ask")],
+        )
+        await harness.run_step(session.id)
+        await harness.confirm_tool(session.id, "call_req2", "allow")
+        await harness.run_step(session.id)
+        await harness.wait_for_tools(session.id)
+        await harness.run_step(session.id)
+
+        events = await harness.all_events(session.id)
+        requested = [
+            e for e in events if e.kind == "lifecycle" and e.data.get("event") == "tool_requested"
+        ]
+        confirmed = [
+            e for e in events if e.kind == "lifecycle" and e.data.get("event") == "tool_confirmed"
+        ]
+        assert [e.data["tool_call_id"] for e in requested] == ["call_req2"]
+        assert [e.data["tool_call_id"] for e in confirmed] == ["call_req2"]
+        assert requested[0].seq < confirmed[0].seq
 
     async def test_always_ask_deny_sends_error(self, harness: Harness) -> None:
         """Confirm deny → model sees error with deny message → responds."""


### PR DESCRIPTION
## What

Append a `lifecycle/tool_requested` event — `{event, tool_call_id, name, kind: mcp|builtin|custom}` — at the moment the step loop partitions offered calls into `needs_confirm`/`custom`, ordered after the assistant message that offered the call and before the step's `turn_ended`.

## Why

The event log recorded confirmations but never the requests for them: `confirm_tool_allow` appends `lifecycle/tool_confirmed` and the deny path appends a tool-role error, but the hold itself was only derived state (`awaiting`, recomputed per read against *current* policy) plus a log line. That asymmetry made "the harness is now waiting on a human for this call" unobservable to stream consumers without re-deriving the permission policy — and policy-derived answers rewrite history, since a per-tool `always_allow` flip changes what `awaiting` would have said.

First consumer: jarbot renders approval cards from this event instead of guessing from policy (a pre-approved tool was rendering fabricated consent UI). But the gap is substrate-level: any operator UI has the same need.

## Blast radius (checked before writing)

- Lifecycle events are not stimuli (`is_stimulus` = message-kind non-assistant only) — nothing wakes.
- Status derives from counters, not lifecycle scans.
- Context builds read message-kind events only — invisible to the model.
- The confirmed-dispatch SQL filters `data->>'event' = 'tool_confirmed'`.
- No idempotency guard, deliberately: fresh `offered_calls` are partitioned exactly once per completion (re-wakes never re-offer prior calls — pinned by the new cross-step test), and a crash between the assistant append and this one merely omits the marker while `awaiting` stays the actionable truth.

## Tests

- `tool_requested` shape + ordering (after offer, before `turn_ended`), builtin kind
- Non-duplication across the full hold → allow → dispatch → respond flow
- `custom` kind on the client-executed tool path

Full suites green: 5117 unit, e2e/integration incl. `test_step_model.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)