### PR TITLE
Add GET /v1/sessions?view=lite&ids= for cheap roster reads

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1714,7 +1714,7 @@
           "sessions"
         ],
         "summary": "List ",
-        "description": "List sessions, newest first, keyset-paginated.\n\nSoft-archived sessions are hidden by default. Two filters surface them so a\nworkflow run's spent ``agent()`` children stay enumerable with their terminal\nstatus and token usage (#831): ``?parent_run_id=`` lists a run's children\n(alive or archived), and ``?status=archived`` lists the terminal ones. Each\nrow carries the derived ``status`` ({active, idle, archived}) and cumulative\n``usage``.",
+        "description": "List sessions, newest first, keyset-paginated.\n\nSoft-archived sessions are hidden by default. Two filters surface them so a\nworkflow run's spent ``agent()`` children stay enumerable with their terminal\nstatus and token usage (#831): ``?parent_run_id=`` lists a run's children\n(alive or archived), and ``?status=archived`` lists the terminal ones. Each\nrow carries the derived ``status`` ({active, idle, archived}) and cumulative\n``usage``.\n\n``view=lite`` skips vaults / resource echoes / triggers / obligations and\nstill returns ``id``, derived ``status``, ``last_event_at``, and\n``awaiting`` \u2014 the cheap path for a roster that already knows its session\nids. ``ids=`` restricts the page to those session ids (account-scoped).",
         "operationId": "list_sessions",
         "parameters": [
           {
@@ -1802,6 +1802,45 @@
                 }
               ],
               "title": "Limit"
+            }
+          },
+          {
+            "name": "ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Ids"
+            }
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "full",
+                    "lite"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "View"
             }
           },
           {

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_sessions.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_sessions.py
@@ -8,6 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
 from ...models.list_response_session import ListResponseSession
 from ...models.list_sessions_status_type_0 import ListSessionsStatusType0
+from ...models.list_sessions_view_type_0 import ListSessionsViewType0
 from ...types import UNSET, Response, Unset
 
 
@@ -18,6 +19,8 @@ def _get_kwargs(
     status: ListSessionsStatusType0 | None | Unset = UNSET,
     parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
+    ids: list[str] | None | Unset = UNSET,
+    view: ListSessionsViewType0 | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
@@ -62,6 +65,25 @@ def _get_kwargs(
     else:
         json_limit = limit
     params["limit"] = json_limit
+
+    json_ids: list[str] | None | Unset
+    if isinstance(ids, Unset):
+        json_ids = UNSET
+    elif isinstance(ids, list):
+        json_ids = ids
+
+    else:
+        json_ids = ids
+    params["ids"] = json_ids
+
+    json_view: None | str | Unset
+    if isinstance(view, Unset):
+        json_view = UNSET
+    elif isinstance(view, ListSessionsViewType0):
+        json_view = view.value
+    else:
+        json_view = view
+    params["view"] = json_view
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -113,6 +135,8 @@ def sync_detailed(
     status: ListSessionsStatusType0 | None | Unset = UNSET,
     parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
+    ids: list[str] | None | Unset = UNSET,
+    view: ListSessionsViewType0 | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseSession]:
     """List
@@ -126,12 +150,19 @@ def sync_detailed(
     row carries the derived ``status`` ({active, idle, archived}) and cumulative
     ``usage``.
 
+    ``view=lite`` skips vaults / resource echoes / triggers / obligations and
+    still returns ``id``, derived ``status``, ``last_event_at``, and
+    ``awaiting`` — the cheap path for a roster that already knows its session
+    ids. ``ids=`` restricts the page to those session ids (account-scoped).
+
     Args:
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
         status (ListSessionsStatusType0 | None | Unset):
         parent_run_id (None | str | Unset):
         limit (int | None | Unset):
+        ids (list[str] | None | Unset):
+        view (ListSessionsViewType0 | None | Unset):
         authorization (None | str | Unset):
 
     Raises:
@@ -148,6 +179,8 @@ def sync_detailed(
         status=status,
         parent_run_id=parent_run_id,
         limit=limit,
+        ids=ids,
+        view=view,
         authorization=authorization,
     )
 
@@ -166,6 +199,8 @@ def sync(
     status: ListSessionsStatusType0 | None | Unset = UNSET,
     parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
+    ids: list[str] | None | Unset = UNSET,
+    view: ListSessionsViewType0 | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseSession | None:
     """List
@@ -179,12 +214,19 @@ def sync(
     row carries the derived ``status`` ({active, idle, archived}) and cumulative
     ``usage``.
 
+    ``view=lite`` skips vaults / resource echoes / triggers / obligations and
+    still returns ``id``, derived ``status``, ``last_event_at``, and
+    ``awaiting`` — the cheap path for a roster that already knows its session
+    ids. ``ids=`` restricts the page to those session ids (account-scoped).
+
     Args:
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
         status (ListSessionsStatusType0 | None | Unset):
         parent_run_id (None | str | Unset):
         limit (int | None | Unset):
+        ids (list[str] | None | Unset):
+        view (ListSessionsViewType0 | None | Unset):
         authorization (None | str | Unset):
 
     Raises:
@@ -202,6 +244,8 @@ def sync(
         status=status,
         parent_run_id=parent_run_id,
         limit=limit,
+        ids=ids,
+        view=view,
         authorization=authorization,
     ).parsed
 
@@ -214,6 +258,8 @@ async def asyncio_detailed(
     status: ListSessionsStatusType0 | None | Unset = UNSET,
     parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
+    ids: list[str] | None | Unset = UNSET,
+    view: ListSessionsViewType0 | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseSession]:
     """List
@@ -227,12 +273,19 @@ async def asyncio_detailed(
     row carries the derived ``status`` ({active, idle, archived}) and cumulative
     ``usage``.
 
+    ``view=lite`` skips vaults / resource echoes / triggers / obligations and
+    still returns ``id``, derived ``status``, ``last_event_at``, and
+    ``awaiting`` — the cheap path for a roster that already knows its session
+    ids. ``ids=`` restricts the page to those session ids (account-scoped).
+
     Args:
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
         status (ListSessionsStatusType0 | None | Unset):
         parent_run_id (None | str | Unset):
         limit (int | None | Unset):
+        ids (list[str] | None | Unset):
+        view (ListSessionsViewType0 | None | Unset):
         authorization (None | str | Unset):
 
     Raises:
@@ -249,6 +302,8 @@ async def asyncio_detailed(
         status=status,
         parent_run_id=parent_run_id,
         limit=limit,
+        ids=ids,
+        view=view,
         authorization=authorization,
     )
 
@@ -265,6 +320,8 @@ async def asyncio(
     status: ListSessionsStatusType0 | None | Unset = UNSET,
     parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
+    ids: list[str] | None | Unset = UNSET,
+    view: ListSessionsViewType0 | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseSession | None:
     """List
@@ -278,12 +335,19 @@ async def asyncio(
     row carries the derived ``status`` ({active, idle, archived}) and cumulative
     ``usage``.
 
+    ``view=lite`` skips vaults / resource echoes / triggers / obligations and
+    still returns ``id``, derived ``status``, ``last_event_at``, and
+    ``awaiting`` — the cheap path for a roster that already knows its session
+    ids. ``ids=`` restricts the page to those session ids (account-scoped).
+
     Args:
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
         status (ListSessionsStatusType0 | None | Unset):
         parent_run_id (None | str | Unset):
         limit (int | None | Unset):
+        ids (list[str] | None | Unset):
+        view (ListSessionsViewType0 | None | Unset):
         authorization (None | str | Unset):
 
     Raises:
@@ -302,6 +366,8 @@ async def asyncio(
             status=status,
             parent_run_id=parent_run_id,
             limit=limit,
+            ids=ids,
+            view=view,
             authorization=authorization,
         )
     ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -131,6 +131,7 @@ from .list_session_events_chat_type_type_0 import ListSessionEventsChatTypeType0
 from .list_session_events_dir import ListSessionEventsDir
 from .list_session_events_kind_type_0 import ListSessionEventsKindType0
 from .list_sessions_status_type_0 import ListSessionsStatusType0
+from .list_sessions_view_type_0 import ListSessionsViewType0
 from .mcp_permission_policy import McpPermissionPolicy
 from .mcp_permission_policy_type import McpPermissionPolicyType
 from .mcp_server_spec import McpServerSpec
@@ -476,6 +477,7 @@ __all__ = (
     "ListSessionEventsDir",
     "ListSessionEventsKindType0",
     "ListSessionsStatusType0",
+    "ListSessionsViewType0",
     "McpPermissionPolicy",
     "McpPermissionPolicyType",
     "McpServerSpec",

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_view_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_view_type_0.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ListSessionsViewType0(str, Enum):
+    FULL = "full"
+    LITE = "lite"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -12,7 +12,7 @@ Postgres ``LISTEN``/``NOTIFY``.
 from __future__ import annotations
 
 import asyncio
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, File, Query, UploadFile, status
 from sse_starlette import EventSourceResponse
@@ -136,6 +136,8 @@ async def list_(
     ] = None,
     parent_run_id: str | None = None,
     limit: PageLimit = None,
+    ids: Annotated[list[str] | None, Query()] = None,
+    view: Literal["full", "lite"] | None = None,
 ) -> ListResponse[Session]:
     """List sessions, newest first, keyset-paginated.
 
@@ -145,7 +147,19 @@ async def list_(
     (alive or archived), and ``?status=archived`` lists the terminal ones. Each
     row carries the derived ``status`` ({active, idle, archived}) and cumulative
     ``usage``.
+
+    ``view=lite`` skips vaults / resource echoes / triggers / obligations and
+    still returns ``id``, derived ``status``, ``last_event_at``, and
+    ``awaiting`` — the cheap path for a roster that already knows its session
+    ids. ``ids=`` restricts the page to those session ids (account-scoped).
     """
+    if ids is not None:
+        ids = [i for i in ids if i]
+        if len(ids) > MAX_PAGE_LIMIT:
+            raise ValidationError(
+                f"ids exceeds {MAX_PAGE_LIMIT} entries",
+                detail={"max": MAX_PAGE_LIMIT, "got": len(ids)},
+            )
     st = page_cursor(
         cursor,
         {
@@ -153,6 +167,8 @@ async def list_(
             "status": status_filter,
             "parent_run_id": parent_run_id,
             "limit": limit,
+            "ids": ids,
+            "view": view,
         },
     )
     after = str(st.cursor) if st is not None else None
@@ -161,6 +177,9 @@ async def list_(
         agent_id = st.filters.get("agent_id")
         status_filter = st.filters.get("status")
         parent_run_id = st.filters.get("parent_run_id")
+        ids = st.filters.get("ids")
+        view = st.filters.get("view")
+    effective_view: Literal["full", "lite"] = view if view in ("full", "lite") else "full"
     items = await service.list_sessions(
         pool,
         agent_id=agent_id,
@@ -169,12 +188,20 @@ async def list_(
         limit=page_limit + 1,
         after=after,
         account_id=account_id,
+        ids=ids,
+        view=effective_view,
     )
     return ListResponse[Session].paginate(
         items,
         page_limit,
         cursor=lambda x: x.id,
-        filters={"agent_id": agent_id, "status": status_filter, "parent_run_id": parent_run_id},
+        filters={
+            "agent_id": agent_id,
+            "status": status_filter,
+            "parent_run_id": parent_run_id,
+            "ids": ids,
+            "view": effective_view if effective_view != "full" else None,
+        },
     )
 
 

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -68,6 +68,7 @@ async def _list_scoped[T](
     filters: list[tuple[str, Any]] | None = None,
     extra_select: str | None = None,
     include_archived: bool = False,
+    ids: list[str] | None = None,
 ) -> list[T]:
     """Keyset-paginated SELECT scoped by ``account_id`` (+ ``archived_at IS NULL``
     unless ``include_archived``).
@@ -86,6 +87,9 @@ async def _list_scoped[T](
     ``agent()`` children (#831). The default keeps every other resource listing
     archive-blind, as before.
 
+    ``ids`` is an optional ``id = ANY($n)`` filter (static column, values
+    parameterized). An empty list is a deliberate empty result — no query.
+
     Readability note: the ``archived_at`` this toggles on a run's ``agent()``
     CHILD SESSIONS is a different concept from ``wf_runs.archived_at`` (set by
     ``archive_run``). Same column name, two unrelated lifecycles: a child session
@@ -93,8 +97,13 @@ async def _list_scoped[T](
     post-mortem usage roll-up); a RUN is archived as its own terminal disposition
     (feeding #10's prune). Don't conflate "this run's children are archived" with
     "this run is archived"."""
+    if ids is not None and len(ids) == 0:
+        return []
     args: list[Any] = [account_id]
     where = ["account_id = $1"] if include_archived else ["archived_at IS NULL", "account_id = $1"]
+    if ids is not None:
+        args.append(list(ids))
+        where.append(f"id = ANY(${len(args)})")
     for column, value in filters or []:
         if value is None:
             continue

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -1463,6 +1463,7 @@ async def list_sessions(
     parent_run_id: str | None = None,
     limit: int = 50,
     after: str | None = None,
+    ids: list[str] | None = None,
 ) -> list[Session]:
     """Keyset-paginated session list with derived ``status`` ({active, idle}).
 
@@ -1510,6 +1511,7 @@ async def list_sessions(
             "(SELECT e.created_at FROM events e WHERE e.session_id = sessions.id "
             "ORDER BY e.seq DESC LIMIT 1) AS last_event_at"
         ),
+        ids=ids,
     )
 
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1289,8 +1289,15 @@ async def list_sessions(
     parent_run_id: str | None = None,
     limit: int = 50,
     after: str | None = None,
+    ids: list[str] | None = None,
+    view: Literal["full", "lite"] = "full",
 ) -> list[Session]:
     # See ``get_session`` for the rationale on the snapshot wrap.
+    # ``view=lite`` is the roster/status path: same rows + derived status /
+    # last_event_at / awaiting, but skip vaults, resource echoes, triggers,
+    # and obligations (those hydrate every account session on the full list).
+    if ids is not None and len(ids) == 0:
+        return []
     async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
         sessions = await queries.list_sessions(
             conn,
@@ -1300,16 +1307,27 @@ async def list_sessions(
             limit=limit,
             after=after,
             account_id=account_id,
+            ids=ids,
         )
         if not sessions:
             return sessions
-        sid_list = [s.id for s in sessions]
-        vault_map = await queries.batch_get_session_vault_ids(conn, sid_list, account_id=account_id)
-        echoes_map = await _batch_list_all_echoes(conn, sid_list, account_id=account_id)
-        trigger_map = await queries.batch_list_session_triggers(
-            conn, sid_list, account_id=account_id
-        )
+        if view == "lite":
+            vault_map = None
+            echoes_map = None
+            trigger_map = None
+        else:
+            sid_list = [s.id for s in sessions]
+            vault_map = await queries.batch_get_session_vault_ids(
+                conn, sid_list, account_id=account_id
+            )
+            echoes_map = await _batch_list_all_echoes(conn, sid_list, account_id=account_id)
+            trigger_map = await queries.batch_list_session_triggers(
+                conn, sid_list, account_id=account_id
+            )
     awaiting_by_sid = await compute_awaiting(pool, sessions, account_id=account_id)
+    if view == "lite":
+        return [s.model_copy(update={"awaiting": awaiting_by_sid.get(s.id, [])}) for s in sessions]
+    assert vault_map is not None and echoes_map is not None and trigger_map is not None
     obligations_by_sid = await compute_obligations(pool, sessions, account_id=account_id)
     enriched: list[Session] = [
         s.model_copy(

--- a/tests/unit/test_list_sessions_lite.py
+++ b/tests/unit/test_list_sessions_lite.py
@@ -1,0 +1,195 @@
+"""``GET /v1/sessions?view=lite&ids=`` skips fat hydration (vaults/echoes/triggers/obligations)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aios.db.queries import sessions as session_queries
+from aios.models.sessions import AwaitingToolCall, Session
+from aios.services import sessions as sessions_service
+
+
+class _CapturingConn:
+    def __init__(self) -> None:
+        self.sql: str | None = None
+        self.args: tuple[Any, ...] = ()
+        self.fetched = False
+
+    async def fetch(self, sql: str, *args: Any) -> list[Any]:
+        self.sql = sql
+        self.args = args
+        self.fetched = True
+        return []
+
+
+def _session(sid: str = "sess_1") -> Session:
+    return Session(
+        id=sid,
+        agent_id="agt_1",
+        environment_id="env_1",
+        agent_version=1,
+        title=None,
+        metadata={},
+        status="idle",
+        stop_reason=None,
+        last_event_seq=0,
+        created_at=datetime(2026, 8, 23, tzinfo=UTC),
+        updated_at=datetime(2026, 8, 23, tzinfo=UTC),
+        last_event_at=datetime(2026, 8, 23, 12, tzinfo=UTC),
+    )
+
+
+class _Txn:
+    async def __aenter__(self) -> Any:
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+    def transaction(self, **_: Any) -> _Txn:
+        return self
+
+
+class _Pool:
+    def acquire(self) -> _Txn:
+        return _Txn()
+
+
+class TestListSessionsIdsSql:
+    async def test_ids_emits_any_clause(self) -> None:
+        conn = _CapturingConn()
+        await session_queries.list_sessions(conn, account_id="acc_x", ids=["sess_1", "sess_2"])
+        assert conn.sql is not None
+        assert "id = ANY(" in conn.sql
+        assert ["sess_1", "sess_2"] in conn.args
+
+    async def test_empty_ids_skips_query(self) -> None:
+        conn = _CapturingConn()
+        rows = await session_queries.list_sessions(conn, account_id="acc_x", ids=[])
+        assert rows == []
+        assert conn.fetched is False
+
+    async def test_no_ids_omits_any_clause(self) -> None:
+        conn = _CapturingConn()
+        await session_queries.list_sessions(conn, account_id="acc_x")
+        assert conn.sql is not None
+        assert "id = ANY(" not in conn.sql
+
+
+class TestListSessionsLiteSkipsFatHydration:
+    async def test_lite_skips_vaults_echoes_triggers_obligations(self) -> None:
+        fat: list[str] = []
+        listed = [_session("sess_1")]
+
+        async def list_rows(*_: Any, **kwargs: Any) -> list[Session]:
+            assert kwargs.get("ids") == ["sess_1"]
+            return listed
+
+        async def trap_vaults(*_: Any, **__: Any) -> dict[str, list[str]]:
+            fat.append("vaults")
+            return {}
+
+        async def trap_echoes(*_: Any, **__: Any) -> dict[str, list[Any]]:
+            fat.append("echoes")
+            return {}
+
+        async def trap_triggers(*_: Any, **__: Any) -> dict[str, list[Any]]:
+            fat.append("triggers")
+            return {}
+
+        async def trap_obligations(*_: Any, **__: Any) -> dict[str, list[Any]]:
+            fat.append("obligations")
+            return {}
+
+        async def awaiting(*_: Any, **__: Any) -> dict[str, list[AwaitingToolCall]]:
+            return {
+                "sess_1": [
+                    AwaitingToolCall(
+                        tool_call_id="tc_1",
+                        name="ask_user",
+                        kind="custom",
+                        pending_since=datetime(2026, 8, 23, tzinfo=UTC),
+                    )
+                ]
+            }
+
+        with (
+            patch("aios.services.sessions.queries.list_sessions", list_rows),
+            patch("aios.services.sessions.queries.batch_get_session_vault_ids", trap_vaults),
+            patch("aios.services.sessions._batch_list_all_echoes", trap_echoes),
+            patch("aios.services.sessions.queries.batch_list_session_triggers", trap_triggers),
+            patch("aios.services.sessions.compute_awaiting", awaiting),
+            patch("aios.services.sessions.compute_obligations", trap_obligations),
+        ):
+            out = await sessions_service.list_sessions(
+                _Pool(),
+                account_id="acc_1",
+                ids=["sess_1"],
+                view="lite",
+            )
+
+        assert fat == []
+        assert len(out) == 1
+        assert out[0].id == "sess_1"
+        assert out[0].status == "idle"
+        assert out[0].last_event_at == datetime(2026, 8, 23, 12, tzinfo=UTC)
+        assert out[0].awaiting[0].kind == "custom"
+        assert out[0].vault_ids == []
+        assert out[0].resources == []
+        assert out[0].triggers == []
+        assert out[0].obligations == []
+
+    async def test_full_still_hydrates(self) -> None:
+        fat: list[str] = []
+
+        async def list_rows(*_: Any, **__: Any) -> list[Session]:
+            return [_session("sess_1")]
+
+        async def vaults(*_: Any, **__: Any) -> dict[str, list[str]]:
+            fat.append("vaults")
+            return {"sess_1": ["vlt_1"]}
+
+        async def echoes(*_: Any, **__: Any) -> dict[str, list[Any]]:
+            fat.append("echoes")
+            return {"sess_1": []}
+
+        async def triggers(*_: Any, **__: Any) -> dict[str, list[Any]]:
+            fat.append("triggers")
+            return {"sess_1": []}
+
+        async def obligations(*_: Any, **__: Any) -> dict[str, list[Any]]:
+            fat.append("obligations")
+            return {"sess_1": []}
+
+        async def awaiting(*_: Any, **__: Any) -> dict[str, list[Any]]:
+            return {}
+
+        with (
+            patch("aios.services.sessions.queries.list_sessions", list_rows),
+            patch("aios.services.sessions.queries.batch_get_session_vault_ids", vaults),
+            patch("aios.services.sessions._batch_list_all_echoes", echoes),
+            patch("aios.services.sessions.queries.batch_list_session_triggers", triggers),
+            patch("aios.services.sessions.compute_awaiting", awaiting),
+            patch("aios.services.sessions.compute_obligations", obligations),
+        ):
+            out = await sessions_service.list_sessions(
+                _Pool(),
+                account_id="acc_1",
+            )
+
+        assert fat == ["vaults", "echoes", "triggers", "obligations"]
+        assert out[0].vault_ids == ["vlt_1"]
+
+    async def test_empty_ids_does_not_touch_db(self) -> None:
+        listed = AsyncMock()
+        with patch("aios.services.sessions.queries.list_sessions", listed):
+            out = await sessions_service.list_sessions(
+                MagicMock(),
+                account_id="acc_1",
+                ids=[],
+                view="lite",
+            )
+        assert out == []
+        listed.assert_not_called()


### PR DESCRIPTION
## Summary
- `GET /v1/sessions` hydrates every row with vaults, resource echoes, triggers, awaiting, and obligations. A roster only needs `id`, derived `status`, `last_event_at`, and `awaiting` (mcp/custom) for unread.
- `?view=lite` skips vaults / echoes / triggers / obligations and still computes `awaiting`.
- `?ids=` restricts the page to those session ids (`id = ANY(...)`, account-scoped). Empty `ids` is an empty list (no query). Cap is `MAX_PAGE_LIMIT`.
- Default list is unchanged. `view` is optional so `?cursor=` pages do not 422.

## Test plan
- [x] `pytest tests/unit/test_list_sessions_lite.py` — ids SQL, empty ids skips fetch, lite skips fat hydration, full still hydrates
- [x] `pytest tests/unit/test_list_sessions_include_archived.py` + `test_openapi_snapshot.py`
- [x] mypy + ruff on touched files
- [x] openapi.json + SDK regen (`ids`, `view`)