### PR TITLE
host_dir_reaper sweeps the pre-#1959 top-level _runs while the writer creates account-scoped run workspaces — terminal-run scratch leaks unboundedly (180GB/3wk in prod)

### DIFF
--- a/src/aios/harness/host_dir_reaper.py
+++ b/src/aios/harness/host_dir_reaper.py
@@ -182,14 +182,47 @@ async def _reap_session_repos(
     return removed
 
 
+def _scan_run_workspaces(*, min_age_seconds: float, now: float) -> list[_Candidate]:
+    """Enumerate account-scoped run scratch plus legacy top-level residue.
+
+    Account and ``_runs`` directories pass the same symlink and resolved-parent
+    confinement gates as run directories before their children are scanned.
+    """
+    workspace_root = run_workspace_dir("_", "_").parents[2]
+    resolved_workspace_root = workspace_root.resolve()
+    if not resolved_workspace_root.exists():
+        return []
+
+    roots = [resolved_workspace_root / "_runs"]  # pre-account-scoping residue
+    for account_dir in resolved_workspace_root.iterdir():
+        if account_dir.name == "_runs" or account_dir.is_symlink() or not account_dir.is_dir():
+            continue
+        resolved_account_dir = account_dir.resolve()
+        if resolved_account_dir.parent != resolved_workspace_root:
+            continue
+        runs_root = run_workspace_dir(account_dir.name, "_").parent
+        if runs_root.is_symlink() or not runs_root.is_dir():
+            continue
+        resolved_runs_root = runs_root.resolve()
+        if resolved_runs_root.parent != resolved_account_dir:
+            continue
+        roots.append(resolved_runs_root)
+
+    candidates: list[_Candidate] = []
+    for root in roots:
+        if root.is_symlink():
+            continue
+        candidates.extend(_scan_children(root, min_age_seconds=min_age_seconds, now=now))
+    return candidates
+
+
 async def _reap_runs(pool: asyncpg.Pool[Any], *, min_age_seconds: float, now: float) -> int:
-    """Reap ``_runs/<run_id>`` scratch for TERMINAL runs ONLY.
+    """Reap account-scoped and legacy run scratch for TERMINAL runs ONLY.
 
     NOT reconstructible ⇒ reap ONLY on a positively observed terminal status;
     a suspended/running/pending/absent run is kept. Fail-closed on DB error.
     """
-    root = run_workspace_dir("_").parent
-    candidates = _scan_children(root, min_age_seconds=min_age_seconds, now=now)
+    candidates = _scan_run_workspaces(min_age_seconds=min_age_seconds, now=now)
     if not candidates:
         return 0
     owner_ids = [c.owner_id for c in candidates]

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -925,7 +925,7 @@ async def build_spec_from_run(run_id: str) -> ProvisioningPlan:
         raise ValueError(f"shared workflow run {run_id!r} has no workspace pointer")
     else:
         # Legacy pre-M2 run rows/tests have no persisted pointer.
-        workspace_path = ensure_run_workspace_dir(run_id)
+        workspace_path = ensure_run_workspace_dir(run.account_id, run_id)
 
     tool_broker = runtime.require_tool_broker()
     tool_socket_host_path = settings.tool_broker_socket_path

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -216,22 +216,19 @@ def validate_workspace_path(
 _RUNS_ROOT = "_runs"
 
 
-def run_workspace_dir(run_id: str) -> Path:
-    """Per-run host workspace directory backing ``/workspace`` in a run sandbox (#988).
+def run_workspace_dir(account_id: str, run_id: str) -> Path:
+    """Per-run host workspace directory backing ``/workspace`` in a run sandbox.
 
-    Rooted at ``<workspace_root>/_runs/<run_id>`` — under a reserved prefix so it
-    never collides with a session workspace (``<workspace_root>/<account_id>/…``)
-    and is independent of any user-supplied path. The run sandbox is **ephemeral
-    scratch**: the directory is created at provision and is not part of any durable
-    snapshot machinery. Pure — does not touch the filesystem; use
-    :func:`ensure_run_workspace_dir` to create.
+    Run scratch is account-scoped at
+    ``<workspace_root>/<account_id>/_runs/<run_id>``. Pure — does not touch the
+    filesystem; use :func:`ensure_run_workspace_dir` to create it.
     """
-    return (get_settings().workspace_root / _RUNS_ROOT / run_id).resolve()
+    return (get_settings().workspace_root / account_id / _RUNS_ROOT / run_id).resolve()
 
 
-def ensure_run_workspace_dir(run_id: str) -> Path:
-    """Return the per-run workspace directory, creating it (and its parents) if needed."""
-    return ensure_owned_dir(run_workspace_dir(run_id))
+def ensure_run_workspace_dir(account_id: str, run_id: str) -> Path:
+    """Return the per-run workspace directory, creating it and its parents."""
+    return ensure_owned_dir(run_workspace_dir(account_id, run_id))
 
 
 _MEMORY_STORES_ROOT = "_memory_stores"

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -38,6 +38,7 @@ from aios.models.agents import (
 )
 from aios.models.attenuation import Surface, surface_diff, surface_of
 from aios.models.workflows import WfRun
+from aios.sandbox.volumes import run_workspace_dir
 from aios.services import agents as agents_service
 from aios.services import attenuation as attenuation_service
 from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
@@ -339,9 +340,7 @@ async def create_run(
         else:
             workspace_path = None
         if workspace == "fresh":
-            workspace_path = str(
-                (get_settings().workspace_root / account_id / "_runs" / effective_run_id).resolve()
-            )
+            workspace_path = str(run_workspace_dir(account_id, effective_run_id))
         source_version: int | None
         if inline is not None:
             # ── inline-script arm (T5, #1466) ──────────────────────────────────

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -2412,9 +2412,15 @@ class TestPoisonEventQuarantine:
             r for r in caplog.records if "context.poison_event_quarantined" in r.getMessage()
         )
         rendered = rec.getMessage()
-        assert "seq=3" in rendered
-        assert "session_id=sess_01TEST" in rendered
-        assert "error_type=RuntimeError" in rendered
+        if rendered.startswith("{"):
+            event = json.loads(rendered)
+            assert event["seq"] == 3
+            assert event["session_id"] == "sess_01TEST"
+            assert event["error_type"] == "RuntimeError"
+        else:
+            assert "seq=3" in rendered
+            assert "session_id=sess_01TEST" in rendered
+            assert "error_type=RuntimeError" in rendered
 
     def test_only_poison_event_quarantined_others_render(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_host_dir_reaper.py
+++ b/tests/unit/test_host_dir_reaper.py
@@ -34,7 +34,7 @@ from aios.db import queries
 from aios.db.queries import workflows as wf_queries
 from aios.harness import host_dir_reaper
 from aios.harness.host_dir_reaper import _scan_run_workspaces, sweep_host_dirs
-from aios.workflows.service import run_workspace_dir
+from aios.sandbox.volumes import run_workspace_dir
 
 
 @pytest.fixture

--- a/tests/unit/test_host_dir_reaper.py
+++ b/tests/unit/test_host_dir_reaper.py
@@ -312,6 +312,36 @@ async def test_symlink_child_is_never_followed(
     assert (outside / "precious").exists()
 
 
+async def test_symlink_child_is_not_submitted_for_deletion(
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The symlink gate itself prevents a link from reaching ``rmtree``.
+
+    Pointing at a sibling keeps the resolved target confined to the reserved
+    root, so the resolved-parent defence cannot mask removal of the explicit
+    symlink check.  ``rmtree`` is replaced with a destructive-path spy because
+    the stdlib implementation independently refuses symlinks.
+    """
+    target = _mkdir_aged(roots["runs"], "wfr_live")
+    link = roots["runs"] / "wfr_done"
+    link.symlink_to(target)
+    rmtree = MagicMock()
+    monkeypatch.setattr(host_dir_reaper.shutil, "rmtree", rmtree)
+    monkeypatch.setattr(
+        wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value={"wfr_done"}),
+    )
+    monkeypatch.setattr(queries, "unscoped_live_session_ids", AsyncMock(return_value=set()))
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0
+    rmtree.assert_not_called()
+    assert link.is_symlink()
+    assert (target / "marker").exists()
+
+
 async def test_root_itself_is_never_removed(
     roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_host_dir_reaper.py
+++ b/tests/unit/test_host_dir_reaper.py
@@ -33,7 +33,8 @@ import pytest
 from aios.db import queries
 from aios.db.queries import workflows as wf_queries
 from aios.harness import host_dir_reaper
-from aios.harness.host_dir_reaper import sweep_host_dirs
+from aios.harness.host_dir_reaper import _scan_run_workspaces, sweep_host_dirs
+from aios.workflows.service import run_workspace_dir
 
 
 @pytest.fixture
@@ -45,12 +46,16 @@ def roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     the tmp roots.
     """
     repos_root = tmp_path / "_session_repos"
-    runs_root = tmp_path / "_runs"
+    runs_root = tmp_path / "acc_test" / "_runs"
     repos_root.mkdir()
-    runs_root.mkdir()
+    runs_root.mkdir(parents=True)
 
     monkeypatch.setattr(host_dir_reaper, "session_repos_root", lambda sid: repos_root / sid)
-    monkeypatch.setattr(host_dir_reaper, "run_workspace_dir", lambda rid: runs_root / rid)
+    monkeypatch.setattr(
+        host_dir_reaper,
+        "run_workspace_dir",
+        lambda account_id, run_id: tmp_path / account_id / "_runs" / run_id,
+    )
 
     settings = MagicMock()
     settings.host_dir_reaper_enabled = True
@@ -58,6 +63,20 @@ def roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setattr(host_dir_reaper, "get_settings", lambda: settings)
 
     return {"repos": repos_root, "runs": runs_root, "settings": settings}
+
+
+def test_service_workspace_builder_is_enumerated_by_reaper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The canonical writer path must always be visible to the run reaper."""
+    settings = MagicMock(workspace_root=tmp_path)
+    monkeypatch.setattr("aios.sandbox.volumes.get_settings", lambda: settings)
+    workspace = run_workspace_dir("acc_one", "wfr_done")
+    workspace.mkdir(parents=True)
+
+    candidates = _scan_run_workspaces(min_age_seconds=0, now=time.time())
+
+    assert [candidate.path for candidate in candidates] == [workspace]
 
 
 def _mkdir_aged(parent: Path, name: str, *, age_s: float = 10_000.0) -> Path:
@@ -117,6 +136,26 @@ async def test_suspended_run_dir_survives_terminal_is_reaped(
     assert removed == 1
     assert suspended.exists(), "a suspended (DB-live) run's _runs dir must survive"
     assert not terminal.exists(), "a terminal run's _runs dir must be reaped"
+
+
+async def test_legacy_top_level_run_dir_is_reaped(
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-account-scoping ``<workspace_root>/_runs`` residue remains swept."""
+    legacy_root = roots["runs"].parents[1] / "_runs"
+    legacy_root.mkdir()
+    legacy = _mkdir_aged(legacy_root, "wfr_legacy")
+    monkeypatch.setattr(
+        wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value={"wfr_legacy"}),
+    )
+    monkeypatch.setattr(queries, "unscoped_live_session_ids", AsyncMock(return_value=set()))
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 1
+    assert not legacy.exists()
 
 
 async def test_runs_absent_from_db_is_kept(

--- a/tests/unit/test_host_dir_reaper.py
+++ b/tests/unit/test_host_dir_reaper.py
@@ -23,6 +23,7 @@ These tests assert the DB-liveness keep-set directly, never a container set:
 
 from __future__ import annotations
 
+import shutil
 import time
 from pathlib import Path
 from typing import Any
@@ -326,7 +327,7 @@ async def test_symlink_child_is_not_submitted_for_deletion(
     link = roots["runs"] / "wfr_done"
     link.symlink_to(target)
     rmtree = MagicMock()
-    monkeypatch.setattr(host_dir_reaper.shutil, "rmtree", rmtree)
+    monkeypatch.setattr(shutil, "rmtree", rmtree)
     monkeypatch.setattr(
         wf_queries,
         "unscoped_terminal_run_ids",


### PR DESCRIPTION
Automated dev-pipeline build for issue #2216.