### PR TITLE
CI: detect a branched alembic history (two migrations claiming one parent) before it fails seven checks obscurely

### DIFF
--- a/.github/workflows/migration-head-check.yml
+++ b/.github/workflows/migration-head-check.yml
@@ -1,0 +1,43 @@
+name: Migration head check
+
+on:
+  pull_request:
+    paths:
+      - migrations/**
+      - scripts/check_migration_heads.py
+      - tests/unit/test_check_migration_heads.py
+      - .github/workflows/migration-head-check.yml
+
+concurrency:
+  group: migration-head-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  migration-head:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # On pull_request, checkout's default ref is refs/pull/<n>/merge. This is
+      # deliberately the merge result, not the stale PR head.
+      - name: Check out merge ref
+        uses: actions/checkout@v4
+
+      - name: Check out current base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: _base
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Detect branched Alembic history
+        run: |
+          set -euo pipefail
+          base_tip=$(uv run python scripts/check_migration_heads.py _base/migrations/versions | sed 's/^alembic history has one head: //')
+          uv run python scripts/check_migration_heads.py migrations/versions --current-tip "${base_tip}"
+
+      - name: Mutation and parser self-tests
+        run: uv run pytest tests/unit/test_check_migration_heads.py -q

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance scripts."""

--- a/scripts/check_migration_heads.py
+++ b/scripts/check_migration_heads.py
@@ -49,6 +49,18 @@ def load_revisions(versions_dir: Path) -> dict[str, str | None]:
 
 
 def check_history(revisions: dict[str, str | None], *, current_tip: str | None = None) -> str:
+    missing_parents = sorted(
+        (revision, parent)
+        for revision, parent in revisions.items()
+        if parent is not None and parent not in revisions
+    )
+    if missing_parents:
+        revision, parent = missing_parents[0]
+        raise MigrationHistoryError(
+            f'unknown down_revision: {revision} declares down_revision="{parent}", '
+            "but that revision is not present"
+        )
+
     children: dict[str, list[str]] = defaultdict(list)
     for revision, parent in revisions.items():
         if parent is not None:

--- a/scripts/check_migration_heads.py
+++ b/scripts/check_migration_heads.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Fail with an actionable error when Alembic's migration history is branched."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from collections import defaultdict
+from pathlib import Path
+
+
+class MigrationHistoryError(ValueError):
+    """The migration files do not form a single-headed history."""
+
+
+def _value(module: ast.Module, name: str, path: Path) -> str | None:
+    for statement in module.body:
+        value: ast.expr | None = None
+        if (
+            isinstance(statement, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == name for target in statement.targets
+            )
+        ) or (
+            isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.target.id == name
+        ):
+            value = statement.value
+        if value is not None:
+            parsed = ast.literal_eval(value)
+            if parsed is None or isinstance(parsed, str):
+                return parsed
+            raise MigrationHistoryError(f"{path}: {name} must be a string or None")
+    raise MigrationHistoryError(f"{path}: missing {name} declaration")
+
+
+def load_revisions(versions_dir: Path) -> dict[str, str | None]:
+    revisions: dict[str, str | None] = {}
+    for path in sorted(versions_dir.glob("*.py")):
+        module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        revision = _value(module, "revision", path)
+        if revision is None:
+            raise MigrationHistoryError(f"{path}: revision must be a string")
+        if revision in revisions:
+            raise MigrationHistoryError(f"duplicate alembic revision: {revision}")
+        revisions[revision] = _value(module, "down_revision", path)
+    return revisions
+
+
+def check_history(revisions: dict[str, str | None], *, current_tip: str | None = None) -> str:
+    children: dict[str, list[str]] = defaultdict(list)
+    for revision, parent in revisions.items():
+        if parent is not None:
+            children[parent].append(revision)
+
+    collisions = [(parent, sorted(nodes)) for parent, nodes in children.items() if len(nodes) > 1]
+    heads = sorted(set(revisions) - {parent for parent in revisions.values() if parent is not None})
+    if len(heads) == 1 and not collisions:
+        return heads[0]
+
+    if collisions:
+        parent, nodes = collisions[0]
+        tip = current_tip if current_tip in nodes else nodes[0]
+        others = [node for node in nodes if node != tip]
+        named = " and ".join([tip, *others])
+        raise MigrationHistoryError(
+            f'branched alembic history: {named} both declare down_revision="{parent}"\n'
+            f"  -> re-parent your migration onto the current tip ({tip})\n"
+            "  -> NOTE: a git rebase moves the file but does NOT re-parent it"
+        )
+
+    raise MigrationHistoryError(f"branched alembic history: expected one head, found {heads}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("versions_dir", type=Path, nargs="?", default=Path("migrations/versions"))
+    parser.add_argument("--current-tip")
+    args = parser.parse_args()
+    try:
+        head = check_history(load_revisions(args.versions_dir), current_tip=args.current_tip)
+    except (MigrationHistoryError, SyntaxError, ValueError) as error:
+        print(error)
+        return 1
+    print(f"alembic history has one head: {head}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_migration_heads.py
+++ b/scripts/check_migration_heads.py
@@ -62,9 +62,11 @@ def check_history(revisions: dict[str, str | None], *, current_tip: str | None =
         )
 
     children: dict[str, list[str]] = defaultdict(list)
-    for revision, parent in revisions.items():
-        if parent is not None:
-            children[parent].append(revision)
+    # NB: distinct names from the `revision, parent` unpacked above — reusing them
+    # rebinds `parent` from `str` to `str | None` and mypy --strict rejects it.
+    for child_revision, child_parent in revisions.items():
+        if child_parent is not None:
+            children[child_parent].append(child_revision)
 
     collisions = [(parent, sorted(nodes)) for parent, nodes in children.items() if len(nodes) > 1]
     heads = sorted(set(revisions) - {parent for parent in revisions.values() if parent is not None})

--- a/tests/unit/test_check_migration_heads.py
+++ b/tests/unit/test_check_migration_heads.py
@@ -25,6 +25,16 @@ def test_parser_handles_annotated_and_unannotated_revisions(tmp_path: Path) -> N
     assert check_history(load_revisions(tmp_path)) == "0159"
 
 
+def test_rejects_revision_whose_parent_is_missing(tmp_path: Path) -> None:
+    _migration(tmp_path / "0161_disconnected.py", "0161", "DOES_NOT_EXIST")
+
+    with pytest.raises(MigrationHistoryError, match="unknown down_revision") as exc_info:
+        check_history(load_revisions(tmp_path))
+
+    assert "0161" in str(exc_info.value)
+    assert "DOES_NOT_EXIST" in str(exc_info.value)
+
+
 def test_mutation_detects_stale_parent_then_passes_when_reparented(tmp_path: Path) -> None:
     _migration(tmp_path / "0158_base.py", "0158", None)
     _migration(tmp_path / "0159_current_tip.py", "0159", "0158")

--- a/tests/unit/test_check_migration_heads.py
+++ b/tests/unit/test_check_migration_heads.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripts.check_migration_heads import MigrationHistoryError, check_history, load_revisions
+
+
+def _migration(
+    path: Path, revision: str, down_revision: str | None, *, annotated: bool = False
+) -> None:
+    annotation = ": str" if annotated else ""
+    parent = "None" if down_revision is None else repr(down_revision)
+    path.write_text(
+        f"revision{annotation} = {revision!r}\ndown_revision: str | None = {parent}\n",
+        encoding="utf-8",
+    )
+
+
+def test_parser_handles_annotated_and_unannotated_revisions(tmp_path: Path) -> None:
+    _migration(tmp_path / "0158_base.py", "0158", None, annotated=True)
+    _migration(tmp_path / "0159_tip.py", "0159", "0158")
+
+    assert load_revisions(tmp_path) == {"0158": None, "0159": "0158"}
+    assert check_history(load_revisions(tmp_path)) == "0159"
+
+
+def test_mutation_detects_stale_parent_then_passes_when_reparented(tmp_path: Path) -> None:
+    _migration(tmp_path / "0158_base.py", "0158", None)
+    _migration(tmp_path / "0159_current_tip.py", "0159", "0158")
+    stale = tmp_path / "0161_pr_migration.py"
+    _migration(stale, "0161", "0158", annotated=True)
+
+    with pytest.raises(MigrationHistoryError) as exc_info:
+        check_history(load_revisions(tmp_path), current_tip="0159")
+
+    assert str(exc_info.value) == (
+        'branched alembic history: 0159 and 0161 both declare down_revision="0158"\n'
+        "  -> re-parent your migration onto the current tip (0159)\n"
+        "  -> NOTE: a git rebase moves the file but does NOT re-parent it"
+    )
+
+    _migration(stale, "0161", "0159", annotated=True)
+    assert check_history(load_revisions(tmp_path), current_tip="0159") == "0161"
+
+
+def test_known_good_repository_has_expected_revision_count_and_one_head() -> None:
+    versions = Path(__file__).resolve().parents[2] / "migrations" / "versions"
+    revisions = load_revisions(versions)
+
+    assert len(revisions) == 155
+    assert check_history(revisions) in revisions

--- a/tests/unit/test_check_migration_heads.py
+++ b/tests/unit/test_check_migration_heads.py
@@ -25,7 +25,12 @@ def test_parser_handles_annotated_and_unannotated_revisions(tmp_path: Path) -> N
     assert check_history(load_revisions(tmp_path)) == "0159"
 
 
-def test_rejects_revision_whose_parent_is_missing(tmp_path: Path) -> None:
+@pytest.mark.parametrize("include_valid_root", [False, True])
+def test_rejects_revision_whose_parent_is_missing(
+    tmp_path: Path, *, include_valid_root: bool
+) -> None:
+    if include_valid_root:
+        _migration(tmp_path / "0158_base.py", "0158", None)
     _migration(tmp_path / "0161_disconnected.py", "0161", "DOES_NOT_EXIST")
 
     with pytest.raises(MigrationHistoryError, match="unknown down_revision") as exc_info:


### PR DESCRIPTION
Automated dev-pipeline build for issue #2126.