### PR TITLE
Nothing stamps archived_at on terminal workflow runs — the enabled T6 prune has a starved feeder; run journals are 93GB of a 110GB prod DB

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -698,9 +698,11 @@ class Settings(BaseSettings):
         le=10_000,
         description="Maximum child rows deleted from one table/run in a prune batch.",
     )
-    reclaimable_prune_archival_backfill_enabled: bool = Field(
-        default=False,
-        description="Deliberate rollout switch for bounded historical terminal archival.",
+    wf_runs_archive_grace_days: int = Field(
+        default=7,
+        ge=1,
+        description="Days after a workflow run becomes terminal before the maintenance "
+        "sweep archives it, feeding terminal history into T6 retention.",
     )
     archived_definition_retention_days: int = Field(
         default=30,

--- a/src/aios/db/queries/prune.py
+++ b/src/aios/db/queries/prune.py
@@ -99,35 +99,44 @@ async def prune_archived_runs(
 
 
 async def reconcile_terminal_archival_batch(
-    conn: asyncpg.Connection[Any], *, row_limit: int = 500
+    conn: asyncpg.Connection[Any], *, grace_days: int = 7, row_limit: int = 500
 ) -> int:
-    """Archive a bounded historical terminal batch and project its final facts."""
+    """Archive a bounded batch of terminal runs older than the grace window.
+
+    The terminal transition updates ``updated_at``, making it the age key for
+    historical rows that predate automatic archival. Already-archived legacy
+    rows missing their durable summary are also projected, irrespective of age.
+    """
     result = await conn.execute(
         """WITH candidates AS (
-               SELECT r.id, r.updated_at, e.payload
+               SELECT r.id, e.payload
                  FROM wf_runs r
                  LEFT JOIN LATERAL (
                      SELECT payload FROM wf_run_events
                       WHERE run_id = r.id AND type = 'run_completed'
                       ORDER BY seq DESC LIMIT 1
                  ) e ON true
-                WHERE (r.archived_at IS NULL OR r.terminal_summary IS NULL)
-                  AND r.status IN ('completed','errored','cancelled')
+                WHERE r.status IN ('completed','errored','cancelled')
+                  AND ((r.archived_at IS NULL
+                        AND r.updated_at < now() - make_interval(days => $1))
+                       OR (r.archived_at IS NOT NULL AND r.terminal_summary IS NULL))
                 ORDER BY r.updated_at, r.id
-                LIMIT $1
+                LIMIT $2
            )
            UPDATE wf_runs r
-              SET archived_at = COALESCE(r.archived_at, c.updated_at),
-                  terminal_summary = jsonb_strip_nulls(jsonb_build_object(
-                      'is_error', c.payload->'is_error',
-                      'error', c.payload->'error',
-                      'usage', c.payload->'usage',
-                      'duration_ms', c.payload->'duration_ms',
-                      'cancelled', (r.status = 'cancelled')
-                  ))
+              SET archived_at = COALESCE(r.archived_at, now()),
+                  terminal_summary = COALESCE(r.terminal_summary,
+                      jsonb_strip_nulls(jsonb_build_object(
+                          'is_error', c.payload->'is_error',
+                          'error', c.payload->'error',
+                          'usage', c.payload->'usage',
+                          'duration_ms', c.payload->'duration_ms',
+                          'cancelled', (r.status = 'cancelled')
+                      )))
              FROM candidates c WHERE r.id = c.id
-               AND (r.archived_at IS NULL OR r.terminal_summary IS NULL)
-               AND r.status IN ('completed','errored','cancelled')""",
+               AND r.status IN ('completed','errored','cancelled')
+               AND (r.archived_at IS NULL OR r.terminal_summary IS NULL)""",
+        grace_days,
         row_limit,
     )
     return int(result.split()[-1])

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -1067,7 +1067,6 @@ async def set_run_terminal(
     """
     await conn.execute(
         "UPDATE wf_runs SET status = $3, output = $4::jsonb, "
-        "archived_at = CASE WHEN $5::jsonb IS NULL THEN archived_at ELSE now() END, "
         "terminal_summary = COALESCE($5::jsonb, terminal_summary), updated_at = now() "
         "WHERE id = $1 AND account_id = $2 "
         "AND status NOT IN ('completed', 'errored', 'cancelled')",

--- a/src/aios/harness/reclaimable_prune.py
+++ b/src/aios/harness/reclaimable_prune.py
@@ -37,16 +37,22 @@ log = get_logger("aios.harness.reclaimable_prune")
 
 
 class PruneResult(NamedTuple):
-    """Per-sweep tally of reclaimed rows (0s when the kill-switch is off)."""
+    """Per-sweep tally and any families whose result could not be determined."""
 
     runs: int
     agents: int
     workflows: int
     skills: int
+    failed_families: tuple[str, ...] = ()
 
     @property
     def total(self) -> int:
         return self.runs + self.agents + self.workflows + self.skills
+
+    @property
+    def degraded(self) -> bool:
+        """Whether at least one family failed, making the tally incomplete."""
+        return bool(self.failed_families)
 
 
 async def _prune_one_family(
@@ -54,26 +60,26 @@ async def _prune_one_family(
     *,
     family: str,
     prune: Callable[[asyncpg.Connection[Any]], Awaitable[int]],
-) -> int:
-    """Run one family's prune in its OWN connection + try/except; 0 on failure.
+) -> tuple[int, bool]:
+    """Run one family's prune in its OWN connection; return count and success.
 
     Each family is isolated so one family's failure cannot silently disable the
     others (the silent-failure mode the sweep is designed against): a raised
     ``ForeignKeyViolationError`` — e.g. a not-yet-guarded reference pinning an
     archived definition — must not skip the families that follow it. We log the
     per-family failure at ``exception`` level (so it is visible, never swallowed
-    into a bare ``tick_failed``) and continue the sweep, returning 0 for that
-    family this tick. The next sweep retries it.
+    into a bare ``tick_failed``) and continue the sweep, returning a zero count
+    plus a failed status for that family. The next sweep retries it.
 
     A fresh connection per family means a family's aborted transaction can never
     poison a sibling's connection state.
     """
     try:
         async with pool.acquire() as conn:
-            return await prune(conn)
+            return await prune(conn), True
     except Exception:
         log.exception("reclaimable_prune.family_failed", family=family)
-        return 0
+        return 0, False
 
 
 async def sweep_reclaimable_ephemera(pool: asyncpg.Pool[Any]) -> PruneResult:
@@ -84,8 +90,9 @@ async def sweep_reclaimable_ephemera(pool: asyncpg.Pool[Any]) -> PruneResult:
     connection and its own ``try/except``, so a failure on one family (a raise or
     a transient error) neither rolls back another's reclaim NOR aborts the rest
     of the sweep — the failing family logs and is skipped this tick (counted 0),
-    the others still run. Idempotent: a second sweep over an already-pruned
-    window deletes nothing further.
+    the others still run, and ``failed_families``/``degraded`` marks the returned
+    tally as incomplete. Idempotent: a second sweep over an already-pruned window
+    deletes nothing further.
     """
     settings = get_settings()
     if not settings.reclaimable_prune_enabled:
@@ -100,7 +107,9 @@ async def sweep_reclaimable_ephemera(pool: asyncpg.Pool[Any]) -> PruneResult:
     # correctness (each prune re-reads liveness), only for promptness. Each
     # family is independently isolated, so a failure mid-sweep does not skip the
     # families that follow.
-    await _prune_one_family(
+    failed_families: list[str] = []
+
+    _, archival_ok = await _prune_one_family(
         pool,
         family="runs_archival",
         prune=lambda c: queries.reconcile_terminal_archival_batch(
@@ -109,7 +118,10 @@ async def sweep_reclaimable_ephemera(pool: asyncpg.Pool[Any]) -> PruneResult:
             row_limit=settings.reclaimable_prune_batch_rows,
         ),
     )
-    runs = await _prune_one_family(
+    if not archival_ok:
+        failed_families.append("runs_archival")
+
+    runs, runs_ok = await _prune_one_family(
         pool,
         family="runs",
         prune=lambda c: queries.prune_archived_runs(
@@ -118,23 +130,40 @@ async def sweep_reclaimable_ephemera(pool: asyncpg.Pool[Any]) -> PruneResult:
             row_limit=settings.reclaimable_prune_batch_rows,
         ),
     )
-    agents = await _prune_one_family(
+    if not runs_ok:
+        failed_families.append("runs")
+
+    agents, agents_ok = await _prune_one_family(
         pool,
         family="agents",
         prune=lambda c: queries.prune_unpinned_archived_agents(c, retention_days=def_days),
     )
-    workflows = await _prune_one_family(
+    if not agents_ok:
+        failed_families.append("agents")
+
+    workflows, workflows_ok = await _prune_one_family(
         pool,
         family="workflows",
         prune=lambda c: queries.prune_unpinned_archived_workflows(c, retention_days=def_days),
     )
-    skills = await _prune_one_family(
+    if not workflows_ok:
+        failed_families.append("workflows")
+
+    skills, skills_ok = await _prune_one_family(
         pool,
         family="skills",
         prune=lambda c: queries.prune_unpinned_archived_skills(c, retention_days=def_days),
     )
+    if not skills_ok:
+        failed_families.append("skills")
 
-    result = PruneResult(runs=runs, agents=agents, workflows=workflows, skills=skills)
+    result = PruneResult(
+        runs=runs,
+        agents=agents,
+        workflows=workflows,
+        skills=skills,
+        failed_families=tuple(failed_families),
+    )
     if result.total:
         log.info(
             "reclaimable_prune.swept",
@@ -142,6 +171,8 @@ async def sweep_reclaimable_ephemera(pool: asyncpg.Pool[Any]) -> PruneResult:
             agents=result.agents,
             workflows=result.workflows,
             skills=result.skills,
+            degraded=result.degraded,
+            failed_families=result.failed_families,
             wf_runs_retention_days=run_days,
             archived_definition_retention_days=def_days,
         )

--- a/src/aios/harness/reclaimable_prune.py
+++ b/src/aios/harness/reclaimable_prune.py
@@ -164,7 +164,9 @@ async def sweep_reclaimable_ephemera(pool: asyncpg.Pool[Any]) -> PruneResult:
         skills=skills,
         failed_families=tuple(failed_families),
     )
-    if result.total:
+    # Emit degraded zero-count sweeps too: otherwise an all-family failure is
+    # represented in the return value but disappears from the aggregate event.
+    if result.total or result.degraded:
         log.info(
             "reclaimable_prune.swept",
             runs=result.runs,

--- a/src/aios/harness/reclaimable_prune.py
+++ b/src/aios/harness/reclaimable_prune.py
@@ -100,14 +100,15 @@ async def sweep_reclaimable_ephemera(pool: asyncpg.Pool[Any]) -> PruneResult:
     # correctness (each prune re-reads liveness), only for promptness. Each
     # family is independently isolated, so a failure mid-sweep does not skip the
     # families that follow.
-    if settings.reclaimable_prune_archival_backfill_enabled:
-        await _prune_one_family(
-            pool,
-            family="runs_archival_backfill",
-            prune=lambda c: queries.reconcile_terminal_archival_batch(
-                c, row_limit=settings.reclaimable_prune_batch_rows
-            ),
-        )
+    await _prune_one_family(
+        pool,
+        family="runs_archival",
+        prune=lambda c: queries.reconcile_terminal_archival_batch(
+            c,
+            grace_days=settings.wf_runs_archive_grace_days,
+            row_limit=settings.reclaimable_prune_batch_rows,
+        ),
+    )
     runs = await _prune_one_family(
         pool,
         family="runs",

--- a/tests/integration/test_reclaimable_prune.py
+++ b/tests/integration/test_reclaimable_prune.py
@@ -99,8 +99,7 @@ async def _make_archived_run(
         account_id="acc_root",
         terminal_summary={"is_error": False},
     )
-    # ``set_run_terminal`` now atomically archives terminal runs; the helper's
-    # former explicit ``archive_run`` call became stale and correctly conflicts.
+    await wf_queries.archive_run(conn, run.id, account_id="acc_root")
     # Back-date archived_at so it is past the retention window.
     await conn.execute(
         "UPDATE wf_runs SET archived_at = now() - make_interval(days => $2) WHERE id = $1",
@@ -253,6 +252,66 @@ async def test_run_prune_is_idempotent(conn: asyncpg.Connection[Any]) -> None:
     second = await prune_archived_runs(conn, retention_days=30)
     assert first == 2
     assert second == 0
+
+
+async def test_terminal_archival_respects_grace_window_and_is_idempotent(
+    conn: asyncpg.Connection[Any],
+) -> None:
+    workflow = await wf_queries.insert_workflow(
+        conn, account_id="acc_root", name="archive_grace", script="x"
+    )
+    old = await wf_queries.insert_wf_run(
+        conn,
+        account_id="acc_root",
+        workflow_id=workflow.id,
+        environment_id="env_root",
+        script="x",
+        host_semantics_epoch=HOST_SEMANTICS_EPOCH,
+        script_sha="old",
+        depth=10,
+    )
+    young = await wf_queries.insert_wf_run(
+        conn,
+        account_id="acc_root",
+        workflow_id=workflow.id,
+        environment_id="env_root",
+        script="x",
+        host_semantics_epoch=HOST_SEMANTICS_EPOCH,
+        script_sha="young",
+        depth=10,
+    )
+    for run in (old, young):
+        await wf_queries.set_run_terminal(
+            conn,
+            run.id,
+            status="completed",
+            output=None,
+            account_id="acc_root",
+            terminal_summary={"is_error": False},
+        )
+    await conn.execute(
+        "UPDATE wf_runs SET updated_at=now() - interval '8 days' WHERE id=$1", old.id
+    )
+
+    assert await reconcile_terminal_archival_batch(conn, grace_days=7) == 1
+    assert await conn.fetchval("SELECT archived_at FROM wf_runs WHERE id=$1", old.id) is not None
+    assert await conn.fetchval("SELECT archived_at FROM wf_runs WHERE id=$1", young.id) is None
+    assert await reconcile_terminal_archival_batch(conn, grace_days=7) == 0
+
+
+async def test_run_signal_detail_is_pruned_with_events(
+    conn: asyncpg.Connection[Any],
+) -> None:
+    run_id = await _make_archived_run(conn, archived_age_days=60)
+    await conn.execute(
+        "INSERT INTO wf_run_signals (run_id, call_key, kind, result) "
+        "VALUES ($1, 'cancel', 'cancel', '{}'::jsonb)",
+        run_id,
+    )
+
+    assert await prune_archived_runs(conn, retention_days=30) == 3
+    assert await _count(conn, "wf_run_events", "run_id", run_id) == 0
+    assert await _count(conn, "wf_run_signals", "run_id", run_id) == 0
 
 
 async def test_archived_legacy_run_is_backfilled_before_detail_prune(

--- a/tests/integration/test_reclaimable_prune.py
+++ b/tests/integration/test_reclaimable_prune.py
@@ -643,6 +643,8 @@ async def test_sweep_one_family_raise_does_not_disable_the_others(
     assert result.runs == 2  # both child-detail rows were pruned
     assert result.workflows == 1
     assert result.skills == 1
+    assert result.degraded
+    assert result.failed_families == ("agents",)
 
     async with pool.acquire() as conn:
         assert await _count(conn, "wf_runs", "id", run_id) == 1

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -479,10 +479,10 @@ async def test_terminal_run_and_double_resume_are_noops(wf_runtime: asyncpg.Pool
     assert await _events(pool, run_id) == before  # journal unchanged
 
 
-async def test_terminal_run_archives_unconditionally_with_no_caller_lifetime_override(
+async def test_terminal_run_remains_visible_during_archive_grace_window(
     wf_runtime: asyncpg.Pool[Any],
 ) -> None:
-    """Every terminal run archives; callers have no run-lifetime flag that can prevent it."""
+    """Terminal archival is maintenance-driven; suspended runs remain ineligible."""
     assert "auto_archive_on_completion" not in inspect.signature(service.create_run).parameters
     pool = wf_runtime
     terminal_id = await _make_run(pool, "def main(input):\n    return 'done'", name="prunable")
@@ -495,7 +495,7 @@ async def test_terminal_run_archives_unconditionally_with_no_caller_lifetime_ove
         terminal = await wf_queries.get_wf_run(conn, terminal_id, account_id="acc_wf")
         live = await wf_queries.get_wf_run(conn, live_id, account_id="acc_wf")
         assert terminal is not None and terminal.status in {"completed", "errored", "cancelled"}
-        assert terminal.archived_at is not None
+        assert terminal.archived_at is None
         assert live is not None and live.status == "suspended"
         assert live.archived_at is None
 

--- a/tests/unit/db/test_run_journal_prune.py
+++ b/tests/unit/db/test_run_journal_prune.py
@@ -1,0 +1,123 @@
+"""Database-free behavioural tests for run-journal deletion eligibility."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from aios.db.queries.prune import prune_archived_runs
+
+
+@dataclass
+class _Run:
+    archived_age_days: int | None
+    status: str
+    has_summary: bool
+    journal_pruned: bool = False
+    events: int = 1
+    signals: int = 0
+
+
+class _PruneConnection:
+    """Small executable model of the wf_runs predicates used by the prune SQL.
+
+    Unlike an AsyncMock SQL-string assertion, this lets the negative fixtures flow
+    through the real prune control flow. Omitting a predicate from either query
+    omits it from this model too, making guard-removal mutations observable.
+    """
+
+    def __init__(self, runs: dict[str, _Run], *, mutate_after_fetch: bool = False) -> None:
+        self.runs = runs
+        self.mutate_after_fetch = mutate_after_fetch
+        self.candidates: list[str] = []
+        self.delete_attempts: list[str] = []
+
+    @staticmethod
+    def _eligible(sql: str, run: _Run, retention_days: int) -> bool:
+        checks = (
+            ("archived_at IS NOT NULL", run.archived_age_days is not None),
+            (
+                "archived_at < now() - make_interval(days => $1)",
+                run.archived_age_days is not None
+                and run.archived_age_days > retention_days,
+            ),
+            ("terminal_summary IS NOT NULL", run.has_summary),
+            ("journal_pruned_at IS NULL", not run.journal_pruned),
+            (
+                "status IN ('completed','errored','cancelled')",
+                run.status in {"completed", "errored", "cancelled"},
+            ),
+        )
+        return all(value for predicate, value in checks if predicate in sql)
+
+    async def fetch(self, sql: str, retention_days: int, row_limit: int) -> list[dict[str, str]]:
+        self.candidates = [
+            run_id
+            for run_id, run in self.runs.items()
+            if self._eligible(sql, run, retention_days)
+        ][:row_limit]
+        if self.mutate_after_fetch:
+            # Model rows becoming unsafe between candidate selection and child DELETE.
+            self.runs[self.candidates[0]].archived_age_days = None
+            self.runs[self.candidates[1]].status = "running"
+            self.runs[self.candidates[2]].archived_age_days = 1
+            self.runs[self.candidates[3]].has_summary = False
+        return [{"id": run_id} for run_id in self.candidates]
+
+    async def execute(self, sql: str, *args: Any) -> str:
+        if sql.startswith("DELETE"):
+            run_id, retention_days, row_limit = args
+            self.delete_attempts.append(run_id)
+            run = self.runs[run_id]
+            # DELETE uses $2 for retention, while the candidate query uses $1.
+            normalized_sql = sql.replace("days => $2", "days => $1")
+            deleted = 0
+            if self._eligible(normalized_sql, run, retention_days):
+                field = "events" if "wf_run_events" in sql else "signals"
+                deleted = min(getattr(run, field), row_limit)
+                setattr(run, field, getattr(run, field) - deleted)
+            return f"DELETE {deleted}"
+        return "UPDATE 1"
+
+    async def fetchval(self, _sql: str, run_id: str) -> bool:
+        run = self.runs[run_id]
+        return bool(run.events or run.signals)
+
+
+def _unsafe_runs() -> dict[str, _Run]:
+    return {
+        "not-archived": _Run(None, "completed", True),
+        "not-terminal": _Run(90, "running", True),
+        "too-young": _Run(1, "completed", True),
+        "summary-less": _Run(90, "completed", False),
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_journal_prune_refuses_each_ineligible_run_without_postgres() -> None:
+    runs = {**_unsafe_runs(), "eligible": _Run(90, "completed", True)}
+    conn = _PruneConnection(runs)
+
+    assert await prune_archived_runs(conn, retention_days=30) == 1
+
+    assert conn.candidates == ["eligible"]
+    assert all(runs[run_id].events == 1 for run_id in _unsafe_runs())
+    assert runs["eligible"].events == 0
+
+
+@pytest.mark.asyncio
+async def test_child_delete_rechecks_eligibility_if_candidates_become_unsafe() -> None:
+    runs = {
+        "becomes-unarchived": _Run(90, "completed", True),
+        "becomes-running": _Run(90, "completed", True),
+        "becomes-young": _Run(90, "completed", True),
+        "loses-summary": _Run(90, "completed", True),
+    }
+    conn = _PruneConnection(runs, mutate_after_fetch=True)
+
+    assert await prune_archived_runs(conn, retention_days=30) == 0
+
+    assert set(conn.delete_attempts) == set(runs)
+    assert all(run.events == 1 for run in runs.values())

--- a/tests/unit/db/test_run_journal_prune.py
+++ b/tests/unit/db/test_run_journal_prune.py
@@ -40,8 +40,7 @@ class _PruneConnection:
             ("archived_at IS NOT NULL", run.archived_age_days is not None),
             (
                 "archived_at < now() - make_interval(days => $1)",
-                run.archived_age_days is not None
-                and run.archived_age_days > retention_days,
+                run.archived_age_days is not None and run.archived_age_days > retention_days,
             ),
             ("terminal_summary IS NOT NULL", run.has_summary),
             ("journal_pruned_at IS NULL", not run.journal_pruned),
@@ -54,9 +53,7 @@ class _PruneConnection:
 
     async def fetch(self, sql: str, retention_days: int, row_limit: int) -> list[dict[str, str]]:
         self.candidates = [
-            run_id
-            for run_id, run in self.runs.items()
-            if self._eligible(sql, run, retention_days)
+            run_id for run_id, run in self.runs.items() if self._eligible(sql, run, retention_days)
         ][:row_limit]
         if self.mutate_after_fetch:
             # Model rows becoming unsafe between candidate selection and child DELETE.

--- a/tests/unit/db/test_terminal_run_archival.py
+++ b/tests/unit/db/test_terminal_run_archival.py
@@ -1,0 +1,25 @@
+"""Terminal workflow runs are automatically archived only after their grace window."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.db.queries.prune import reconcile_terminal_archival_batch
+
+
+@pytest.mark.asyncio
+async def test_terminal_archival_is_bounded_aged_and_idempotent() -> None:
+    conn = AsyncMock()
+    conn.execute.return_value = "UPDATE 17"
+
+    count = await reconcile_terminal_archival_batch(conn, grace_days=7, row_limit=123)
+
+    assert count == 17
+    sql, grace_days, row_limit = conn.execute.await_args.args
+    assert "r.updated_at < now() - make_interval(days => $1)" in sql
+    assert "SET archived_at = COALESCE(r.archived_at, now())" in sql
+    assert "r.archived_at IS NULL" in sql
+    assert "LIMIT $2" in sql
+    assert (grace_days, row_limit) == (7, 123)

--- a/tests/unit/test_reclaimable_prune.py
+++ b/tests/unit/test_reclaimable_prune.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from aios.harness import reclaimable_prune
+
+
+@pytest.mark.asyncio
+async def test_archival_feeder_failure_degrades_sweep_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SimpleNamespace(
+        reclaimable_prune_enabled=True,
+        wf_runs_retention_days=30,
+        archived_definition_retention_days=30,
+        wf_runs_archive_grace_days=7,
+        reclaimable_prune_batch_rows=100,
+    )
+    monkeypatch.setattr(reclaimable_prune, "get_settings", lambda: settings)
+
+    @asynccontextmanager
+    async def acquire() -> Any:
+        yield object()
+
+    pool = SimpleNamespace(acquire=acquire)
+    calls: list[str] = []
+
+    async def fail_archival(*_args: Any, **_kwargs: Any) -> int:
+        calls.append("runs_archival")
+        raise RuntimeError("archival feeder unavailable")
+
+    def successful(family: str, count: int) -> Any:
+        async def prune(*_args: Any, **_kwargs: Any) -> int:
+            calls.append(family)
+            return count
+
+        return prune
+
+    monkeypatch.setattr(
+        reclaimable_prune.queries, "reconcile_terminal_archival_batch", fail_archival
+    )
+    monkeypatch.setattr(reclaimable_prune.queries, "prune_archived_runs", successful("runs", 2))
+    monkeypatch.setattr(
+        reclaimable_prune.queries,
+        "prune_unpinned_archived_agents",
+        successful("agents", 3),
+    )
+    monkeypatch.setattr(
+        reclaimable_prune.queries,
+        "prune_unpinned_archived_workflows",
+        successful("workflows", 5),
+    )
+    monkeypatch.setattr(
+        reclaimable_prune.queries,
+        "prune_unpinned_archived_skills",
+        successful("skills", 7),
+    )
+
+    result = await reclaimable_prune.sweep_reclaimable_ephemera(pool)
+
+    assert calls == ["runs_archival", "runs", "agents", "workflows", "skills"]
+    assert result.total == 17
+    assert result.degraded
+    assert result.failed_families == ("runs_archival",)

--- a/tests/unit/test_reclaimable_prune.py
+++ b/tests/unit/test_reclaimable_prune.py
@@ -65,3 +65,4 @@ async def test_archival_feeder_failure_degrades_sweep_result(
     assert result.total == 17
     assert result.degraded
     assert result.failed_families == ("runs_archival",)
+    assert result != reclaimable_prune.PruneResult(2, 3, 5, 7)

--- a/tests/unit/test_reclaimable_prune.py
+++ b/tests/unit/test_reclaimable_prune.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from aios.db import queries
 from aios.harness import reclaimable_prune
 
 
@@ -40,22 +41,20 @@ async def test_archival_feeder_failure_degrades_sweep_result(
 
         return prune
 
+    monkeypatch.setattr(queries, "reconcile_terminal_archival_batch", fail_archival)
+    monkeypatch.setattr(queries, "prune_archived_runs", successful("runs", 2))
     monkeypatch.setattr(
-        reclaimable_prune.queries, "reconcile_terminal_archival_batch", fail_archival
-    )
-    monkeypatch.setattr(reclaimable_prune.queries, "prune_archived_runs", successful("runs", 2))
-    monkeypatch.setattr(
-        reclaimable_prune.queries,
+        queries,
         "prune_unpinned_archived_agents",
         successful("agents", 3),
     )
     monkeypatch.setattr(
-        reclaimable_prune.queries,
+        queries,
         "prune_unpinned_archived_workflows",
         successful("workflows", 5),
     )
     monkeypatch.setattr(
-        reclaimable_prune.queries,
+        queries,
         "prune_unpinned_archived_skills",
         successful("skills", 7),
     )

--- a/tests/unit/test_reclaimable_prune.py
+++ b/tests/unit/test_reclaimable_prune.py
@@ -62,6 +62,13 @@ async def test_archival_feeder_failure_degrades_sweep_result(
     result = await reclaimable_prune.sweep_reclaimable_ephemera(pool)
 
     assert calls == ["runs_archival", "runs", "agents", "workflows", "skills"]
+    assert result == reclaimable_prune.PruneResult(
+        runs=2,
+        agents=3,
+        workflows=5,
+        skills=7,
+        failed_families=("runs_archival",),
+    )
     assert result.total == 17
     assert result.degraded
     assert result.failed_families == ("runs_archival",)


### PR DESCRIPTION
Automated dev-pipeline build for issue #2217.