### PR TITLE
Creation-edge accounting: own/subtree usage and live rates

### DIFF
--- a/docs/ops/workflow-spend-accounting-migration.md
+++ b/docs/ops/workflow-spend-accounting-migration.md
@@ -1,18 +1,18 @@
 # Workflow spend accounting migration
 
-Migration 0168 repairs the historical period in which raw workflow `call_llm`
+Migration 0169 repairs the historical period in which raw workflow `call_llm`
 cost was stored on `wf_runs` but was not automatically projected into
 `accounts.spent_microusd`. Account totals cannot prove whether a particular
 workflow charge was already included: manual adjustments and deleted sessions
-can produce the same aggregate value. Migration 0167 therefore creates an
-explicit operator watermark and 0168 refuses to guess when one is missing.
+can produce the same aggregate value. Migration 0168 therefore creates an
+explicit operator watermark and 0169 refuses to guess when one is missing.
 
 ## Procedure
 
 1. Upgrade only through the watermark revision:
 
    ```console
-   uv run alembic upgrade 0167
+   uv run alembic upgrade 0168
    ```
 
 2. List accounts with retained raw-workflow cost:
@@ -43,17 +43,17 @@ explicit operator watermark and 0168 refuses to guess when one is missing.
    added for that account. Use the exact retained amount already included for a
    full or partial prior repair. Do not infer this value from aggregate equality.
    Do not manually adjust `accounts.spent_microusd` between recording the
-   watermark and completing 0168. Raw workflow writers may continue: 0168 locks
+   watermark and completing 0169. Raw workflow writers may continue: 0169 locks
    their run meter at cutover and includes any later pre-cutover increment in
    the unaccounted delta.
 
-4. Upgrade through 0168 or head:
+4. Upgrade through 0169 or head:
 
    ```console
    uv run alembic upgrade head
    ```
 
-0168 adds only `retained run cost - accounted watermark` and advances the
+0169 adds only `retained run cost - accounted watermark` and advances the
 watermark to the retained run meter in the same transaction. It fails before
 changing account spend if a required watermark is absent or exceeds retained
 run cost. The post-migration database trigger advances the account meter and

--- a/docs/ops/workflow-spend-accounting-migration.md
+++ b/docs/ops/workflow-spend-accounting-migration.md
@@ -1,0 +1,60 @@
+# Workflow spend accounting migration
+
+Migration 0168 repairs the historical period in which raw workflow `call_llm`
+cost was stored on `wf_runs` but was not automatically projected into
+`accounts.spent_microusd`. Account totals cannot prove whether a particular
+workflow charge was already included: manual adjustments and deleted sessions
+can produce the same aggregate value. Migration 0167 therefore creates an
+explicit operator watermark and 0168 refuses to guess when one is missing.
+
+## Procedure
+
+1. Upgrade only through the watermark revision:
+
+   ```console
+   uv run alembic upgrade 0167
+   ```
+
+2. List accounts with retained raw-workflow cost:
+
+   ```sql
+   SELECT account_id,
+          SUM(call_llm_cost_microusd)::bigint AS retained_run_cost_microusd
+     FROM wf_runs
+    GROUP BY account_id
+   HAVING SUM(call_llm_cost_microusd) > 0
+    ORDER BY account_id;
+   ```
+
+3. For every returned account, determine how much of that retained run cost is
+   already represented in `accounts.spent_microusd`, then record that amount:
+
+   ```sql
+   INSERT INTO workflow_spend_accounting_watermarks (
+       account_id,
+       accounted_run_cost_microusd
+   ) VALUES (
+       'acc_example',
+       0
+   );
+   ```
+
+   Use `0` only after confirming no historical raw-workflow charge was manually
+   added for that account. Use the exact retained amount already included for a
+   full or partial prior repair. Do not infer this value from aggregate equality.
+   Do not manually adjust `accounts.spent_microusd` between recording the
+   watermark and completing 0168. Raw workflow writers may continue: 0168 locks
+   their run meter at cutover and includes any later pre-cutover increment in
+   the unaccounted delta.
+
+4. Upgrade through 0168 or head:
+
+   ```console
+   uv run alembic upgrade head
+   ```
+
+0168 adds only `retained run cost - accounted watermark` and advances the
+watermark to the retained run meter in the same transaction. It fails before
+changing account spend if a required watermark is absent or exceeds retained
+run cost. The post-migration database trigger advances the account meter and
+watermark together for every new raw-workflow charge.

--- a/docs/reference/inference-accounting.md
+++ b/docs/reference/inference-accounting.md
@@ -1,0 +1,50 @@
+# Inference accounting
+
+aios attributes inference through an immutable creation tree containing both
+sessions and workflow runs. The rule is simple: the node that creates a child
+owns that child's spend. Invoking an existing session does not change ownership.
+
+## Resource usage
+
+`GET /v1/sessions/{id}` and `GET /v1/runs/{id}` expose:
+
+- `usage.own`: inference performed at this node;
+- `usage.subtree`: `own` plus every creation descendant, transitively across
+  session and workflow-run boundaries;
+- `usage.own_rate` and `usage.subtree_rate`: rolling-window counters normalized
+  per hour.
+
+The flat fields retained beside these values are compatibility fields. Session
+flat counters remain self-only. Workflow-run flat counters retain the older
+direct-child budget view. New accounting consumers should use `own` and
+`subtree`.
+
+Subtree usage is live. It includes active, archived, errored, cancelled, and
+terminated descendants. A child's ownership does not expire when its creator
+finishes waiting, so a finished node's subtree can continue growing while a
+descendant runs. This is expected.
+
+## Rates and coverage
+
+Rates come from an append-only delta ledger written atomically with each
+cumulative meter. `window_seconds` is the requested rolling window;
+`observed_seconds` is the portion covered by the ledger. `complete=false` means
+the account is newer than the requested window. The values remain normalized to
+one hour, using the explicit observed denominator.
+
+## Ranked consumers
+
+`GET /v1/usage/consumers` ranks account root nodes by live subtree rate in one
+request. Query parameters:
+
+- `window_seconds` (default `86400`, 60 seconds through 30 days);
+- `metric=cost_microusd|total_tokens`;
+- `limit` (default `20`, maximum `100`).
+
+Only roots appear in this view. Creation gives each node exactly one root, so
+the rows are additive and `share` values do not double-count a descendant under
+both parent and child. Point resource reads still expose every intermediate
+node's own and subtree values.
+
+Traversal uses a visited-set-equivalent recursive `UNION`. A malformed legacy
+cycle terminates and each `(kind, id)` contributes at most once per root.

--- a/docs/reference/run-observability.md
+++ b/docs/reference/run-observability.md
@@ -107,7 +107,7 @@ the **child-session** events produced when a run spawns agent sessions:
 Source of truth: `aios.models.workflows.WfRunEvent` and
 `aios.models.events.Event`.
 
-## (d) Per-run cost / token / wall-clock usage on the read path (#1324)
+## (d) Per-run cost / token / wall-clock usage on the read path (#1324, #2151)
 
 `GET /v1/runs/{id}` (`WfRun`) and `GET /v1/runs` (`list_runs`) carry a `usage`
 object — the run's realized spend, the machine-observer's cost-substrate. It is
@@ -116,6 +116,12 @@ source the in-script `budget()` builtin consumes, so the run's `budget_usd`
 *ceiling* and its `usage.cost_microusd` *spend* are both legible from the read
 path (not buried in a builtin). On `list_runs` the whole page is enriched in one
 batched aggregate — no per-run fan-out.
+
+Creation-edge accounting adds `usage.own`, `usage.subtree`, `usage.own_rate`,
+and `usage.subtree_rate`. These values cross session/run boundaries to arbitrary
+depth and include archived descendants. See
+[`inference-accounting.md`](inference-accounting.md). The older flat fields below
+remain as compatibility fields for the direct-child budget view.
 
 `usage` fields (`WfRunUsage`):
 

--- a/migrations/versions/0167_workflow_spend_accounting_watermarks.py
+++ b/migrations/versions/0167_workflow_spend_accounting_watermarks.py
@@ -1,0 +1,81 @@
+"""Durable provenance for historical workflow-spend reconciliation.
+
+Revision ID: 0167
+Revises: 0166
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0167"
+down_revision = "0166"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(r"""
+        CREATE TABLE workflow_spend_accounting_watermarks (
+            account_id text PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+            accounted_run_cost_microusd bigint NOT NULL
+                CHECK (accounted_run_cost_microusd >= 0),
+            last_observed_run_cost_microusd bigint
+                CHECK (last_observed_run_cost_microusd >= 0),
+            last_applied_delta_microusd bigint
+                CHECK (last_applied_delta_microusd >= 0),
+            reconciled_at timestamptz
+        )
+    """)
+    op.execute(r"""
+        COMMENT ON TABLE workflow_spend_accounting_watermarks IS
+        'Operator-declared and migration-maintained provenance for the amount '
+        'of cumulative wf_runs.call_llm_cost_microusd already represented in '
+        'accounts.spent_microusd'
+    """)
+    op.execute(r"""
+        DO $$
+        BEGIN
+            IF to_regclass('_aios_0167_workflow_spend_watermarks_archive') IS NOT NULL THEN
+                IF EXISTS (
+                    SELECT 1
+                      FROM _aios_0167_workflow_spend_watermarks_archive archived
+                      LEFT JOIN accounts a ON a.id = archived.account_id
+                     WHERE a.id IS NULL
+                ) THEN
+                    RAISE EXCEPTION
+                        'cannot restore archived 0167 workflow spend watermark: an account is missing';
+                END IF;
+                INSERT INTO workflow_spend_accounting_watermarks (
+                    account_id,
+                    accounted_run_cost_microusd,
+                    last_observed_run_cost_microusd,
+                    last_applied_delta_microusd,
+                    reconciled_at
+                )
+                SELECT account_id,
+                       accounted_run_cost_microusd,
+                       last_observed_run_cost_microusd,
+                       last_applied_delta_microusd,
+                       reconciled_at
+                  FROM _aios_0167_workflow_spend_watermarks_archive;
+                DROP TABLE _aios_0167_workflow_spend_watermarks_archive;
+            END IF;
+        END
+        $$
+    """)
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("LOCK TABLE accounts, workflow_spend_accounting_watermarks IN ACCESS EXCLUSIVE MODE")
+    op.execute(r"""
+        CREATE TABLE _aios_0167_workflow_spend_watermarks_archive AS
+        SELECT account_id,
+               accounted_run_cost_microusd,
+               last_observed_run_cost_microusd,
+               last_applied_delta_microusd,
+               reconciled_at
+          FROM workflow_spend_accounting_watermarks
+    """)
+    op.execute("DROP TABLE workflow_spend_accounting_watermarks")

--- a/migrations/versions/0168_creation_edge_usage_accounting.py
+++ b/migrations/versions/0168_creation_edge_usage_accounting.py
@@ -1,7 +1,7 @@
 """Creation-edge inference accounting and rolling usage ledger.
 
 Revision ID: 0168
-Revises: 0166
+Revises: 0167
 """
 
 from __future__ import annotations
@@ -9,7 +9,7 @@ from __future__ import annotations
 from alembic import op
 
 revision = "0168"
-down_revision = "0166"
+down_revision = "0167"
 branch_labels = None
 depends_on = None
 
@@ -20,6 +20,7 @@ def upgrade() -> None:
     # may run; PostgreSQL rolls the revision back atomically on either timeout.
     op.execute("SET LOCAL lock_timeout = '5s'")
     op.execute("SET LOCAL statement_timeout = '5min'")
+    op.execute("LOCK TABLE workflow_spend_accounting_watermarks IN ACCESS EXCLUSIVE MODE")
 
     # One immutable accounting parent per node.  Two nullable typed FKs avoid a
     # polymorphic id with no referential integrity; the XOR check makes the
@@ -201,6 +202,20 @@ def upgrade() -> None:
                 UPDATE accounts
                    SET spent_microusd = spent_microusd + delta
                  WHERE id = NEW.account_id;
+                INSERT INTO workflow_spend_accounting_watermarks AS watermark (
+                    account_id,
+                    accounted_run_cost_microusd,
+                    last_observed_run_cost_microusd,
+                    last_applied_delta_microusd,
+                    reconciled_at
+                ) VALUES (NEW.account_id, delta, delta, delta, now())
+                ON CONFLICT (account_id) DO UPDATE
+                    SET accounted_run_cost_microusd =
+                            watermark.accounted_run_cost_microusd + delta,
+                        last_observed_run_cost_microusd =
+                            watermark.accounted_run_cost_microusd + delta,
+                        last_applied_delta_microusd = delta,
+                        reconciled_at = now();
             END IF;
             RETURN NEW;
         END
@@ -214,53 +229,72 @@ def upgrade() -> None:
         EXECUTE FUNCTION _aios_charge_workflow_account_spend()
     """)
 
-    # Historical account repair is safe only when durable meters prove one of
-    # two exact states: account spend equals retained session spend (raw workflow
-    # cost is wholly missing), or it equals session + raw workflow spend (already
-    # repaired). Any other state may contain deleted-session spend or a partial
-    # manual repair; fail closed and require operator reconciliation instead of
-    # silently adding or omitting money.
+    # Aggregate equality cannot prove which historical workflow charges were
+    # already counted: unrelated/manual spend and deleted sessions can produce
+    # the same scalar. Revision 0167 therefore requires an operator-declared
+    # watermark for every account with retained workflow cost. Reconcile only
+    # the unaccounted delta, then advance the watermark atomically. The trigger
+    # above maintains the same provenance for every post-migration charge.
     op.execute(r"""
         DO $$
         BEGIN
             IF EXISTS (
-                WITH session_meter AS (
-                    SELECT account_id, SUM(cost_microusd)::bigint AS total
-                      FROM sessions GROUP BY account_id
-                ),
-                run_meter AS (
+                WITH run_meter AS (
                     SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total
                       FROM wf_runs GROUP BY account_id
                 )
                 SELECT 1
-                  FROM accounts a
-                  JOIN run_meter r ON r.account_id = a.id AND r.total > 0
-                  LEFT JOIN session_meter s ON s.account_id = a.id
-                 WHERE a.spent_microusd NOT IN (
-                     COALESCE(s.total, 0), COALESCE(s.total, 0) + r.total
-                 )
+                  FROM run_meter r
+                  LEFT JOIN workflow_spend_accounting_watermarks watermark
+                    ON watermark.account_id = r.account_id
+                 WHERE r.total > 0 AND watermark.account_id IS NULL
             ) THEN
                 RAISE EXCEPTION USING
-                    MESSAGE = 'ambiguous historical workflow spend; reconcile account meter before 0168',
-                    HINT = 'spent_microusd must equal retained session spend, or retained session plus workflow spend';
+                    MESSAGE = 'missing workflow spend accounting watermark before 0168',
+                    HINT = 'at revision 0167, explicitly record how much retained workflow cost is already represented in each account meter';
+            END IF;
+            IF EXISTS (
+                WITH run_meter AS (
+                    SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total
+                      FROM wf_runs GROUP BY account_id
+                )
+                SELECT 1
+                  FROM workflow_spend_accounting_watermarks watermark
+                  LEFT JOIN run_meter r ON r.account_id = watermark.account_id
+                 WHERE watermark.accounted_run_cost_microusd > COALESCE(r.total, 0)
+            ) THEN
+                RAISE EXCEPTION USING
+                    MESSAGE = 'workflow spend accounting watermark exceeds retained run cost',
+                    HINT = 'correct the operator-declared watermark at revision 0167 before retrying 0168';
             END IF;
         END
         $$
     """)
     op.execute(r"""
         UPDATE accounts a
-           SET spent_microusd = a.spent_microusd + r.total
+           SET spent_microusd = a.spent_microusd
+               + r.total - watermark.accounted_run_cost_microusd
           FROM (
                SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total
                  FROM wf_runs GROUP BY account_id
           ) r
-          LEFT JOIN (
-               SELECT account_id, SUM(cost_microusd)::bigint AS total
-                 FROM sessions GROUP BY account_id
-          ) s ON s.account_id = r.account_id
+          JOIN workflow_spend_accounting_watermarks watermark
+            ON watermark.account_id = r.account_id
          WHERE a.id = r.account_id
            AND r.total > 0
-           AND a.spent_microusd = COALESCE(s.total, 0)
+    """)
+    op.execute(r"""
+        UPDATE workflow_spend_accounting_watermarks watermark
+           SET last_applied_delta_microusd =
+                   r.total - watermark.accounted_run_cost_microusd,
+               accounted_run_cost_microusd = r.total,
+               last_observed_run_cost_microusd = r.total,
+               reconciled_at = now()
+          FROM (
+               SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total
+                 FROM wf_runs GROUP BY account_id
+          ) r
+         WHERE watermark.account_id = r.account_id
     """)
 
     # Rates need deltas, not cumulative rows. Per-account coverage makes a

--- a/migrations/versions/0168_creation_edge_usage_accounting.py
+++ b/migrations/versions/0168_creation_edge_usage_accounting.py
@@ -1,0 +1,313 @@
+"""Creation-edge inference accounting and rolling usage ledger.
+
+Revision ID: 0168
+Revises: 0166
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0168"
+down_revision = "0166"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # One immutable accounting parent per node.  Two nullable typed FKs avoid a
+    # polymorphic id with no referential integrity; the XOR check makes the
+    # creation graph single-parented (roots leave both NULL).
+    for table in ("sessions", "wf_runs"):
+        op.execute(f"ALTER TABLE {table} ADD COLUMN creator_session_id text")
+        op.execute(f"ALTER TABLE {table} ADD COLUMN creator_run_id text")
+        op.execute(
+            f"ALTER TABLE {table} ADD CONSTRAINT {table}_one_creator_ck CHECK ("
+            "creator_session_id IS NULL OR creator_run_id IS NULL)"
+        )
+
+    op.execute(
+        "ALTER TABLE sessions ADD CONSTRAINT sessions_creator_not_self_ck "
+        "CHECK (creator_session_id IS NULL OR creator_session_id <> id)"
+    )
+    op.execute(
+        "ALTER TABLE wf_runs ADD CONSTRAINT wf_runs_creator_not_self_ck "
+        "CHECK (creator_run_id IS NULL OR creator_run_id <> id)"
+    )
+
+    # Existing workflow agent() children already have an unambiguous creation
+    # edge.  Backfill those before considering session caller provenance.
+    op.execute("UPDATE sessions SET creator_run_id = parent_run_id WHERE parent_run_id IS NOT NULL")
+    # Historical call_agent children are ephemeral (archive_when_idle) fresh
+    # sessions whose first request_opened frame names the creating session.
+    # Existing-session call_session targets are not ephemeral, so they are
+    # intentionally excluded: invocation never changes accounting ownership.
+    op.execute(r"""
+        UPDATE sessions s
+           SET creator_session_id = (
+               SELECT e.data->'caller'->>'id'
+                 FROM events e
+                 JOIN sessions creator
+                   ON creator.id = e.data->'caller'->>'id'
+                  AND creator.account_id = s.account_id
+                WHERE e.session_id = s.id
+                  AND e.account_id = s.account_id
+                  AND e.kind = 'lifecycle'
+                  AND e.data->>'event' = 'request_opened'
+                  AND e.data->'caller'->>'kind' = 'session'
+                  AND e.data->'caller'->>'id' <> s.id
+                ORDER BY e.seq
+                LIMIT 1
+           )
+         WHERE s.creator_run_id IS NULL
+           AND s.archive_when_idle = TRUE
+           AND EXISTS (
+               SELECT 1
+                 FROM events e
+                 JOIN sessions creator
+                   ON creator.id = e.data->'caller'->>'id'
+                  AND creator.account_id = s.account_id
+                WHERE e.session_id = s.id
+                  AND e.account_id = s.account_id
+                  AND e.kind = 'lifecycle'
+                  AND e.data->>'event' = 'request_opened'
+                  AND e.data->'caller'->>'kind' = 'session'
+                  AND e.data->'caller'->>'id' <> s.id
+           )
+    """)
+    # Soft resource provenance predates this migration and is a useful fallback
+    # for any session-created resource not covered by the invocation substrate.
+    op.execute(r"""
+        UPDATE sessions s
+           SET creator_session_id = s.created_by_ref
+         WHERE s.creator_run_id IS NULL
+           AND s.creator_session_id IS NULL
+           AND s.created_by_type = 'session_actor'
+           AND s.created_by_ref <> s.id
+           AND EXISTS (
+               SELECT 1 FROM sessions creator
+                WHERE creator.id = s.created_by_ref
+                  AND creator.account_id = s.account_id
+           )
+    """)
+
+    # A run is always newly created.  Its trusted caller is therefore the best
+    # historical creation edge.  Detached launches fall back to their launcher
+    # session; a bare nested run falls back to parent_run_id.
+    op.execute(r"""
+        UPDATE wf_runs r
+           SET creator_session_id = r.caller->>'id'
+         WHERE r.caller->>'kind' = 'session'
+           AND EXISTS (
+               SELECT 1 FROM sessions s
+                WHERE s.id = r.caller->>'id' AND s.account_id = r.account_id
+           )
+    """)
+
+    # Creator ids are tenant-bearing edges. Composite FKs make a cross-account
+    # ownership edge impossible even if a future internal writer forgets a
+    # service-layer scope check. PostgreSQL's column-list SET NULL preserves the
+    # child's non-null account_id when a creator is hard-deleted.
+    for table in ("sessions", "wf_runs"):
+        op.execute(
+            f"ALTER TABLE {table} ADD CONSTRAINT {table}_creator_session_account_fk "
+            "FOREIGN KEY (creator_session_id, account_id) "
+            "REFERENCES sessions(id, account_id) "
+            "ON DELETE SET NULL (creator_session_id) NOT VALID"
+        )
+        op.execute(
+            f"ALTER TABLE {table} ADD CONSTRAINT {table}_creator_run_account_fk "
+            "FOREIGN KEY (creator_run_id, account_id) "
+            "REFERENCES wf_runs(id, account_id) "
+            "ON DELETE SET NULL (creator_run_id) NOT VALID"
+        )
+        op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {table}_creator_session_account_fk")
+        op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {table}_creator_run_account_fk")
+    op.execute(r"""
+        UPDATE wf_runs r
+           SET creator_run_id = r.caller->>'id'
+         WHERE r.creator_session_id IS NULL
+           AND r.caller->>'kind' = 'run'
+           AND r.caller->>'id' <> r.id
+           AND EXISTS (
+               SELECT 1 FROM wf_runs parent
+                WHERE parent.id = r.caller->>'id' AND parent.account_id = r.account_id
+           )
+    """)
+    op.execute(r"""
+        UPDATE wf_runs r
+           SET creator_session_id = r.launcher_session_id
+         WHERE r.creator_session_id IS NULL
+           AND r.creator_run_id IS NULL
+           AND r.launcher_session_id IS NOT NULL
+    """)
+    op.execute(r"""
+        UPDATE wf_runs r
+           SET creator_run_id = r.parent_run_id
+         WHERE r.creator_session_id IS NULL
+           AND r.creator_run_id IS NULL
+           AND r.parent_run_id IS NOT NULL
+           AND r.parent_run_id <> r.id
+    """)
+
+    for table in ("sessions", "wf_runs"):
+        op.execute(
+            f"CREATE INDEX {table}_creator_session_idx ON {table} "
+            "(account_id, creator_session_id) WHERE creator_session_id IS NOT NULL"
+        )
+        op.execute(
+            f"CREATE INDEX {table}_creator_run_idx ON {table} "
+            "(account_id, creator_run_id) WHERE creator_run_id IS NOT NULL"
+        )
+
+    # Raw call_llm() already had a run-level cost meter.  Add its token peers so
+    # a workflow run's own inference is the same complete vector as a session's.
+    for column in (
+        "call_llm_input_tokens",
+        "call_llm_output_tokens",
+        "call_llm_cache_read_input_tokens",
+        "call_llm_cache_creation_input_tokens",
+    ):
+        op.execute(
+            f"ALTER TABLE wf_runs ADD COLUMN {column} bigint NOT NULL DEFAULT 0 "
+            f"CHECK ({column} >= 0)"
+        )
+
+    # Recover historical raw-turn tokens wherever the durable run journal is
+    # still present. The call_started row identifies call_llm unambiguously;
+    # the unique (run_id, call_key, type) memo guarantees one matching result.
+    # Pruned journals cannot supply tokens, so cost remains the exact historical
+    # source of truth for those older runs.
+    op.execute(r"""
+        UPDATE wf_runs r
+           SET call_llm_input_tokens = history.input_tokens,
+               call_llm_output_tokens = history.output_tokens,
+               call_llm_cache_read_input_tokens = history.cache_read_input_tokens,
+               call_llm_cache_creation_input_tokens = history.cache_creation_input_tokens
+          FROM (
+               SELECT started.run_id,
+                      SUM(CASE WHEN jsonb_typeof(done.payload->'result'->'usage'->'input_tokens')
+                                         = 'number'
+                               THEN (done.payload->'result'->'usage'->>'input_tokens')::bigint
+                               ELSE 0 END)::bigint AS input_tokens,
+                      SUM(CASE WHEN jsonb_typeof(done.payload->'result'->'usage'->'output_tokens')
+                                         = 'number'
+                               THEN (done.payload->'result'->'usage'->>'output_tokens')::bigint
+                               ELSE 0 END)::bigint AS output_tokens,
+                      SUM(CASE WHEN jsonb_typeof(
+                                             done.payload->'result'->'usage'
+                                                 ->'cache_read_input_tokens'
+                                         ) = 'number'
+                               THEN (done.payload->'result'->'usage'
+                                         ->>'cache_read_input_tokens')::bigint
+                               ELSE 0 END)::bigint AS cache_read_input_tokens,
+                      SUM(CASE WHEN jsonb_typeof(
+                                             done.payload->'result'->'usage'
+                                                 ->'cache_creation_input_tokens'
+                                         ) = 'number'
+                               THEN (done.payload->'result'->'usage'
+                                         ->>'cache_creation_input_tokens')::bigint
+                               ELSE 0 END)::bigint AS cache_creation_input_tokens
+                 FROM wf_run_events started
+                 JOIN wf_run_events done
+                   ON done.run_id = started.run_id
+                  AND done.call_key = started.call_key
+                  AND done.type = 'call_result'
+                WHERE started.type = 'call_started'
+                  AND started.payload->>'capability' = 'call_llm'
+                GROUP BY started.run_id
+          ) history
+         WHERE r.id = history.run_id
+    """)
+
+    # Repair the original workflows-as-models accounting omission: historical
+    # raw call_llm cost lived only on wf_runs, while every public/account limit
+    # read trusts accounts.spent_microusd. Future charges dual-write atomically.
+    op.execute(r"""
+        UPDATE accounts a
+           SET spent_microusd = a.spent_microusd + raw.total_microusd
+          FROM (
+               SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total_microusd
+                 FROM wf_runs
+                GROUP BY account_id
+          ) raw
+         WHERE a.id = raw.account_id
+    """)
+
+    # Rates need deltas, not cumulative rows. Per-account coverage makes a
+    # partial first window explicit and follows account lifecycle naturally.
+    op.execute(
+        "ALTER TABLE accounts ADD COLUMN usage_ledger_started_at timestamptz NOT NULL DEFAULT now()"
+    )
+    op.execute(r"""
+        CREATE TABLE inference_usage_ledger (
+            id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            account_id text NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+            session_id text REFERENCES sessions(id) ON DELETE CASCADE,
+            run_id text REFERENCES wf_runs(id) ON DELETE CASCADE,
+            input_tokens bigint NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+            output_tokens bigint NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+            cache_read_input_tokens bigint NOT NULL DEFAULT 0
+                CHECK (cache_read_input_tokens >= 0),
+            cache_creation_input_tokens bigint NOT NULL DEFAULT 0
+                CHECK (cache_creation_input_tokens >= 0),
+            cost_microusd bigint NOT NULL DEFAULT 0 CHECK (cost_microusd >= 0),
+            occurred_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT inference_usage_ledger_one_node_ck CHECK (
+                (session_id IS NOT NULL)::integer + (run_id IS NOT NULL)::integer = 1
+            )
+        )
+    """)
+    op.execute(
+        "CREATE INDEX inference_usage_ledger_session_window_idx "
+        "ON inference_usage_ledger (session_id, occurred_at DESC) "
+        "WHERE session_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX inference_usage_ledger_run_window_idx "
+        "ON inference_usage_ledger (run_id, occurred_at DESC) WHERE run_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX inference_usage_ledger_account_window_idx "
+        "ON inference_usage_ledger (account_id, occurred_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE inference_usage_ledger")
+    # ``IF EXISTS`` also makes local iteration safe for databases that briefly
+    # ran the pre-review singleton coverage design of this unreleased revision.
+    op.execute("DROP TABLE IF EXISTS inference_usage_ledger_state")
+    op.execute("ALTER TABLE accounts DROP COLUMN IF EXISTS usage_ledger_started_at")
+    op.execute(r"""
+        UPDATE accounts a
+           SET spent_microusd = GREATEST(0, a.spent_microusd - raw.total_microusd)
+          FROM (
+               SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total_microusd
+                 FROM wf_runs
+                GROUP BY account_id
+          ) raw
+         WHERE a.id = raw.account_id
+    """)
+    for column in reversed(
+        (
+            "call_llm_input_tokens",
+            "call_llm_output_tokens",
+            "call_llm_cache_read_input_tokens",
+            "call_llm_cache_creation_input_tokens",
+        )
+    ):
+        op.execute(f"ALTER TABLE wf_runs DROP COLUMN {column}")
+    for table in reversed(("sessions", "wf_runs")):
+        op.execute(f"DROP INDEX {table}_creator_run_idx")
+        op.execute(f"DROP INDEX {table}_creator_session_idx")
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {table}_creator_run_account_fk")
+        op.execute(
+            f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {table}_creator_session_account_fk"
+        )
+    op.execute("ALTER TABLE wf_runs DROP CONSTRAINT wf_runs_creator_not_self_ck")
+    op.execute("ALTER TABLE sessions DROP CONSTRAINT sessions_creator_not_self_ck")
+    for table in reversed(("sessions", "wf_runs")):
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT {table}_one_creator_ck")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN creator_run_id")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN creator_session_id")

--- a/migrations/versions/0168_creation_edge_usage_accounting.py
+++ b/migrations/versions/0168_creation_edge_usage_accounting.py
@@ -15,6 +15,12 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # This revision takes ACCESS EXCLUSIVE locks as it adds columns. Bound how
+    # long deploy waits for old writers and how long the whole repair statement
+    # may run; PostgreSQL rolls the revision back atomically on either timeout.
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '5min'")
+
     # One immutable accounting parent per node.  Two nullable typed FKs avoid a
     # polymorphic id with no referential integrity; the XOR check makes the
     # creation graph single-parented (roots leave both NULL).
@@ -128,8 +134,10 @@ def upgrade() -> None:
             "(account_id, creator_run_id) WHERE creator_run_id IS NOT NULL"
         )
 
-    # Raw call_llm() already had a run-level cost meter.  Add its token peers so
-    # a workflow run's own inference is the same complete vector as a session's.
+    # Raw call_llm() already had a run-level cost meter. Add its token peers.
+    # Existing runs start explicitly incomplete: journals may be pruned or
+    # malformed, so zero is not evidence of a measured zero. New runs default
+    # complete because every post-migration writer persists all four counters.
     for column in (
         "call_llm_input_tokens",
         "call_llm_output_tokens",
@@ -140,66 +148,119 @@ def upgrade() -> None:
             f"ALTER TABLE wf_runs ADD COLUMN {column} bigint NOT NULL DEFAULT 0 "
             f"CHECK ({column} >= 0)"
         )
-
-    # Recover historical raw-turn tokens wherever the durable run journal is
-    # still present. The call_started row identifies call_llm unambiguously;
-    # the unique (run_id, call_key, type) memo guarantees one matching result.
-    # Pruned journals cannot supply tokens, so cost remains the exact historical
-    # source of truth for those older runs.
+    op.execute(
+        "ALTER TABLE wf_runs ADD COLUMN call_llm_tokens_complete boolean NOT NULL DEFAULT FALSE"
+    )
+    op.execute("ALTER TABLE wf_runs ALTER COLUMN call_llm_tokens_complete SET DEFAULT TRUE")
     op.execute(r"""
-        UPDATE wf_runs r
-           SET call_llm_input_tokens = history.input_tokens,
-               call_llm_output_tokens = history.output_tokens,
-               call_llm_cache_read_input_tokens = history.cache_read_input_tokens,
-               call_llm_cache_creation_input_tokens = history.cache_creation_input_tokens
-          FROM (
-               SELECT started.run_id,
-                      SUM(CASE WHEN jsonb_typeof(done.payload->'result'->'usage'->'input_tokens')
-                                         = 'number'
-                               THEN (done.payload->'result'->'usage'->>'input_tokens')::bigint
-                               ELSE 0 END)::bigint AS input_tokens,
-                      SUM(CASE WHEN jsonb_typeof(done.payload->'result'->'usage'->'output_tokens')
-                                         = 'number'
-                               THEN (done.payload->'result'->'usage'->>'output_tokens')::bigint
-                               ELSE 0 END)::bigint AS output_tokens,
-                      SUM(CASE WHEN jsonb_typeof(
-                                             done.payload->'result'->'usage'
-                                                 ->'cache_read_input_tokens'
-                                         ) = 'number'
-                               THEN (done.payload->'result'->'usage'
-                                         ->>'cache_read_input_tokens')::bigint
-                               ELSE 0 END)::bigint AS cache_read_input_tokens,
-                      SUM(CASE WHEN jsonb_typeof(
-                                             done.payload->'result'->'usage'
-                                                 ->'cache_creation_input_tokens'
-                                         ) = 'number'
-                               THEN (done.payload->'result'->'usage'
-                                         ->>'cache_creation_input_tokens')::bigint
-                               ELSE 0 END)::bigint AS cache_creation_input_tokens
-                 FROM wf_run_events started
-                 JOIN wf_run_events done
-                   ON done.run_id = started.run_id
-                  AND done.call_key = started.call_key
-                  AND done.type = 'call_result'
-                WHERE started.type = 'call_started'
-                  AND started.payload->>'capability' = 'call_llm'
-                GROUP BY started.run_id
-          ) history
-         WHERE r.id = history.run_id
+        DO $$
+        BEGIN
+            IF to_regclass('_aios_0168_wf_run_usage_archive') IS NOT NULL THEN
+                IF EXISTS (
+                    SELECT 1
+                      FROM _aios_0168_wf_run_usage_archive archived
+                      LEFT JOIN wf_runs r
+                        ON r.id = archived.run_id
+                       AND r.account_id = archived.account_id
+                     WHERE r.id IS NULL
+                ) THEN
+                    RAISE EXCEPTION
+                        'cannot restore archived 0168 run usage: a workflow run is missing';
+                END IF;
+                UPDATE wf_runs r
+                   SET call_llm_input_tokens = a.call_llm_input_tokens,
+                       call_llm_output_tokens = a.call_llm_output_tokens,
+                       call_llm_cache_read_input_tokens = a.call_llm_cache_read_input_tokens,
+                       call_llm_cache_creation_input_tokens = a.call_llm_cache_creation_input_tokens,
+                       call_llm_tokens_complete = a.call_llm_tokens_complete
+                  FROM _aios_0168_wf_run_usage_archive a
+                 WHERE r.id = a.run_id
+                   AND r.account_id = a.account_id;
+                DROP TABLE _aios_0168_wf_run_usage_archive;
+            END IF;
+        END
+        $$
     """)
 
-    # Repair the original workflows-as-models accounting omission: historical
-    # raw call_llm cost lived only on wf_runs, while every public/account limit
-    # read trusts accounts.spent_microusd. Future charges dual-write atomically.
+    # Make the database own the canonical account projection. The trigger is
+    # deliberately installed before historical reconciliation: an old writer
+    # blocked by this migration's table lock resumes after COMMIT and still
+    # dual-writes its delta exactly once. New application writers update only
+    # the run meter, so old/new cutover cannot double-charge the account.
+    op.execute(r"""
+        CREATE FUNCTION _aios_charge_workflow_account_spend() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+        DECLARE
+            delta bigint;
+        BEGIN
+            delta := NEW.call_llm_cost_microusd - OLD.call_llm_cost_microusd;
+            IF delta < 0 THEN
+                RAISE EXCEPTION 'wf_runs.call_llm_cost_microusd is append-only';
+            END IF;
+            IF delta > 0 THEN
+                UPDATE accounts
+                   SET spent_microusd = spent_microusd + delta
+                 WHERE id = NEW.account_id;
+            END IF;
+            RETURN NEW;
+        END
+        $$
+    """)
+    op.execute(r"""
+        CREATE TRIGGER wf_runs_charge_account_spend_trg
+        AFTER UPDATE OF call_llm_cost_microusd ON wf_runs
+        FOR EACH ROW
+        WHEN (NEW.call_llm_cost_microusd <> OLD.call_llm_cost_microusd)
+        EXECUTE FUNCTION _aios_charge_workflow_account_spend()
+    """)
+
+    # Historical account repair is safe only when durable meters prove one of
+    # two exact states: account spend equals retained session spend (raw workflow
+    # cost is wholly missing), or it equals session + raw workflow spend (already
+    # repaired). Any other state may contain deleted-session spend or a partial
+    # manual repair; fail closed and require operator reconciliation instead of
+    # silently adding or omitting money.
+    op.execute(r"""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                WITH session_meter AS (
+                    SELECT account_id, SUM(cost_microusd)::bigint AS total
+                      FROM sessions GROUP BY account_id
+                ),
+                run_meter AS (
+                    SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total
+                      FROM wf_runs GROUP BY account_id
+                )
+                SELECT 1
+                  FROM accounts a
+                  JOIN run_meter r ON r.account_id = a.id AND r.total > 0
+                  LEFT JOIN session_meter s ON s.account_id = a.id
+                 WHERE a.spent_microusd NOT IN (
+                     COALESCE(s.total, 0), COALESCE(s.total, 0) + r.total
+                 )
+            ) THEN
+                RAISE EXCEPTION USING
+                    MESSAGE = 'ambiguous historical workflow spend; reconcile account meter before 0168',
+                    HINT = 'spent_microusd must equal retained session spend, or retained session plus workflow spend';
+            END IF;
+        END
+        $$
+    """)
     op.execute(r"""
         UPDATE accounts a
-           SET spent_microusd = a.spent_microusd + raw.total_microusd
+           SET spent_microusd = a.spent_microusd + r.total
           FROM (
-               SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total_microusd
-                 FROM wf_runs
-                GROUP BY account_id
-          ) raw
-         WHERE a.id = raw.account_id
+               SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total
+                 FROM wf_runs GROUP BY account_id
+          ) r
+          LEFT JOIN (
+               SELECT account_id, SUM(cost_microusd)::bigint AS total
+                 FROM sessions GROUP BY account_id
+          ) s ON s.account_id = r.account_id
+         WHERE a.id = r.account_id
+           AND r.total > 0
+           AND a.spent_microusd = COALESCE(s.total, 0)
     """)
 
     # Rates need deltas, not cumulative rows. Per-account coverage makes a
@@ -207,6 +268,28 @@ def upgrade() -> None:
     op.execute(
         "ALTER TABLE accounts ADD COLUMN usage_ledger_started_at timestamptz NOT NULL DEFAULT now()"
     )
+    op.execute(r"""
+        DO $$
+        BEGIN
+            IF to_regclass('_aios_0168_account_usage_archive') IS NOT NULL THEN
+                IF EXISTS (
+                    SELECT 1
+                      FROM _aios_0168_account_usage_archive archived
+                      LEFT JOIN accounts a ON a.id = archived.account_id
+                     WHERE a.id IS NULL
+                ) THEN
+                    RAISE EXCEPTION
+                        'cannot restore archived 0168 coverage: an account is missing';
+                END IF;
+                UPDATE accounts a
+                   SET usage_ledger_started_at = archived.usage_ledger_started_at
+                  FROM _aios_0168_account_usage_archive archived
+                 WHERE a.id = archived.account_id;
+                DROP TABLE _aios_0168_account_usage_archive;
+            END IF;
+        END
+        $$
+    """)
     op.execute(r"""
         CREATE TABLE inference_usage_ledger (
             id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -226,6 +309,44 @@ def upgrade() -> None:
             )
         )
     """)
+    op.execute(r"""
+        DO $$
+        BEGIN
+            IF to_regclass('_aios_0168_inference_usage_ledger_archive') IS NOT NULL THEN
+                INSERT INTO inference_usage_ledger (
+                    id,
+                    account_id,
+                    session_id,
+                    run_id,
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                    cost_microusd,
+                    occurred_at
+                )
+                OVERRIDING SYSTEM VALUE
+                SELECT id,
+                       account_id,
+                       session_id,
+                       run_id,
+                       input_tokens,
+                       output_tokens,
+                       cache_read_input_tokens,
+                       cache_creation_input_tokens,
+                       cost_microusd,
+                       occurred_at
+                  FROM _aios_0168_inference_usage_ledger_archive;
+                PERFORM setval(
+                    pg_get_serial_sequence('inference_usage_ledger', 'id'),
+                    COALESCE((SELECT MAX(id) FROM inference_usage_ledger), 1),
+                    EXISTS (SELECT 1 FROM inference_usage_ledger)
+                );
+                DROP TABLE _aios_0168_inference_usage_ledger_archive;
+            END IF;
+        END
+        $$
+    """)
     op.execute(
         "CREATE INDEX inference_usage_ledger_session_window_idx "
         "ON inference_usage_ledger (session_id, occurred_at DESC) "
@@ -242,21 +363,48 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute("DROP TABLE inference_usage_ledger")
-    # ``IF EXISTS`` also makes local iteration safe for databases that briefly
-    # ran the pre-review singleton coverage design of this unreleased revision.
-    op.execute("DROP TABLE IF EXISTS inference_usage_ledger_state")
-    op.execute("ALTER TABLE accounts DROP COLUMN IF EXISTS usage_ledger_started_at")
+    # Older application revisions do not know about the rolling ledger or
+    # token-completeness flag. Archive that evidence instead of deleting it;
+    # a later re-upgrade restores it before accepting new writes. Account spend
+    # remains at its canonical value rather than attempting a lossy subtraction.
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '5min'")
+    op.execute("LOCK TABLE wf_runs, accounts, inference_usage_ledger IN ACCESS EXCLUSIVE MODE")
     op.execute(r"""
-        UPDATE accounts a
-           SET spent_microusd = GREATEST(0, a.spent_microusd - raw.total_microusd)
-          FROM (
-               SELECT account_id, SUM(call_llm_cost_microusd)::bigint AS total_microusd
-                 FROM wf_runs
-                GROUP BY account_id
-          ) raw
-         WHERE a.id = raw.account_id
+        CREATE TABLE _aios_0168_wf_run_usage_archive AS
+        SELECT id AS run_id,
+               account_id,
+               call_llm_input_tokens,
+               call_llm_output_tokens,
+               call_llm_cache_read_input_tokens,
+               call_llm_cache_creation_input_tokens,
+               call_llm_tokens_complete
+          FROM wf_runs
     """)
+    op.execute(r"""
+        CREATE TABLE _aios_0168_account_usage_archive AS
+        SELECT id AS account_id, usage_ledger_started_at
+          FROM accounts
+    """)
+    op.execute(r"""
+        CREATE TABLE _aios_0168_inference_usage_ledger_archive AS
+        SELECT id,
+               account_id,
+               session_id,
+               run_id,
+               input_tokens,
+               output_tokens,
+               cache_read_input_tokens,
+               cache_creation_input_tokens,
+               cost_microusd,
+               occurred_at
+          FROM inference_usage_ledger
+    """)
+    op.execute("DROP TABLE inference_usage_ledger")
+    op.execute("DROP TRIGGER wf_runs_charge_account_spend_trg ON wf_runs")
+    op.execute("DROP FUNCTION _aios_charge_workflow_account_spend()")
+    op.execute("ALTER TABLE accounts DROP COLUMN usage_ledger_started_at")
+    op.execute("ALTER TABLE wf_runs DROP COLUMN call_llm_tokens_complete")
     for column in reversed(
         (
             "call_llm_input_tokens",
@@ -269,10 +417,8 @@ def downgrade() -> None:
     for table in reversed(("sessions", "wf_runs")):
         op.execute(f"DROP INDEX {table}_creator_run_idx")
         op.execute(f"DROP INDEX {table}_creator_session_idx")
-        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {table}_creator_run_account_fk")
-        op.execute(
-            f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {table}_creator_session_account_fk"
-        )
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT {table}_creator_run_account_fk")
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT {table}_creator_session_account_fk")
     op.execute("ALTER TABLE wf_runs DROP CONSTRAINT wf_runs_creator_not_self_ck")
     op.execute("ALTER TABLE sessions DROP CONSTRAINT sessions_creator_not_self_ck")
     for table in reversed(("sessions", "wf_runs")):

--- a/migrations/versions/0168_creation_edge_usage_accounting.py
+++ b/migrations/versions/0168_creation_edge_usage_accounting.py
@@ -36,47 +36,15 @@ def upgrade() -> None:
     )
 
     # Existing workflow agent() children already have an unambiguous creation
-    # edge.  Backfill those before considering session caller provenance.
+    # edge. Backfill those before considering explicit resource provenance.
     op.execute("UPDATE sessions SET creator_run_id = parent_run_id WHERE parent_run_id IS NOT NULL")
-    # Historical call_agent children are ephemeral (archive_when_idle) fresh
-    # sessions whose first request_opened frame names the creating session.
-    # Existing-session call_session targets are not ephemeral, so they are
-    # intentionally excluded: invocation never changes accounting ownership.
-    op.execute(r"""
-        UPDATE sessions s
-           SET creator_session_id = (
-               SELECT e.data->'caller'->>'id'
-                 FROM events e
-                 JOIN sessions creator
-                   ON creator.id = e.data->'caller'->>'id'
-                  AND creator.account_id = s.account_id
-                WHERE e.session_id = s.id
-                  AND e.account_id = s.account_id
-                  AND e.kind = 'lifecycle'
-                  AND e.data->>'event' = 'request_opened'
-                  AND e.data->'caller'->>'kind' = 'session'
-                  AND e.data->'caller'->>'id' <> s.id
-                ORDER BY e.seq
-                LIMIT 1
-           )
-         WHERE s.creator_run_id IS NULL
-           AND s.archive_when_idle = TRUE
-           AND EXISTS (
-               SELECT 1
-                 FROM events e
-                 JOIN sessions creator
-                   ON creator.id = e.data->'caller'->>'id'
-                  AND creator.account_id = s.account_id
-                WHERE e.session_id = s.id
-                  AND e.account_id = s.account_id
-                  AND e.kind = 'lifecycle'
-                  AND e.data->>'event' = 'request_opened'
-                  AND e.data->'caller'->>'kind' = 'session'
-                  AND e.data->'caller'->>'id' <> s.id
-           )
-    """)
-    # Soft resource provenance predates this migration and is a useful fallback
-    # for any session-created resource not covered by the invocation substrate.
+    # Soft resource provenance predates this migration and records who created
+    # the resource, rather than who later invoked it. It is the only safe legacy
+    # session -> session backfill. In particular, archive_when_idle plus a first
+    # request_opened event is NOT creation evidence: the public API can create a
+    # self-archiving root which call_session invokes later. Ambiguous historical
+    # rows intentionally remain roots instead of transferring their spend to an
+    # invocation peer. New call_agent writes creator_session_id at insert time.
     op.execute(r"""
         UPDATE sessions s
            SET creator_session_id = s.created_by_ref

--- a/migrations/versions/0168_workflow_spend_accounting_watermarks.py
+++ b/migrations/versions/0168_workflow_spend_accounting_watermarks.py
@@ -1,6 +1,6 @@
 """Durable provenance for historical workflow-spend reconciliation.
 
-Revision ID: 0167
+Revision ID: 0168
 Revises: 0166
 """
 
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from alembic import op
 
-revision = "0167"
+revision = "0168"
 down_revision = "0166"
 branch_labels = None
 depends_on = None
@@ -36,15 +36,15 @@ def upgrade() -> None:
     op.execute(r"""
         DO $$
         BEGIN
-            IF to_regclass('_aios_0167_workflow_spend_watermarks_archive') IS NOT NULL THEN
+            IF to_regclass('_aios_0168_workflow_spend_watermarks_archive') IS NOT NULL THEN
                 IF EXISTS (
                     SELECT 1
-                      FROM _aios_0167_workflow_spend_watermarks_archive archived
+                      FROM _aios_0168_workflow_spend_watermarks_archive archived
                       LEFT JOIN accounts a ON a.id = archived.account_id
                      WHERE a.id IS NULL
                 ) THEN
                     RAISE EXCEPTION
-                        'cannot restore archived 0167 workflow spend watermark: an account is missing';
+                        'cannot restore archived 0168 workflow spend watermark: an account is missing';
                 END IF;
                 INSERT INTO workflow_spend_accounting_watermarks (
                     account_id,
@@ -58,8 +58,8 @@ def upgrade() -> None:
                        last_observed_run_cost_microusd,
                        last_applied_delta_microusd,
                        reconciled_at
-                  FROM _aios_0167_workflow_spend_watermarks_archive;
-                DROP TABLE _aios_0167_workflow_spend_watermarks_archive;
+                  FROM _aios_0168_workflow_spend_watermarks_archive;
+                DROP TABLE _aios_0168_workflow_spend_watermarks_archive;
             END IF;
         END
         $$
@@ -70,7 +70,7 @@ def downgrade() -> None:
     op.execute("SET LOCAL lock_timeout = '5s'")
     op.execute("LOCK TABLE accounts, workflow_spend_accounting_watermarks IN ACCESS EXCLUSIVE MODE")
     op.execute(r"""
-        CREATE TABLE _aios_0167_workflow_spend_watermarks_archive AS
+        CREATE TABLE _aios_0168_workflow_spend_watermarks_archive AS
         SELECT account_id,
                accounted_run_cost_microusd,
                last_observed_run_cost_microusd,

--- a/migrations/versions/0169_creation_edge_usage_accounting.py
+++ b/migrations/versions/0169_creation_edge_usage_accounting.py
@@ -1,15 +1,15 @@
 """Creation-edge inference accounting and rolling usage ledger.
 
-Revision ID: 0168
-Revises: 0167
+Revision ID: 0169
+Revises: 0168
 """
 
 from __future__ import annotations
 
 from alembic import op
 
-revision = "0168"
-down_revision = "0167"
+revision = "0169"
+down_revision = "0168"
 branch_labels = None
 depends_on = None
 
@@ -156,17 +156,17 @@ def upgrade() -> None:
     op.execute(r"""
         DO $$
         BEGIN
-            IF to_regclass('_aios_0168_wf_run_usage_archive') IS NOT NULL THEN
+            IF to_regclass('_aios_0169_wf_run_usage_archive') IS NOT NULL THEN
                 IF EXISTS (
                     SELECT 1
-                      FROM _aios_0168_wf_run_usage_archive archived
+                      FROM _aios_0169_wf_run_usage_archive archived
                       LEFT JOIN wf_runs r
                         ON r.id = archived.run_id
                        AND r.account_id = archived.account_id
                      WHERE r.id IS NULL
                 ) THEN
                     RAISE EXCEPTION
-                        'cannot restore archived 0168 run usage: a workflow run is missing';
+                        'cannot restore archived 0169 run usage: a workflow run is missing';
                 END IF;
                 UPDATE wf_runs r
                    SET call_llm_input_tokens = a.call_llm_input_tokens,
@@ -174,10 +174,10 @@ def upgrade() -> None:
                        call_llm_cache_read_input_tokens = a.call_llm_cache_read_input_tokens,
                        call_llm_cache_creation_input_tokens = a.call_llm_cache_creation_input_tokens,
                        call_llm_tokens_complete = a.call_llm_tokens_complete
-                  FROM _aios_0168_wf_run_usage_archive a
+                  FROM _aios_0169_wf_run_usage_archive a
                  WHERE r.id = a.run_id
                    AND r.account_id = a.account_id;
-                DROP TABLE _aios_0168_wf_run_usage_archive;
+                DROP TABLE _aios_0169_wf_run_usage_archive;
             END IF;
         END
         $$
@@ -231,7 +231,7 @@ def upgrade() -> None:
 
     # Aggregate equality cannot prove which historical workflow charges were
     # already counted: unrelated/manual spend and deleted sessions can produce
-    # the same scalar. Revision 0167 therefore requires an operator-declared
+    # the same scalar. Revision 0168 therefore requires an operator-declared
     # watermark for every account with retained workflow cost. Reconcile only
     # the unaccounted delta, then advance the watermark atomically. The trigger
     # above maintains the same provenance for every post-migration charge.
@@ -250,8 +250,8 @@ def upgrade() -> None:
                  WHERE r.total > 0 AND watermark.account_id IS NULL
             ) THEN
                 RAISE EXCEPTION USING
-                    MESSAGE = 'missing workflow spend accounting watermark before 0168',
-                    HINT = 'at revision 0167, explicitly record how much retained workflow cost is already represented in each account meter';
+                    MESSAGE = 'missing workflow spend accounting watermark before 0169',
+                    HINT = 'at revision 0168, explicitly record how much retained workflow cost is already represented in each account meter';
             END IF;
             IF EXISTS (
                 WITH run_meter AS (
@@ -265,7 +265,7 @@ def upgrade() -> None:
             ) THEN
                 RAISE EXCEPTION USING
                     MESSAGE = 'workflow spend accounting watermark exceeds retained run cost',
-                    HINT = 'correct the operator-declared watermark at revision 0167 before retrying 0168';
+                    HINT = 'correct the operator-declared watermark at revision 0168 before retrying 0169';
             END IF;
         END
         $$
@@ -305,21 +305,21 @@ def upgrade() -> None:
     op.execute(r"""
         DO $$
         BEGIN
-            IF to_regclass('_aios_0168_account_usage_archive') IS NOT NULL THEN
+            IF to_regclass('_aios_0169_account_usage_archive') IS NOT NULL THEN
                 IF EXISTS (
                     SELECT 1
-                      FROM _aios_0168_account_usage_archive archived
+                      FROM _aios_0169_account_usage_archive archived
                       LEFT JOIN accounts a ON a.id = archived.account_id
                      WHERE a.id IS NULL
                 ) THEN
                     RAISE EXCEPTION
-                        'cannot restore archived 0168 coverage: an account is missing';
+                        'cannot restore archived 0169 coverage: an account is missing';
                 END IF;
                 UPDATE accounts a
                    SET usage_ledger_started_at = archived.usage_ledger_started_at
-                  FROM _aios_0168_account_usage_archive archived
+                  FROM _aios_0169_account_usage_archive archived
                  WHERE a.id = archived.account_id;
-                DROP TABLE _aios_0168_account_usage_archive;
+                DROP TABLE _aios_0169_account_usage_archive;
             END IF;
         END
         $$
@@ -346,7 +346,7 @@ def upgrade() -> None:
     op.execute(r"""
         DO $$
         BEGIN
-            IF to_regclass('_aios_0168_inference_usage_ledger_archive') IS NOT NULL THEN
+            IF to_regclass('_aios_0169_inference_usage_ledger_archive') IS NOT NULL THEN
                 INSERT INTO inference_usage_ledger (
                     id,
                     account_id,
@@ -370,13 +370,13 @@ def upgrade() -> None:
                        cache_creation_input_tokens,
                        cost_microusd,
                        occurred_at
-                  FROM _aios_0168_inference_usage_ledger_archive;
+                  FROM _aios_0169_inference_usage_ledger_archive;
                 PERFORM setval(
                     pg_get_serial_sequence('inference_usage_ledger', 'id'),
                     COALESCE((SELECT MAX(id) FROM inference_usage_ledger), 1),
                     EXISTS (SELECT 1 FROM inference_usage_ledger)
                 );
-                DROP TABLE _aios_0168_inference_usage_ledger_archive;
+                DROP TABLE _aios_0169_inference_usage_ledger_archive;
             END IF;
         END
         $$
@@ -405,7 +405,7 @@ def downgrade() -> None:
     op.execute("SET LOCAL statement_timeout = '5min'")
     op.execute("LOCK TABLE wf_runs, accounts, inference_usage_ledger IN ACCESS EXCLUSIVE MODE")
     op.execute(r"""
-        CREATE TABLE _aios_0168_wf_run_usage_archive AS
+        CREATE TABLE _aios_0169_wf_run_usage_archive AS
         SELECT id AS run_id,
                account_id,
                call_llm_input_tokens,
@@ -416,12 +416,12 @@ def downgrade() -> None:
           FROM wf_runs
     """)
     op.execute(r"""
-        CREATE TABLE _aios_0168_account_usage_archive AS
+        CREATE TABLE _aios_0169_account_usage_archive AS
         SELECT id AS account_id, usage_ledger_started_at
           FROM accounts
     """)
     op.execute(r"""
-        CREATE TABLE _aios_0168_inference_usage_ledger_archive AS
+        CREATE TABLE _aios_0169_inference_usage_ledger_archive AS
         SELECT id,
                account_id,
                session_id,

--- a/openapi.json
+++ b/openapi.json
@@ -19103,6 +19103,11 @@
             "type": "integer",
             "title": "Cache Creation Input Tokens",
             "default": 0
+          },
+          "tokens_complete": {
+            "type": "boolean",
+            "title": "Tokens Complete",
+            "default": true
           }
         },
         "type": "object",
@@ -20235,6 +20240,11 @@
             "type": "integer",
             "title": "Call Llm Cost Microusd",
             "default": 0
+          },
+          "call_llm_tokens_complete": {
+            "type": "boolean",
+            "title": "Call Llm Tokens Complete",
+            "default": true
           },
           "last_event_seq": {
             "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -9964,6 +9964,94 @@
         }
       }
     },
+    "/v1/usage/consumers": {
+      "get": {
+        "tags": [
+          "usage"
+        ],
+        "summary": "List Usage Consumers",
+        "description": "Rank root consumers by rolling creation-subtree inference rate.\n\nRoot consumers are additive: every session/run belongs to exactly one root\nthrough immutable creation edges, so ``share`` values never double-count\nshared invocation work. Archived descendants remain in the rollup. Rates\nupdate on every inference charge and are normalized per hour over the\nrequested rolling window.",
+        "operationId": "list_usage_consumers",
+        "parameters": [
+          {
+            "name": "window_seconds",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 2592000,
+              "minimum": 60,
+              "default": 86400,
+              "title": "Window Seconds"
+            }
+          },
+          {
+            "name": "metric",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "cost_microusd",
+                "total_tokens"
+              ],
+              "type": "string",
+              "default": "cost_microusd",
+              "title": "Metric"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageConsumersResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/workflows": {
       "post": {
         "tags": [
@@ -12233,6 +12321,39 @@
         ],
         "title": "AllowSenders",
         "description": "Admit only canonical connector-supplied sender identifiers."
+      },
+      "AttributedUsage": {
+        "properties": {
+          "own": {
+            "$ref": "#/components/schemas/UsageCounters"
+          },
+          "subtree": {
+            "$ref": "#/components/schemas/UsageCounters"
+          },
+          "own_rate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageRate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "subtree_rate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageRate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "AttributedUsage",
+        "description": "Own and transitive usage for one node in the accounting tree."
       },
       "AwaitResponse": {
         "properties": {
@@ -16536,6 +16657,16 @@
           "usage": {
             "$ref": "#/components/schemas/SessionUsage"
           },
+          "usage_parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageNodeRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "resources": {
             "items": {
               "oneOf": [
@@ -17250,6 +17381,37 @@
       },
       "SessionUsage": {
         "properties": {
+          "own": {
+            "$ref": "#/components/schemas/UsageCounters"
+          },
+          "subtree": {
+            "$ref": "#/components/schemas/UsageCounters"
+          },
+          "own_rate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageRate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "subtree_rate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageRate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "cost_microusd": {
+            "type": "integer",
+            "title": "Cost Microusd",
+            "default": 0
+          },
           "input_tokens": {
             "type": "integer",
             "title": "Input Tokens",
@@ -17273,7 +17435,7 @@
         },
         "type": "object",
         "title": "SessionUsage",
-        "description": "Cumulative token usage across all model calls in a session."
+        "description": "Session inference usage, with backward-compatible own counters.\n\nThe flat counters retain their historical self-only meaning.  New clients\nshould use ``own`` and ``subtree``; those fields cross session/run creation\nboundaries transitively and include archived descendants."
       },
       "SessionUserMessage": {
         "properties": {
@@ -18809,6 +18971,216 @@
         "title": "UpdateAccountRequest",
         "description": "Body for ``PATCH /v1/accounts/{id}``.\n\nPartial update: omitted fields are preserved. All fields are optional;\nsubmitting none is a no-op that returns the account row unchanged.\n``config`` is *merged* into the stored config (only the keys present in\nthe submitted object are written), so setting one config item never\ndisturbs the others."
       },
+      "UsageConsumer": {
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "title": "Rank"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "session",
+              "run"
+            ],
+            "title": "Kind"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
+          },
+          "share": {
+            "type": "number",
+            "title": "Share"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/AttributedUsage"
+          }
+        },
+        "type": "object",
+        "required": [
+          "rank",
+          "kind",
+          "id",
+          "label",
+          "status",
+          "created_at",
+          "share",
+          "usage"
+        ],
+        "title": "UsageConsumer",
+        "description": "One root consumer in the ranked account-wide usage view."
+      },
+      "UsageConsumersResponse": {
+        "properties": {
+          "metric": {
+            "type": "string",
+            "enum": [
+              "cost_microusd",
+              "total_tokens"
+            ],
+            "title": "Metric"
+          },
+          "window_seconds": {
+            "type": "integer",
+            "title": "Window Seconds"
+          },
+          "coverage_started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Coverage Started At"
+          },
+          "total_rate_per_hour": {
+            "type": "number",
+            "title": "Total Rate Per Hour"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UsageConsumer"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "metric",
+          "window_seconds",
+          "coverage_started_at",
+          "total_rate_per_hour"
+        ],
+        "title": "UsageConsumersResponse",
+        "description": "Ranked, additive root consumers for one account."
+      },
+      "UsageCounters": {
+        "properties": {
+          "cost_microusd": {
+            "type": "integer",
+            "title": "Cost Microusd",
+            "default": 0
+          },
+          "input_tokens": {
+            "type": "integer",
+            "title": "Input Tokens",
+            "default": 0
+          },
+          "output_tokens": {
+            "type": "integer",
+            "title": "Output Tokens",
+            "default": 0
+          },
+          "cache_read_input_tokens": {
+            "type": "integer",
+            "title": "Cache Read Input Tokens",
+            "default": 0
+          },
+          "cache_creation_input_tokens": {
+            "type": "integer",
+            "title": "Cache Creation Input Tokens",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "UsageCounters",
+        "description": "Cumulative inference bought at one node or in one subtree."
+      },
+      "UsageNodeRef": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "session",
+              "run"
+            ],
+            "title": "Kind"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "id"
+        ],
+        "title": "UsageNodeRef",
+        "description": "One immutable parent in the creation-accounting tree."
+      },
+      "UsageRate": {
+        "properties": {
+          "window_seconds": {
+            "type": "integer",
+            "title": "Window Seconds"
+          },
+          "observed_seconds": {
+            "type": "integer",
+            "title": "Observed Seconds"
+          },
+          "complete": {
+            "type": "boolean",
+            "title": "Complete"
+          },
+          "cost_microusd_per_hour": {
+            "type": "number",
+            "title": "Cost Microusd Per Hour",
+            "default": 0.0
+          },
+          "input_tokens_per_hour": {
+            "type": "number",
+            "title": "Input Tokens Per Hour",
+            "default": 0.0
+          },
+          "output_tokens_per_hour": {
+            "type": "number",
+            "title": "Output Tokens Per Hour",
+            "default": 0.0
+          },
+          "cache_read_input_tokens_per_hour": {
+            "type": "number",
+            "title": "Cache Read Input Tokens Per Hour",
+            "default": 0.0
+          },
+          "cache_creation_input_tokens_per_hour": {
+            "type": "number",
+            "title": "Cache Creation Input Tokens Per Hour",
+            "default": 0.0
+          }
+        },
+        "type": "object",
+        "required": [
+          "window_seconds",
+          "observed_seconds",
+          "complete"
+        ],
+        "title": "UsageRate",
+        "description": "Rolling-window inference rate, normalized to one hour.\n\nThe usage ledger starts when the accounting migration lands.  Until one\nfull requested window has elapsed, ``complete`` is false and\n``observed_seconds`` states the actual denominator.  Rates remain useful\nimmediately without pretending pre-ledger history was observed."
+      },
       "ValidationError": {
         "properties": {
           "loc": {
@@ -19923,6 +20295,16 @@
                 "type": "null"
               }
             ]
+          },
+          "usage_parent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageNodeRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -20100,6 +20482,32 @@
       },
       "WfRunUsage": {
         "properties": {
+          "own": {
+            "$ref": "#/components/schemas/UsageCounters"
+          },
+          "subtree": {
+            "$ref": "#/components/schemas/UsageCounters"
+          },
+          "own_rate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageRate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "subtree_rate": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageRate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "cost_microusd": {
             "anyOf": [
               {
@@ -20180,7 +20588,7 @@
         },
         "type": "object",
         "title": "WfRunUsage",
-        "description": "Per-run cost / token / iteration / wall-clock \u2014 the machine-observer's substrate.\n\nThe read-path projection of a run's actual spend (#1324). The numbers are summed\nover the run's direct child sessions via ``run_children_usage`` \u2014 the SAME source\n``step.py``'s ``budget()`` builtin consumes \u2014 so a run's ``budget_usd`` *ceiling*\n(on ``WfRun``) and its realized ``cost_microusd`` *spend* (here) are finally both\nlegible from the read path.\n\nEVERY field is ``int | None``, and absence is reported as **explicit null**, never\na silent ``0`` or an omitted key (cf. the ``vault_ids:null`` read-path disease this\nmust not inherit \u2014 see the substrate-different-verdict invariant). The observer\nreads null as *cannot-determine* and fails loud, NOT as \"zero spend\":\n\n* ``cost_microusd`` / ``*_tokens`` \u2014 summed over the run's child sessions. A run\n  with no children sums to ``0`` (a real, observed zero \u2014 distinct from null).\n* ``iteration_count`` \u2014 the run's wake/step count. The host keeps **no** per-run\n  iteration counter on any substrate today, so this is reported as ``None``\n  (cannot-determine) rather than fabricated from an unrelated proxy. Reserved for\n  when a real counter lands; surfaced now so the observer's contract is stable.\n* ``wall_clock_ms`` \u2014 wall-clock span ``updated_at - created_at`` in milliseconds,\n  reported ONLY for a TERMINAL run (``updated_at`` is its completion instant). A\n  still-running run's ``updated_at`` is a moving \"last touched\" stamp, not an end,\n  so it is reported as ``None`` rather than a misleading partial span."
+        "description": "Per-run cost / token / iteration / wall-clock \u2014 the machine-observer's substrate.\n\nThe read-path projection of a run's actual spend (#1324). The numbers are summed\nover the run's direct child sessions via ``run_children_usage`` \u2014 the SAME source\n``step.py``'s ``budget()`` builtin consumes \u2014 so a run's ``budget_usd`` *ceiling*\n(on ``WfRun``) and its realized ``cost_microusd`` *spend* (here) are finally both\nlegible from the read path.\n\nEvery legacy flat metric is ``int | None``, and absence is reported as\n**explicit null**, never a silent ``0`` or an omitted key (cf. the\n``vault_ids:null`` read-path disease this must not inherit \u2014 see the\nsubstrate-different-verdict invariant). The observer reads null as\n*cannot-determine* and fails loud, NOT as \"zero spend\". Creation accounting\nis carried separately by the inherited ``own``/``subtree`` and rate fields:\n\n* ``cost_microusd`` / ``*_tokens`` \u2014 summed over the run's child sessions. A run\n  with no children sums to ``0`` (a real, observed zero \u2014 distinct from null).\n* ``iteration_count`` \u2014 the run's wake/step count. The host keeps **no** per-run\n  iteration counter on any substrate today, so this is reported as ``None``\n  (cannot-determine) rather than fabricated from an unrelated proxy. Reserved for\n  when a real counter lands; surfaced now so the observer's contract is stable.\n* ``wall_clock_ms`` \u2014 wall-clock span ``updated_at - created_at`` in milliseconds,\n  reported ONLY for a TERMINAL run (``updated_at`` is its completion instant). A\n  still-running run's ``updated_at`` is a moving \"last touched\" stamp, not an end,\n  so it is reported as ``None`` rather than a misleading partial span."
       },
       "WhatsappConfirmPairingRequest": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/usage/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/usage/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/aios-sdk/aios_sdk/_generated/api/usage/list_usage_consumers.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/usage/list_usage_consumers.py
@@ -1,0 +1,254 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_usage_consumers_metric import ListUsageConsumersMetric
+from ...models.usage_consumers_response import UsageConsumersResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    window_seconds: int | Unset = 86400,
+    metric: ListUsageConsumersMetric | Unset = ListUsageConsumersMetric.COST_MICROUSD,
+    limit: int | Unset = 20,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["window_seconds"] = window_seconds
+
+    json_metric: str | Unset = UNSET
+    if not isinstance(metric, Unset):
+        json_metric = metric.value
+
+    params["metric"] = json_metric
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/usage/consumers",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | UsageConsumersResponse | None:
+    if response.status_code == 200:
+        response_200 = UsageConsumersResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | UsageConsumersResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    window_seconds: int | Unset = 86400,
+    metric: ListUsageConsumersMetric | Unset = ListUsageConsumersMetric.COST_MICROUSD,
+    limit: int | Unset = 20,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | UsageConsumersResponse]:
+    """List Usage Consumers
+
+     Rank root consumers by rolling creation-subtree inference rate.
+
+    Root consumers are additive: every session/run belongs to exactly one root
+    through immutable creation edges, so ``share`` values never double-count
+    shared invocation work. Archived descendants remain in the rollup. Rates
+    update on every inference charge and are normalized per hour over the
+    requested rolling window.
+
+    Args:
+        window_seconds (int | Unset):  Default: 86400.
+        metric (ListUsageConsumersMetric | Unset):  Default:
+            ListUsageConsumersMetric.COST_MICROUSD.
+        limit (int | Unset):  Default: 20.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | UsageConsumersResponse]
+    """
+
+    kwargs = _get_kwargs(
+        window_seconds=window_seconds,
+        metric=metric,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    window_seconds: int | Unset = 86400,
+    metric: ListUsageConsumersMetric | Unset = ListUsageConsumersMetric.COST_MICROUSD,
+    limit: int | Unset = 20,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | UsageConsumersResponse | None:
+    """List Usage Consumers
+
+     Rank root consumers by rolling creation-subtree inference rate.
+
+    Root consumers are additive: every session/run belongs to exactly one root
+    through immutable creation edges, so ``share`` values never double-count
+    shared invocation work. Archived descendants remain in the rollup. Rates
+    update on every inference charge and are normalized per hour over the
+    requested rolling window.
+
+    Args:
+        window_seconds (int | Unset):  Default: 86400.
+        metric (ListUsageConsumersMetric | Unset):  Default:
+            ListUsageConsumersMetric.COST_MICROUSD.
+        limit (int | Unset):  Default: 20.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | UsageConsumersResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        window_seconds=window_seconds,
+        metric=metric,
+        limit=limit,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    window_seconds: int | Unset = 86400,
+    metric: ListUsageConsumersMetric | Unset = ListUsageConsumersMetric.COST_MICROUSD,
+    limit: int | Unset = 20,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | UsageConsumersResponse]:
+    """List Usage Consumers
+
+     Rank root consumers by rolling creation-subtree inference rate.
+
+    Root consumers are additive: every session/run belongs to exactly one root
+    through immutable creation edges, so ``share`` values never double-count
+    shared invocation work. Archived descendants remain in the rollup. Rates
+    update on every inference charge and are normalized per hour over the
+    requested rolling window.
+
+    Args:
+        window_seconds (int | Unset):  Default: 86400.
+        metric (ListUsageConsumersMetric | Unset):  Default:
+            ListUsageConsumersMetric.COST_MICROUSD.
+        limit (int | Unset):  Default: 20.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | UsageConsumersResponse]
+    """
+
+    kwargs = _get_kwargs(
+        window_seconds=window_seconds,
+        metric=metric,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    window_seconds: int | Unset = 86400,
+    metric: ListUsageConsumersMetric | Unset = ListUsageConsumersMetric.COST_MICROUSD,
+    limit: int | Unset = 20,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | UsageConsumersResponse | None:
+    """List Usage Consumers
+
+     Rank root consumers by rolling creation-subtree inference rate.
+
+    Root consumers are additive: every session/run belongs to exactly one root
+    through immutable creation edges, so ``share`` values never double-count
+    shared invocation work. Archived descendants remain in the rollup. Rates
+    update on every inference charge and are normalized per hour over the
+    requested rolling window.
+
+    Args:
+        window_seconds (int | Unset):  Default: 86400.
+        metric (ListUsageConsumersMetric | Unset):  Default:
+            ListUsageConsumersMetric.COST_MICROUSD.
+        limit (int | Unset):  Default: 20.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | UsageConsumersResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            window_seconds=window_seconds,
+            metric=metric,
+            limit=limit,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -26,6 +26,7 @@ from .agent_version_preempt_policy import AgentVersionPreemptPolicy
 from .allow_all import AllowAll
 from .allow_list import AllowList
 from .allow_senders import AllowSenders
+from .attributed_usage import AttributedUsage
 from .await_response import AwaitResponse
 from .await_response_error_type_0 import AwaitResponseErrorType0
 from .await_response_outcome_type_0 import AwaitResponseOutcomeType0
@@ -132,6 +133,7 @@ from .list_session_events_dir import ListSessionEventsDir
 from .list_session_events_kind_type_0 import ListSessionEventsKindType0
 from .list_sessions_status_type_0 import ListSessionsStatusType0
 from .list_sessions_view_type_0 import ListSessionsViewType0
+from .list_usage_consumers_metric import ListUsageConsumersMetric
 from .mcp_permission_policy import McpPermissionPolicy
 from .mcp_permission_policy_type import McpPermissionPolicyType
 from .mcp_server_spec import McpServerSpec
@@ -294,6 +296,14 @@ from .trigger_update import TriggerUpdate
 from .trigger_update_metadata_type_0 import TriggerUpdateMetadataType0
 from .unrestricted_networking import UnrestrictedNetworking
 from .update_account_request import UpdateAccountRequest
+from .usage_consumer import UsageConsumer
+from .usage_consumer_kind import UsageConsumerKind
+from .usage_consumers_response import UsageConsumersResponse
+from .usage_consumers_response_metric import UsageConsumersResponseMetric
+from .usage_counters import UsageCounters
+from .usage_node_ref import UsageNodeRef
+from .usage_node_ref_kind import UsageNodeRefKind
+from .usage_rate import UsageRate
 from .validation_error import ValidationError
 from .validation_error_context import ValidationErrorContext
 from .vault import Vault
@@ -382,6 +392,7 @@ __all__ = (
     "AllowAll",
     "AllowList",
     "AllowSenders",
+    "AttributedUsage",
     "AwaitingToolCall",
     "AwaitingToolCallKind",
     "AwaitResponse",
@@ -478,6 +489,7 @@ __all__ = (
     "ListSessionEventsKindType0",
     "ListSessionsStatusType0",
     "ListSessionsViewType0",
+    "ListUsageConsumersMetric",
     "McpPermissionPolicy",
     "McpPermissionPolicyType",
     "McpServerSpec",
@@ -620,6 +632,14 @@ __all__ = (
     "TriggerUpdateMetadataType0",
     "UnrestrictedNetworking",
     "UpdateAccountRequest",
+    "UsageConsumer",
+    "UsageConsumerKind",
+    "UsageConsumersResponse",
+    "UsageConsumersResponseMetric",
+    "UsageCounters",
+    "UsageNodeRef",
+    "UsageNodeRefKind",
+    "UsageRate",
     "ValidationError",
     "ValidationErrorContext",
     "Vault",

--- a/packages/aios-sdk/aios_sdk/_generated/models/attributed_usage.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/attributed_usage.py
@@ -13,38 +13,24 @@ if TYPE_CHECKING:
     from ..models.usage_rate import UsageRate
 
 
-T = TypeVar("T", bound="SessionUsage")
+T = TypeVar("T", bound="AttributedUsage")
 
 
 @_attrs_define
-class SessionUsage:
-    """Session inference usage, with backward-compatible own counters.
+class AttributedUsage:
+    """Own and transitive usage for one node in the accounting tree.
 
-    The flat counters retain their historical self-only meaning.  New clients
-    should use ``own`` and ``subtree``; those fields cross session/run creation
-    boundaries transitively and include archived descendants.
-
-        Attributes:
-            own (UsageCounters | Unset): Cumulative inference bought at one node or in one subtree.
-            subtree (UsageCounters | Unset): Cumulative inference bought at one node or in one subtree.
-            own_rate (None | Unset | UsageRate):
-            subtree_rate (None | Unset | UsageRate):
-            cost_microusd (int | Unset):  Default: 0.
-            input_tokens (int | Unset):  Default: 0.
-            output_tokens (int | Unset):  Default: 0.
-            cache_read_input_tokens (int | Unset):  Default: 0.
-            cache_creation_input_tokens (int | Unset):  Default: 0.
+    Attributes:
+        own (UsageCounters | Unset): Cumulative inference bought at one node or in one subtree.
+        subtree (UsageCounters | Unset): Cumulative inference bought at one node or in one subtree.
+        own_rate (None | Unset | UsageRate):
+        subtree_rate (None | Unset | UsageRate):
     """
 
     own: UsageCounters | Unset = UNSET
     subtree: UsageCounters | Unset = UNSET
     own_rate: None | Unset | UsageRate = UNSET
     subtree_rate: None | Unset | UsageRate = UNSET
-    cost_microusd: int | Unset = 0
-    input_tokens: int | Unset = 0
-    output_tokens: int | Unset = 0
-    cache_read_input_tokens: int | Unset = 0
-    cache_creation_input_tokens: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -74,16 +60,6 @@ class SessionUsage:
         else:
             subtree_rate = self.subtree_rate
 
-        cost_microusd = self.cost_microusd
-
-        input_tokens = self.input_tokens
-
-        output_tokens = self.output_tokens
-
-        cache_read_input_tokens = self.cache_read_input_tokens
-
-        cache_creation_input_tokens = self.cache_creation_input_tokens
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -95,16 +71,6 @@ class SessionUsage:
             field_dict["own_rate"] = own_rate
         if subtree_rate is not UNSET:
             field_dict["subtree_rate"] = subtree_rate
-        if cost_microusd is not UNSET:
-            field_dict["cost_microusd"] = cost_microusd
-        if input_tokens is not UNSET:
-            field_dict["input_tokens"] = input_tokens
-        if output_tokens is not UNSET:
-            field_dict["output_tokens"] = output_tokens
-        if cache_read_input_tokens is not UNSET:
-            field_dict["cache_read_input_tokens"] = cache_read_input_tokens
-        if cache_creation_input_tokens is not UNSET:
-            field_dict["cache_creation_input_tokens"] = cache_creation_input_tokens
 
         return field_dict
 
@@ -162,30 +128,15 @@ class SessionUsage:
 
         subtree_rate = _parse_subtree_rate(d.pop("subtree_rate", UNSET))
 
-        cost_microusd = d.pop("cost_microusd", UNSET)
-
-        input_tokens = d.pop("input_tokens", UNSET)
-
-        output_tokens = d.pop("output_tokens", UNSET)
-
-        cache_read_input_tokens = d.pop("cache_read_input_tokens", UNSET)
-
-        cache_creation_input_tokens = d.pop("cache_creation_input_tokens", UNSET)
-
-        session_usage = cls(
+        attributed_usage = cls(
             own=own,
             subtree=subtree,
             own_rate=own_rate,
             subtree_rate=subtree_rate,
-            cost_microusd=cost_microusd,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cache_read_input_tokens=cache_read_input_tokens,
-            cache_creation_input_tokens=cache_creation_input_tokens,
         )
 
-        session_usage.additional_properties = d
-        return session_usage
+        attributed_usage.additional_properties = d
+        return attributed_usage
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_usage_consumers_metric.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_usage_consumers_metric.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ListUsageConsumersMetric(str, Enum):
+    COST_MICROUSD = "cost_microusd"
+    TOTAL_TOKENS = "total_tokens"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from ..models.session_stop_reason_type_0 import SessionStopReasonType0
     from ..models.session_usage import SessionUsage
     from ..models.trigger_echo import TriggerEcho
+    from ..models.usage_node_ref import UsageNodeRef
 
 
 T = TypeVar("T", bound="Session")
@@ -57,7 +58,12 @@ class Session:
             awaiting (list[AwaitingToolCall] | Unset):
             obligations (list[Obligation] | Unset):
             vault_ids (list[str] | Unset):
-            usage (SessionUsage | Unset): Cumulative token usage across all model calls in a session.
+            usage (SessionUsage | Unset): Session inference usage, with backward-compatible own counters.
+
+                The flat counters retain their historical self-only meaning.  New clients
+                should use ``own`` and ``subtree``; those fields cross session/run creation
+                boundaries transitively and include archived descendants.
+            usage_parent (None | Unset | UsageNodeRef):
             resources (list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset):
             triggers (list[TriggerEcho] | Unset):
             created_by (Actor | None | Unset):
@@ -88,6 +94,7 @@ class Session:
     obligations: list[Obligation] | Unset = UNSET
     vault_ids: list[str] | Unset = UNSET
     usage: SessionUsage | Unset = UNSET
+    usage_parent: None | Unset | UsageNodeRef = UNSET
     resources: list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset = (
         UNSET
     )
@@ -110,6 +117,7 @@ class Session:
         from ..models.actor import Actor
         from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
         from ..models.session_stop_reason_type_0 import SessionStopReasonType0
+        from ..models.usage_node_ref import UsageNodeRef
 
         id = self.id
 
@@ -167,6 +175,14 @@ class Session:
         usage: dict[str, Any] | Unset = UNSET
         if not isinstance(self.usage, Unset):
             usage = self.usage.to_dict()
+
+        usage_parent: dict[str, Any] | None | Unset
+        if isinstance(self.usage_parent, Unset):
+            usage_parent = UNSET
+        elif isinstance(self.usage_parent, UsageNodeRef):
+            usage_parent = self.usage_parent.to_dict()
+        else:
+            usage_parent = self.usage_parent
 
         resources: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.resources, Unset):
@@ -264,6 +280,8 @@ class Session:
             field_dict["vault_ids"] = vault_ids
         if usage is not UNSET:
             field_dict["usage"] = usage
+        if usage_parent is not UNSET:
+            field_dict["usage_parent"] = usage_parent
         if resources is not UNSET:
             field_dict["resources"] = resources
         if triggers is not UNSET:
@@ -304,6 +322,7 @@ class Session:
         from ..models.session_stop_reason_type_0 import SessionStopReasonType0
         from ..models.session_usage import SessionUsage
         from ..models.trigger_echo import TriggerEcho
+        from ..models.usage_node_ref import UsageNodeRef
 
         d = dict(src_dict)
         id = d.pop("id")
@@ -391,6 +410,23 @@ class Session:
             usage = UNSET
         else:
             usage = SessionUsage.from_dict(_usage)
+
+        def _parse_usage_parent(data: object) -> None | Unset | UsageNodeRef:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                usage_parent_type_0 = UsageNodeRef.from_dict(data)
+
+                return usage_parent_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UsageNodeRef, data)
+
+        usage_parent = _parse_usage_parent(d.pop("usage_parent", UNSET))
 
         _resources = d.pop("resources", UNSET)
         resources: (
@@ -536,6 +572,7 @@ class Session:
             obligations=obligations,
             vault_ids=vault_ids,
             usage=usage,
+            usage_parent=usage_parent,
             resources=resources,
             triggers=triggers,
             created_by=created_by,

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_consumer.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_consumer.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.usage_consumer_kind import UsageConsumerKind
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.attributed_usage import AttributedUsage
+
+
+T = TypeVar("T", bound="UsageConsumer")
+
+
+@_attrs_define
+class UsageConsumer:
+    """One root consumer in the ranked account-wide usage view.
+
+    Attributes:
+        rank (int):
+        kind (UsageConsumerKind):
+        id (str):
+        label (str):
+        status (str):
+        created_at (datetime.datetime):
+        share (float):
+        usage (AttributedUsage): Own and transitive usage for one node in the accounting tree.
+        archived_at (datetime.datetime | None | Unset):
+    """
+
+    rank: int
+    kind: UsageConsumerKind
+    id: str
+    label: str
+    status: str
+    created_at: datetime.datetime
+    share: float
+    usage: AttributedUsage
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        rank = self.rank
+
+        kind = self.kind.value
+
+        id = self.id
+
+        label = self.label
+
+        status = self.status
+
+        created_at = self.created_at.isoformat()
+
+        share = self.share
+
+        usage = self.usage.to_dict()
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "rank": rank,
+                "kind": kind,
+                "id": id,
+                "label": label,
+                "status": status,
+                "created_at": created_at,
+                "share": share,
+                "usage": usage,
+            }
+        )
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.attributed_usage import AttributedUsage
+
+        d = dict(src_dict)
+        rank = d.pop("rank")
+
+        kind = UsageConsumerKind(d.pop("kind"))
+
+        id = d.pop("id")
+
+        label = d.pop("label")
+
+        status = d.pop("status")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        share = d.pop("share")
+
+        usage = AttributedUsage.from_dict(d.pop("usage"))
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        usage_consumer = cls(
+            rank=rank,
+            kind=kind,
+            id=id,
+            label=label,
+            status=status,
+            created_at=created_at,
+            share=share,
+            usage=usage,
+            archived_at=archived_at,
+        )
+
+        usage_consumer.additional_properties = d
+        return usage_consumer
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_consumer_kind.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_consumer_kind.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class UsageConsumerKind(str, Enum):
+    RUN = "run"
+    SESSION = "session"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_consumers_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_consumers_response.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.usage_consumers_response_metric import UsageConsumersResponseMetric
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.usage_consumer import UsageConsumer
+
+
+T = TypeVar("T", bound="UsageConsumersResponse")
+
+
+@_attrs_define
+class UsageConsumersResponse:
+    """Ranked, additive root consumers for one account.
+
+    Attributes:
+        metric (UsageConsumersResponseMetric):
+        window_seconds (int):
+        coverage_started_at (datetime.datetime):
+        total_rate_per_hour (float):
+        items (list[UsageConsumer] | Unset):
+    """
+
+    metric: UsageConsumersResponseMetric
+    window_seconds: int
+    coverage_started_at: datetime.datetime
+    total_rate_per_hour: float
+    items: list[UsageConsumer] | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        metric = self.metric.value
+
+        window_seconds = self.window_seconds
+
+        coverage_started_at = self.coverage_started_at.isoformat()
+
+        total_rate_per_hour = self.total_rate_per_hour
+
+        items: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.items, Unset):
+            items = []
+            for items_item_data in self.items:
+                items_item = items_item_data.to_dict()
+                items.append(items_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "metric": metric,
+                "window_seconds": window_seconds,
+                "coverage_started_at": coverage_started_at,
+                "total_rate_per_hour": total_rate_per_hour,
+            }
+        )
+        if items is not UNSET:
+            field_dict["items"] = items
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.usage_consumer import UsageConsumer
+
+        d = dict(src_dict)
+        metric = UsageConsumersResponseMetric(d.pop("metric"))
+
+        window_seconds = d.pop("window_seconds")
+
+        coverage_started_at = isoparse(d.pop("coverage_started_at"))
+
+        total_rate_per_hour = d.pop("total_rate_per_hour")
+
+        _items = d.pop("items", UNSET)
+        items: list[UsageConsumer] | Unset = UNSET
+        if _items is not UNSET:
+            items = []
+            for items_item_data in _items:
+                items_item = UsageConsumer.from_dict(items_item_data)
+
+                items.append(items_item)
+
+        usage_consumers_response = cls(
+            metric=metric,
+            window_seconds=window_seconds,
+            coverage_started_at=coverage_started_at,
+            total_rate_per_hour=total_rate_per_hour,
+            items=items,
+        )
+
+        usage_consumers_response.additional_properties = d
+        return usage_consumers_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_consumers_response_metric.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_consumers_response_metric.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class UsageConsumersResponseMetric(str, Enum):
+    COST_MICROUSD = "cost_microusd"
+    TOTAL_TOKENS = "total_tokens"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_counters.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_counters.py
@@ -21,6 +21,7 @@ class UsageCounters:
         output_tokens (int | Unset):  Default: 0.
         cache_read_input_tokens (int | Unset):  Default: 0.
         cache_creation_input_tokens (int | Unset):  Default: 0.
+        tokens_complete (bool | Unset):  Default: True.
     """
 
     cost_microusd: int | Unset = 0
@@ -28,6 +29,7 @@ class UsageCounters:
     output_tokens: int | Unset = 0
     cache_read_input_tokens: int | Unset = 0
     cache_creation_input_tokens: int | Unset = 0
+    tokens_complete: bool | Unset = True
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -40,6 +42,8 @@ class UsageCounters:
         cache_read_input_tokens = self.cache_read_input_tokens
 
         cache_creation_input_tokens = self.cache_creation_input_tokens
+
+        tokens_complete = self.tokens_complete
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -54,6 +58,8 @@ class UsageCounters:
             field_dict["cache_read_input_tokens"] = cache_read_input_tokens
         if cache_creation_input_tokens is not UNSET:
             field_dict["cache_creation_input_tokens"] = cache_creation_input_tokens
+        if tokens_complete is not UNSET:
+            field_dict["tokens_complete"] = tokens_complete
 
         return field_dict
 
@@ -70,12 +76,15 @@ class UsageCounters:
 
         cache_creation_input_tokens = d.pop("cache_creation_input_tokens", UNSET)
 
+        tokens_complete = d.pop("tokens_complete", UNSET)
+
         usage_counters = cls(
             cost_microusd=cost_microusd,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
             cache_creation_input_tokens=cache_creation_input_tokens,
+            tokens_complete=tokens_complete,
         )
 
         usage_counters.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_counters.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_counters.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UsageCounters")
+
+
+@_attrs_define
+class UsageCounters:
+    """Cumulative inference bought at one node or in one subtree.
+
+    Attributes:
+        cost_microusd (int | Unset):  Default: 0.
+        input_tokens (int | Unset):  Default: 0.
+        output_tokens (int | Unset):  Default: 0.
+        cache_read_input_tokens (int | Unset):  Default: 0.
+        cache_creation_input_tokens (int | Unset):  Default: 0.
+    """
+
+    cost_microusd: int | Unset = 0
+    input_tokens: int | Unset = 0
+    output_tokens: int | Unset = 0
+    cache_read_input_tokens: int | Unset = 0
+    cache_creation_input_tokens: int | Unset = 0
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        cost_microusd = self.cost_microusd
+
+        input_tokens = self.input_tokens
+
+        output_tokens = self.output_tokens
+
+        cache_read_input_tokens = self.cache_read_input_tokens
+
+        cache_creation_input_tokens = self.cache_creation_input_tokens
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if cost_microusd is not UNSET:
+            field_dict["cost_microusd"] = cost_microusd
+        if input_tokens is not UNSET:
+            field_dict["input_tokens"] = input_tokens
+        if output_tokens is not UNSET:
+            field_dict["output_tokens"] = output_tokens
+        if cache_read_input_tokens is not UNSET:
+            field_dict["cache_read_input_tokens"] = cache_read_input_tokens
+        if cache_creation_input_tokens is not UNSET:
+            field_dict["cache_creation_input_tokens"] = cache_creation_input_tokens
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        cost_microusd = d.pop("cost_microusd", UNSET)
+
+        input_tokens = d.pop("input_tokens", UNSET)
+
+        output_tokens = d.pop("output_tokens", UNSET)
+
+        cache_read_input_tokens = d.pop("cache_read_input_tokens", UNSET)
+
+        cache_creation_input_tokens = d.pop("cache_creation_input_tokens", UNSET)
+
+        usage_counters = cls(
+            cost_microusd=cost_microusd,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+        )
+
+        usage_counters.additional_properties = d
+        return usage_counters
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_node_ref.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_node_ref.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.usage_node_ref_kind import UsageNodeRefKind
+
+T = TypeVar("T", bound="UsageNodeRef")
+
+
+@_attrs_define
+class UsageNodeRef:
+    """One immutable parent in the creation-accounting tree.
+
+    Attributes:
+        kind (UsageNodeRefKind):
+        id (str):
+    """
+
+    kind: UsageNodeRefKind
+    id: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        kind = self.kind.value
+
+        id = self.id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "kind": kind,
+                "id": id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        kind = UsageNodeRefKind(d.pop("kind"))
+
+        id = d.pop("id")
+
+        usage_node_ref = cls(
+            kind=kind,
+            id=id,
+        )
+
+        usage_node_ref.additional_properties = d
+        return usage_node_ref
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_node_ref_kind.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_node_ref_kind.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class UsageNodeRefKind(str, Enum):
+    RUN = "run"
+    SESSION = "session"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/usage_rate.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/usage_rate.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UsageRate")
+
+
+@_attrs_define
+class UsageRate:
+    """Rolling-window inference rate, normalized to one hour.
+
+    The usage ledger starts when the accounting migration lands.  Until one
+    full requested window has elapsed, ``complete`` is false and
+    ``observed_seconds`` states the actual denominator.  Rates remain useful
+    immediately without pretending pre-ledger history was observed.
+
+        Attributes:
+            window_seconds (int):
+            observed_seconds (int):
+            complete (bool):
+            cost_microusd_per_hour (float | Unset):  Default: 0.0.
+            input_tokens_per_hour (float | Unset):  Default: 0.0.
+            output_tokens_per_hour (float | Unset):  Default: 0.0.
+            cache_read_input_tokens_per_hour (float | Unset):  Default: 0.0.
+            cache_creation_input_tokens_per_hour (float | Unset):  Default: 0.0.
+    """
+
+    window_seconds: int
+    observed_seconds: int
+    complete: bool
+    cost_microusd_per_hour: float | Unset = 0.0
+    input_tokens_per_hour: float | Unset = 0.0
+    output_tokens_per_hour: float | Unset = 0.0
+    cache_read_input_tokens_per_hour: float | Unset = 0.0
+    cache_creation_input_tokens_per_hour: float | Unset = 0.0
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        window_seconds = self.window_seconds
+
+        observed_seconds = self.observed_seconds
+
+        complete = self.complete
+
+        cost_microusd_per_hour = self.cost_microusd_per_hour
+
+        input_tokens_per_hour = self.input_tokens_per_hour
+
+        output_tokens_per_hour = self.output_tokens_per_hour
+
+        cache_read_input_tokens_per_hour = self.cache_read_input_tokens_per_hour
+
+        cache_creation_input_tokens_per_hour = self.cache_creation_input_tokens_per_hour
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "window_seconds": window_seconds,
+                "observed_seconds": observed_seconds,
+                "complete": complete,
+            }
+        )
+        if cost_microusd_per_hour is not UNSET:
+            field_dict["cost_microusd_per_hour"] = cost_microusd_per_hour
+        if input_tokens_per_hour is not UNSET:
+            field_dict["input_tokens_per_hour"] = input_tokens_per_hour
+        if output_tokens_per_hour is not UNSET:
+            field_dict["output_tokens_per_hour"] = output_tokens_per_hour
+        if cache_read_input_tokens_per_hour is not UNSET:
+            field_dict["cache_read_input_tokens_per_hour"] = (
+                cache_read_input_tokens_per_hour
+            )
+        if cache_creation_input_tokens_per_hour is not UNSET:
+            field_dict["cache_creation_input_tokens_per_hour"] = (
+                cache_creation_input_tokens_per_hour
+            )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        window_seconds = d.pop("window_seconds")
+
+        observed_seconds = d.pop("observed_seconds")
+
+        complete = d.pop("complete")
+
+        cost_microusd_per_hour = d.pop("cost_microusd_per_hour", UNSET)
+
+        input_tokens_per_hour = d.pop("input_tokens_per_hour", UNSET)
+
+        output_tokens_per_hour = d.pop("output_tokens_per_hour", UNSET)
+
+        cache_read_input_tokens_per_hour = d.pop(
+            "cache_read_input_tokens_per_hour", UNSET
+        )
+
+        cache_creation_input_tokens_per_hour = d.pop(
+            "cache_creation_input_tokens_per_hour", UNSET
+        )
+
+        usage_rate = cls(
+            window_seconds=window_seconds,
+            observed_seconds=observed_seconds,
+            complete=complete,
+            cost_microusd_per_hour=cost_microusd_per_hour,
+            input_tokens_per_hour=input_tokens_per_hour,
+            output_tokens_per_hour=output_tokens_per_hour,
+            cache_read_input_tokens_per_hour=cache_read_input_tokens_per_hour,
+            cache_creation_input_tokens_per_hour=cache_creation_input_tokens_per_hour,
+        )
+
+        usage_rate.additional_properties = d
+        return usage_rate
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -75,6 +75,7 @@ class WfRun:
             budget_usd (float | None | Unset):
             default_child_model (None | str | Unset):
             call_llm_cost_microusd (int | Unset):  Default: 0.
+            call_llm_tokens_complete (bool | Unset):  Default: True.
             archived_at (datetime.datetime | None | Unset):
             terminal_summary (None | Unset | WfRunTerminalSummaryType0):
             journal_pruned_at (datetime.datetime | None | Unset):
@@ -110,6 +111,7 @@ class WfRun:
     budget_usd: float | None | Unset = UNSET
     default_child_model: None | str | Unset = UNSET
     call_llm_cost_microusd: int | Unset = 0
+    call_llm_tokens_complete: bool | Unset = True
     archived_at: datetime.datetime | None | Unset = UNSET
     terminal_summary: None | Unset | WfRunTerminalSummaryType0 = UNSET
     journal_pruned_at: datetime.datetime | None | Unset = UNSET
@@ -243,6 +245,8 @@ class WfRun:
 
         call_llm_cost_microusd = self.call_llm_cost_microusd
 
+        call_llm_tokens_complete = self.call_llm_tokens_complete
+
         archived_at: None | str | Unset
         if isinstance(self.archived_at, Unset):
             archived_at = UNSET
@@ -335,6 +339,8 @@ class WfRun:
             field_dict["default_child_model"] = default_child_model
         if call_llm_cost_microusd is not UNSET:
             field_dict["call_llm_cost_microusd"] = call_llm_cost_microusd
+        if call_llm_tokens_complete is not UNSET:
+            field_dict["call_llm_tokens_complete"] = call_llm_tokens_complete
         if archived_at is not UNSET:
             field_dict["archived_at"] = archived_at
         if terminal_summary is not UNSET:
@@ -540,6 +546,8 @@ class WfRun:
 
         call_llm_cost_microusd = d.pop("call_llm_cost_microusd", UNSET)
 
+        call_llm_tokens_complete = d.pop("call_llm_tokens_complete", UNSET)
+
         def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -656,6 +664,7 @@ class WfRun:
             budget_usd=budget_usd,
             default_child_model=default_child_model,
             call_llm_cost_microusd=call_llm_cost_microusd,
+            call_llm_tokens_complete=call_llm_tokens_complete,
             archived_at=archived_at,
             terminal_summary=terminal_summary,
             journal_pruned_at=journal_pruned_at,

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from ..models.http_server_spec import HttpServerSpec
     from ..models.mcp_server_spec import McpServerSpec
     from ..models.tool_spec import ToolSpec
+    from ..models.usage_node_ref import UsageNodeRef
     from ..models.wf_run_caller_type_0 import WfRunCallerType0
     from ..models.wf_run_request_output_schema_type_0 import (
         WfRunRequestOutputSchemaType0,
@@ -78,6 +79,7 @@ class WfRun:
             terminal_summary (None | Unset | WfRunTerminalSummaryType0):
             journal_pruned_at (datetime.datetime | None | Unset):
             usage (None | Unset | WfRunUsage):
+            usage_parent (None | Unset | UsageNodeRef):
     """
 
     id: str
@@ -112,9 +114,11 @@ class WfRun:
     terminal_summary: None | Unset | WfRunTerminalSummaryType0 = UNSET
     journal_pruned_at: datetime.datetime | None | Unset = UNSET
     usage: None | Unset | WfRunUsage = UNSET
+    usage_parent: None | Unset | UsageNodeRef = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.usage_node_ref import UsageNodeRef
         from ..models.wf_run_caller_type_0 import WfRunCallerType0
         from ..models.wf_run_request_output_schema_type_0 import (
             WfRunRequestOutputSchemaType0,
@@ -271,6 +275,14 @@ class WfRun:
         else:
             usage = self.usage
 
+        usage_parent: dict[str, Any] | None | Unset
+        if isinstance(self.usage_parent, Unset):
+            usage_parent = UNSET
+        elif isinstance(self.usage_parent, UsageNodeRef):
+            usage_parent = self.usage_parent.to_dict()
+        else:
+            usage_parent = self.usage_parent
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -331,6 +343,8 @@ class WfRun:
             field_dict["journal_pruned_at"] = journal_pruned_at
         if usage is not UNSET:
             field_dict["usage"] = usage
+        if usage_parent is not UNSET:
+            field_dict["usage_parent"] = usage_parent
 
         return field_dict
 
@@ -339,6 +353,7 @@ class WfRun:
         from ..models.http_server_spec import HttpServerSpec
         from ..models.mcp_server_spec import McpServerSpec
         from ..models.tool_spec import ToolSpec
+        from ..models.usage_node_ref import UsageNodeRef
         from ..models.wf_run_caller_type_0 import WfRunCallerType0
         from ..models.wf_run_request_output_schema_type_0 import (
             WfRunRequestOutputSchemaType0,
@@ -595,6 +610,23 @@ class WfRun:
 
         usage = _parse_usage(d.pop("usage", UNSET))
 
+        def _parse_usage_parent(data: object) -> None | Unset | UsageNodeRef:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                usage_parent_type_0 = UsageNodeRef.from_dict(data)
+
+                return usage_parent_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UsageNodeRef, data)
+
+        usage_parent = _parse_usage_parent(d.pop("usage_parent", UNSET))
+
         wf_run = cls(
             id=id,
             account_id=account_id,
@@ -628,6 +660,7 @@ class WfRun:
             terminal_summary=terminal_summary,
             journal_pruned_at=journal_pruned_at,
             usage=usage,
+            usage_parent=usage_parent,
         )
 
         wf_run.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_usage.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_usage.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.usage_counters import UsageCounters
+    from ..models.usage_rate import UsageRate
+
 
 T = TypeVar("T", bound="WfRunUsage")
 
@@ -21,10 +26,12 @@ class WfRunUsage:
     (on ``WfRun``) and its realized ``cost_microusd`` *spend* (here) are finally both
     legible from the read path.
 
-    EVERY field is ``int | None``, and absence is reported as **explicit null**, never
-    a silent ``0`` or an omitted key (cf. the ``vault_ids:null`` read-path disease this
-    must not inherit — see the substrate-different-verdict invariant). The observer
-    reads null as *cannot-determine* and fails loud, NOT as "zero spend":
+    Every legacy flat metric is ``int | None``, and absence is reported as
+    **explicit null**, never a silent ``0`` or an omitted key (cf. the
+    ``vault_ids:null`` read-path disease this must not inherit — see the
+    substrate-different-verdict invariant). The observer reads null as
+    *cannot-determine* and fails loud, NOT as "zero spend". Creation accounting
+    is carried separately by the inherited ``own``/``subtree`` and rate fields:
 
     * ``cost_microusd`` / ``*_tokens`` — summed over the run's child sessions. A run
       with no children sums to ``0`` (a real, observed zero — distinct from null).
@@ -38,6 +45,10 @@ class WfRunUsage:
       so it is reported as ``None`` rather than a misleading partial span.
 
         Attributes:
+            own (UsageCounters | Unset): Cumulative inference bought at one node or in one subtree.
+            subtree (UsageCounters | Unset): Cumulative inference bought at one node or in one subtree.
+            own_rate (None | Unset | UsageRate):
+            subtree_rate (None | Unset | UsageRate):
             cost_microusd (int | None | Unset):
             input_tokens (int | None | Unset):
             output_tokens (int | None | Unset):
@@ -47,6 +58,10 @@ class WfRunUsage:
             wall_clock_ms (int | None | Unset):
     """
 
+    own: UsageCounters | Unset = UNSET
+    subtree: UsageCounters | Unset = UNSET
+    own_rate: None | Unset | UsageRate = UNSET
+    subtree_rate: None | Unset | UsageRate = UNSET
     cost_microusd: int | None | Unset = UNSET
     input_tokens: int | None | Unset = UNSET
     output_tokens: int | None | Unset = UNSET
@@ -57,6 +72,32 @@ class WfRunUsage:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.usage_rate import UsageRate
+
+        own: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.own, Unset):
+            own = self.own.to_dict()
+
+        subtree: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.subtree, Unset):
+            subtree = self.subtree.to_dict()
+
+        own_rate: dict[str, Any] | None | Unset
+        if isinstance(self.own_rate, Unset):
+            own_rate = UNSET
+        elif isinstance(self.own_rate, UsageRate):
+            own_rate = self.own_rate.to_dict()
+        else:
+            own_rate = self.own_rate
+
+        subtree_rate: dict[str, Any] | None | Unset
+        if isinstance(self.subtree_rate, Unset):
+            subtree_rate = UNSET
+        elif isinstance(self.subtree_rate, UsageRate):
+            subtree_rate = self.subtree_rate.to_dict()
+        else:
+            subtree_rate = self.subtree_rate
+
         cost_microusd: int | None | Unset
         if isinstance(self.cost_microusd, Unset):
             cost_microusd = UNSET
@@ -102,6 +143,14 @@ class WfRunUsage:
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
+        if own is not UNSET:
+            field_dict["own"] = own
+        if subtree is not UNSET:
+            field_dict["subtree"] = subtree
+        if own_rate is not UNSET:
+            field_dict["own_rate"] = own_rate
+        if subtree_rate is not UNSET:
+            field_dict["subtree_rate"] = subtree_rate
         if cost_microusd is not UNSET:
             field_dict["cost_microusd"] = cost_microusd
         if input_tokens is not UNSET:
@@ -121,7 +170,57 @@ class WfRunUsage:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.usage_counters import UsageCounters
+        from ..models.usage_rate import UsageRate
+
         d = dict(src_dict)
+        _own = d.pop("own", UNSET)
+        own: UsageCounters | Unset
+        if isinstance(_own, Unset):
+            own = UNSET
+        else:
+            own = UsageCounters.from_dict(_own)
+
+        _subtree = d.pop("subtree", UNSET)
+        subtree: UsageCounters | Unset
+        if isinstance(_subtree, Unset):
+            subtree = UNSET
+        else:
+            subtree = UsageCounters.from_dict(_subtree)
+
+        def _parse_own_rate(data: object) -> None | Unset | UsageRate:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                own_rate_type_0 = UsageRate.from_dict(data)
+
+                return own_rate_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UsageRate, data)
+
+        own_rate = _parse_own_rate(d.pop("own_rate", UNSET))
+
+        def _parse_subtree_rate(data: object) -> None | Unset | UsageRate:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                subtree_rate_type_0 = UsageRate.from_dict(data)
+
+                return subtree_rate_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UsageRate, data)
+
+        subtree_rate = _parse_subtree_rate(d.pop("subtree_rate", UNSET))
 
         def _parse_cost_microusd(data: object) -> int | None | Unset:
             if data is None:
@@ -191,6 +290,10 @@ class WfRunUsage:
         wall_clock_ms = _parse_wall_clock_ms(d.pop("wall_clock_ms", UNSET))
 
         wf_run_usage = cls(
+            own=own,
+            subtree=subtree,
+            own_rate=own_rate,
+            subtree_rate=subtree_rate,
             cost_microusd=cost_microusd,
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/scripts/pooled_connection_lint.py
+++ b/scripts/pooled_connection_lint.py
@@ -42,6 +42,9 @@ def _expression_name(node: ast.AST) -> str | None:
 _DB_HELPER_SYMBOLS = frozenset(
     {
         "_queries.list_session_memory_store_echoes",
+        "accounting_queries.ranked_consumers",
+        "accounting_queries.usage_for_node",
+        "accounting_queries.usage_for_nodes",
         "db_stats_queries.database_size",
         "db_stats_queries.monthly_buckets",
         "db_stats_queries.table_storage_stats",

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -35,6 +35,7 @@ from aios.api.routers import (
     skills,
     tasks,
     triggers_ingest,
+    usage,
     vaults,
     workflows,
 )
@@ -206,6 +207,7 @@ def create_app() -> FastAPI:
     app.include_router(triggers_ingest.router)
     app.include_router(connectors.router)
     app.include_router(session_templates.router)
+    app.include_router(usage.router)
     app.include_router(workflows.router)
     app.include_router(workflows.runs_router)
     app.include_router(tasks.router)

--- a/src/aios/api/routers/usage.py
+++ b/src/aios/api/routers/usage.py
@@ -1,0 +1,46 @@
+"""Account-wide inference attribution endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Query
+
+from aios.api.deps import AccountIdDep, PoolDep
+from aios.models.accounting import (
+    DEFAULT_USAGE_WINDOW_SECONDS,
+    MAX_USAGE_WINDOW_SECONDS,
+    MIN_USAGE_WINDOW_SECONDS,
+    UsageConsumersResponse,
+    UsageMetric,
+)
+from aios.services import accounting as service
+
+router = APIRouter(prefix="/v1/usage", tags=["usage"])
+
+
+@router.get("/consumers", operation_id="list_usage_consumers")
+async def list_usage_consumers(
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    window_seconds: Annotated[
+        int, Query(ge=MIN_USAGE_WINDOW_SECONDS, le=MAX_USAGE_WINDOW_SECONDS)
+    ] = DEFAULT_USAGE_WINDOW_SECONDS,
+    metric: UsageMetric = "cost_microusd",
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> UsageConsumersResponse:
+    """Rank root consumers by rolling creation-subtree inference rate.
+
+    Root consumers are additive: every session/run belongs to exactly one root
+    through immutable creation edges, so ``share`` values never double-count
+    shared invocation work. Archived descendants remain in the rollup. Rates
+    update on every inference charge and are normalized per hour over the
+    requested rolling window.
+    """
+    return await service.ranked_consumers(
+        pool,
+        account_id=account_id,
+        window_seconds=window_seconds,
+        metric=metric,
+        limit=limit,
+    )

--- a/src/aios/cli/app.py
+++ b/src/aios/cli/app.py
@@ -111,6 +111,7 @@ from aios.cli.commands import status as _status  # noqa: E402
 from aios.cli.commands import tail as _tail  # noqa: E402
 from aios.cli.commands import tasks as _tasks  # noqa: E402
 from aios.cli.commands import trace as _trace  # noqa: E402
+from aios.cli.commands import usage as _usage  # noqa: E402
 from aios.cli.commands import vaults as _vaults  # noqa: E402
 from aios.cli.commands import whatsapp as _whatsapp  # noqa: E402
 from aios.cli.commands import workflows as _workflows  # noqa: E402
@@ -130,6 +131,7 @@ app.add_typer(_whatsapp.app, name="whatsapp")
 app.add_typer(_workflows.app, name="workflows")
 app.add_typer(_workflows.runs_app, name="runs")
 app.add_typer(_tasks.app, name="tasks")
+app.add_typer(_usage.app, name="usage")
 
 _ops.register(app)
 _sandbox.register(app)

--- a/src/aios/cli/commands/usage.py
+++ b/src/aios/cli/commands/usage.py
@@ -1,0 +1,60 @@
+"""``aios usage ...`` — live inference attribution views."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from aios.cli.commands._shared import call_single
+from aios.cli.coverage import covers
+from aios.cli.runtime import run_or_die
+from aios.models.accounting import (
+    DEFAULT_USAGE_WINDOW_SECONDS,
+    MAX_USAGE_WINDOW_SECONDS,
+    MIN_USAGE_WINDOW_SECONDS,
+)
+from aios_sdk._generated.api.usage import list_usage_consumers
+from aios_sdk._generated.models.list_usage_consumers_metric import ListUsageConsumersMetric
+
+app = typer.Typer(
+    name="usage",
+    help="Inspect live inference attribution and rates.",
+    no_args_is_help=True,
+)
+
+
+@app.command("consumers")
+@covers("list_usage_consumers")
+def consumers(
+    ctx: typer.Context,
+    window_seconds: Annotated[
+        int,
+        typer.Option(
+            "--window-seconds",
+            min=MIN_USAGE_WINDOW_SECONDS,
+            max=MAX_USAGE_WINDOW_SECONDS,
+            help="Rolling window in seconds (60 seconds through 30 days).",
+        ),
+    ] = DEFAULT_USAGE_WINDOW_SECONDS,
+    metric: Annotated[
+        ListUsageConsumersMetric,
+        typer.Option("--metric", help="Rank by subtree cost or total-token rate."),
+    ] = ListUsageConsumersMetric.COST_MICROUSD,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", min=1, max=100, help="Maximum root consumers to return."),
+    ] = 20,
+) -> None:
+    """Rank additive account roots by live creation-subtree inference rate."""
+
+    def _run() -> None:
+        call_single(
+            ctx,
+            list_usage_consumers.sync_detailed,
+            window_seconds=window_seconds,
+            metric=metric,
+            limit=limit,
+        )
+
+    run_or_die(_run)

--- a/src/aios/db/queries/accounting.py
+++ b/src/aios/db/queries/accounting.py
@@ -1,0 +1,394 @@
+"""Creation-edge inference accounting queries (#2151).
+
+Sessions and workflow runs are two node types in one tree.  Every traversal is
+account-scoped and uses recursive ``UNION`` (not ``UNION ALL``), so a malformed
+legacy cycle terminates and a node is counted at most once per root.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import asyncpg
+
+from aios.models.accounting import (
+    AttributedUsage,
+    UsageConsumer,
+    UsageCounters,
+    UsageMetric,
+    UsageNodeRef,
+    UsageRate,
+)
+
+_COUNTER_NAMES = (
+    "cost_microusd",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+)
+
+
+def _counters(row: Any, prefix: str) -> UsageCounters:
+    return UsageCounters(**{name: int(row[f"{prefix}_{name}"] or 0) for name in _COUNTER_NAMES})
+
+
+def _rate(counters: UsageCounters, *, window_seconds: int, observed_seconds: int) -> UsageRate:
+    scale = 3600 / max(1, observed_seconds)
+    return UsageRate(
+        window_seconds=window_seconds,
+        observed_seconds=observed_seconds,
+        complete=observed_seconds >= window_seconds,
+        cost_microusd_per_hour=counters.cost_microusd * scale,
+        input_tokens_per_hour=counters.input_tokens * scale,
+        output_tokens_per_hour=counters.output_tokens * scale,
+        cache_read_input_tokens_per_hour=counters.cache_read_input_tokens * scale,
+        cache_creation_input_tokens_per_hour=counters.cache_creation_input_tokens * scale,
+    )
+
+
+def _attributed(row: Any, *, window_seconds: int) -> AttributedUsage:
+    observed_seconds = int(row["observed_seconds"])
+    own_window = _counters(row, "own_window")
+    subtree_window = _counters(row, "subtree_window")
+    return AttributedUsage(
+        own=_counters(row, "own"),
+        subtree=_counters(row, "subtree"),
+        own_rate=_rate(
+            own_window, window_seconds=window_seconds, observed_seconds=observed_seconds
+        ),
+        subtree_rate=_rate(
+            subtree_window, window_seconds=window_seconds, observed_seconds=observed_seconds
+        ),
+    )
+
+
+_BATCH_USAGE_SQL = r"""
+WITH RECURSIVE
+roots(kind, id) AS (
+    SELECT * FROM unnest($1::text[], $2::text[])
+),
+tree(root_kind, root_id, kind, id) AS (
+    SELECT r.kind, r.id, r.kind, r.id
+      FROM roots r
+     WHERE (r.kind = 'session' AND EXISTS (
+                SELECT 1 FROM sessions s WHERE s.id = r.id AND s.account_id = $3
+           ))
+        OR (r.kind = 'run' AND EXISTS (
+                SELECT 1 FROM wf_runs w WHERE w.id = r.id AND w.account_id = $3
+           ))
+    UNION
+    SELECT t.root_kind, t.root_id, child.kind, child.id
+      FROM tree t
+      JOIN LATERAL (
+           SELECT 'session'::text AS kind, s.id
+             FROM sessions s
+            WHERE s.account_id = $3
+              AND ((t.kind = 'session' AND s.creator_session_id = t.id)
+                OR (t.kind = 'run' AND s.creator_run_id = t.id))
+           UNION ALL
+           SELECT 'run'::text AS kind, w.id
+             FROM wf_runs w
+            WHERE w.account_id = $3
+              AND ((t.kind = 'session' AND w.creator_session_id = t.id)
+                OR (t.kind = 'run' AND w.creator_run_id = t.id))
+      ) child ON TRUE
+),
+node_usage(kind, id, cost_microusd, input_tokens, output_tokens,
+           cache_read_input_tokens, cache_creation_input_tokens) AS (
+    SELECT 'session', s.id, s.cost_microusd, s.input_tokens, s.output_tokens,
+           s.cache_read_input_tokens, s.cache_creation_input_tokens
+      FROM sessions s WHERE s.account_id = $3
+    UNION ALL
+    SELECT 'run', w.id, w.call_llm_cost_microusd, w.call_llm_input_tokens,
+           w.call_llm_output_tokens, w.call_llm_cache_read_input_tokens,
+           w.call_llm_cache_creation_input_tokens
+      FROM wf_runs w WHERE w.account_id = $3
+),
+window_node(kind, id, cost_microusd, input_tokens, output_tokens,
+            cache_read_input_tokens, cache_creation_input_tokens) AS (
+    SELECT CASE WHEN l.session_id IS NOT NULL THEN 'session' ELSE 'run' END,
+           COALESCE(l.session_id, l.run_id), SUM(l.cost_microusd),
+           SUM(l.input_tokens), SUM(l.output_tokens),
+           SUM(l.cache_read_input_tokens), SUM(l.cache_creation_input_tokens)
+      FROM inference_usage_ledger l
+     WHERE l.account_id = $3
+       AND l.occurred_at >= now() - ($4 * interval '1 second')
+     GROUP BY 1, 2
+),
+totals AS (
+    SELECT t.root_kind, t.root_id,
+           SUM(n.cost_microusd)::bigint AS subtree_cost_microusd,
+           SUM(n.input_tokens)::bigint AS subtree_input_tokens,
+           SUM(n.output_tokens)::bigint AS subtree_output_tokens,
+           SUM(n.cache_read_input_tokens)::bigint AS subtree_cache_read_input_tokens,
+           SUM(n.cache_creation_input_tokens)::bigint AS subtree_cache_creation_input_tokens,
+           SUM(COALESCE(wn.cost_microusd, 0))::bigint AS subtree_window_cost_microusd,
+           SUM(COALESCE(wn.input_tokens, 0))::bigint AS subtree_window_input_tokens,
+           SUM(COALESCE(wn.output_tokens, 0))::bigint AS subtree_window_output_tokens,
+           SUM(COALESCE(wn.cache_read_input_tokens, 0))::bigint
+               AS subtree_window_cache_read_input_tokens,
+           SUM(COALESCE(wn.cache_creation_input_tokens, 0))::bigint
+               AS subtree_window_cache_creation_input_tokens
+      FROM tree t
+      JOIN node_usage n ON n.kind = t.kind AND n.id = t.id
+      LEFT JOIN window_node wn ON wn.kind = t.kind AND wn.id = t.id
+     GROUP BY t.root_kind, t.root_id
+),
+coverage AS (
+    SELECT usage_ledger_started_at AS coverage_started_at,
+           LEAST(
+               $4,
+               GREATEST(
+                   1,
+                   FLOOR(EXTRACT(EPOCH FROM (now() - usage_ledger_started_at)))::integer
+               )
+           ) AS observed_seconds
+      FROM accounts WHERE id = $3
+)
+SELECT r.kind AS root_kind, r.id AS root_id,
+       own.cost_microusd AS own_cost_microusd,
+       own.input_tokens AS own_input_tokens,
+       own.output_tokens AS own_output_tokens,
+       own.cache_read_input_tokens AS own_cache_read_input_tokens,
+       own.cache_creation_input_tokens AS own_cache_creation_input_tokens,
+       total.subtree_cost_microusd,
+       total.subtree_input_tokens,
+       total.subtree_output_tokens,
+       total.subtree_cache_read_input_tokens,
+       total.subtree_cache_creation_input_tokens,
+       COALESCE(own_window.cost_microusd, 0)::bigint AS own_window_cost_microusd,
+       COALESCE(own_window.input_tokens, 0)::bigint AS own_window_input_tokens,
+       COALESCE(own_window.output_tokens, 0)::bigint AS own_window_output_tokens,
+       COALESCE(own_window.cache_read_input_tokens, 0)::bigint
+           AS own_window_cache_read_input_tokens,
+       COALESCE(own_window.cache_creation_input_tokens, 0)::bigint
+           AS own_window_cache_creation_input_tokens,
+       total.subtree_window_cost_microusd,
+       total.subtree_window_input_tokens,
+       total.subtree_window_output_tokens,
+       total.subtree_window_cache_read_input_tokens,
+       total.subtree_window_cache_creation_input_tokens,
+       coverage.coverage_started_at, coverage.observed_seconds
+  FROM roots r
+  JOIN node_usage own ON own.kind = r.kind AND own.id = r.id
+  JOIN totals total ON total.root_kind = r.kind AND total.root_id = r.id
+  LEFT JOIN window_node own_window ON own_window.kind = r.kind AND own_window.id = r.id
+  CROSS JOIN coverage
+"""
+
+
+async def usage_for_nodes(
+    conn: asyncpg.Connection[Any],
+    roots: list[UsageNodeRef],
+    *,
+    account_id: str,
+    window_seconds: int,
+) -> dict[tuple[str, str], AttributedUsage]:
+    """Return coherent own/subtree usage for many roots in one SQL statement."""
+    if not roots:
+        return {}
+    rows = await conn.fetch(
+        _BATCH_USAGE_SQL,
+        [root.kind for root in roots],
+        [root.id for root in roots],
+        account_id,
+        window_seconds,
+    )
+    return {
+        (str(row["root_kind"]), str(row["root_id"])): _attributed(
+            row, window_seconds=window_seconds
+        )
+        for row in rows
+    }
+
+
+async def usage_for_node(
+    conn: asyncpg.Connection[Any],
+    root: UsageNodeRef,
+    *,
+    account_id: str,
+    window_seconds: int,
+) -> AttributedUsage | None:
+    """Point form of :func:`usage_for_nodes`."""
+    return (
+        await usage_for_nodes(conn, [root], account_id=account_id, window_seconds=window_seconds)
+    ).get((root.kind, root.id))
+
+
+_SESSION_STATUS_SQL = """
+CASE WHEN s.archived_at IS NOT NULL THEN 'archived'
+     WHEN s.last_error_seq > 0 AND s.last_error_seq > s.last_user_seq THEN 'errored'
+     WHEN (s.last_stimulus_seq > s.last_reacted_seq OR s.open_tool_call_count > 0)
+          THEN 'active'
+     ELSE 'idle' END
+"""
+
+
+def _ranked_consumers_sql(metric: UsageMetric) -> str:
+    metric_column = {
+        "cost_microusd": "subtree_window_cost_microusd",
+        "total_tokens": "subtree_window_total_tokens",
+    }[metric]
+    return rf"""
+WITH RECURSIVE
+nodes(kind, id, parent_kind, parent_id, label, status, created_at, archived_at,
+      cost_microusd, input_tokens, output_tokens, cache_read_input_tokens,
+      cache_creation_input_tokens) AS (
+    SELECT 'session', s.id,
+           CASE WHEN s.creator_session_id IS NOT NULL THEN 'session'
+                WHEN s.creator_run_id IS NOT NULL THEN 'run' END,
+           COALESCE(s.creator_session_id, s.creator_run_id),
+           COALESCE(s.title, s.agent_id, s.id), {_SESSION_STATUS_SQL},
+           s.created_at, s.archived_at, s.cost_microusd, s.input_tokens,
+           s.output_tokens, s.cache_read_input_tokens, s.cache_creation_input_tokens
+      FROM sessions s WHERE s.account_id = $1
+    UNION ALL
+    SELECT 'run', w.id,
+           CASE WHEN w.creator_session_id IS NOT NULL THEN 'session'
+                WHEN w.creator_run_id IS NOT NULL THEN 'run' END,
+           COALESCE(w.creator_session_id, w.creator_run_id),
+           COALESCE(w.workflow_id, 'inline workflow ' || w.id), w.status,
+           w.created_at, w.archived_at, w.call_llm_cost_microusd,
+           w.call_llm_input_tokens, w.call_llm_output_tokens,
+           w.call_llm_cache_read_input_tokens, w.call_llm_cache_creation_input_tokens
+      FROM wf_runs w WHERE w.account_id = $1
+),
+closure(ancestor_kind, ancestor_id, descendant_kind, descendant_id) AS (
+    SELECT n.kind, n.id, n.kind, n.id FROM nodes n
+    UNION
+    SELECT parent.kind, parent.id, c.descendant_kind, c.descendant_id
+      FROM closure c
+      JOIN nodes current
+        ON current.kind = c.ancestor_kind AND current.id = c.ancestor_id
+      JOIN nodes parent
+        ON parent.kind = current.parent_kind AND parent.id = current.parent_id
+),
+window_node(kind, id, cost_microusd, input_tokens, output_tokens,
+            cache_read_input_tokens, cache_creation_input_tokens) AS (
+    SELECT CASE WHEN l.session_id IS NOT NULL THEN 'session' ELSE 'run' END,
+           COALESCE(l.session_id, l.run_id), SUM(l.cost_microusd),
+           SUM(l.input_tokens), SUM(l.output_tokens),
+           SUM(l.cache_read_input_tokens), SUM(l.cache_creation_input_tokens)
+      FROM inference_usage_ledger l
+     WHERE l.account_id = $1
+       AND l.occurred_at >= now() - ($2 * interval '1 second')
+     GROUP BY 1, 2
+),
+rollup AS (
+    SELECT c.ancestor_kind, c.ancestor_id,
+           SUM(n.cost_microusd)::bigint AS subtree_cost_microusd,
+           SUM(n.input_tokens)::bigint AS subtree_input_tokens,
+           SUM(n.output_tokens)::bigint AS subtree_output_tokens,
+           SUM(n.cache_read_input_tokens)::bigint AS subtree_cache_read_input_tokens,
+           SUM(n.cache_creation_input_tokens)::bigint
+               AS subtree_cache_creation_input_tokens,
+           SUM(COALESCE(wn.cost_microusd, 0))::bigint
+               AS subtree_window_cost_microusd,
+           SUM(COALESCE(wn.input_tokens, 0))::bigint
+               AS subtree_window_input_tokens,
+           SUM(COALESCE(wn.output_tokens, 0))::bigint
+               AS subtree_window_output_tokens,
+           SUM(COALESCE(wn.input_tokens, 0) + COALESCE(wn.output_tokens, 0))::bigint
+               AS subtree_window_total_tokens,
+           SUM(COALESCE(wn.cache_read_input_tokens, 0))::bigint
+               AS subtree_window_cache_read_input_tokens,
+           SUM(COALESCE(wn.cache_creation_input_tokens, 0))::bigint
+               AS subtree_window_cache_creation_input_tokens
+      FROM closure c
+      JOIN nodes n ON n.kind = c.descendant_kind AND n.id = c.descendant_id
+      LEFT JOIN window_node wn
+        ON wn.kind = c.descendant_kind AND wn.id = c.descendant_id
+     GROUP BY c.ancestor_kind, c.ancestor_id
+),
+coverage AS (
+    SELECT usage_ledger_started_at AS coverage_started_at,
+           LEAST(
+               $2,
+               GREATEST(
+                   1,
+                   FLOOR(EXTRACT(EPOCH FROM (now() - usage_ledger_started_at)))::integer
+               )
+           ) AS observed_seconds
+      FROM accounts WHERE id = $1
+),
+rankable AS (
+    SELECT n.*, r.*,
+           n.cost_microusd AS own_cost_microusd,
+           n.input_tokens AS own_input_tokens,
+           n.output_tokens AS own_output_tokens,
+           n.cache_read_input_tokens AS own_cache_read_input_tokens,
+           n.cache_creation_input_tokens AS own_cache_creation_input_tokens,
+           COALESCE(wn.cost_microusd, 0)::bigint AS own_window_cost_microusd,
+           COALESCE(wn.input_tokens, 0)::bigint AS own_window_input_tokens,
+           COALESCE(wn.output_tokens, 0)::bigint AS own_window_output_tokens,
+           COALESCE(wn.cache_read_input_tokens, 0)::bigint
+               AS own_window_cache_read_input_tokens,
+           COALESCE(wn.cache_creation_input_tokens, 0)::bigint
+               AS own_window_cache_creation_input_tokens,
+           coverage.coverage_started_at, coverage.observed_seconds,
+           SUM(r.{metric_column}) OVER ()::bigint AS pool_window_metric
+      FROM nodes n
+      JOIN rollup r ON r.ancestor_kind = n.kind AND r.ancestor_id = n.id
+      LEFT JOIN window_node wn ON wn.kind = n.kind AND wn.id = n.id
+      CROSS JOIN coverage
+     WHERE n.parent_id IS NULL
+)
+SELECT * FROM rankable
+ ORDER BY {metric_column} DESC, created_at DESC, id DESC
+ LIMIT $3
+"""
+
+
+async def ranked_consumers(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    window_seconds: int,
+    metric: UsageMetric,
+    limit: int,
+) -> tuple[datetime, float, list[UsageConsumer]]:
+    """Rank additive root consumers by rolling subtree rate in one view."""
+    rows = await conn.fetch(_ranked_consumers_sql(metric), account_id, window_seconds, limit)
+    if rows:
+        coverage_started_at = rows[0]["coverage_started_at"]
+        observed_seconds = int(rows[0]["observed_seconds"])
+    else:
+        coverage_started_at = await conn.fetchval(
+            "SELECT usage_ledger_started_at FROM accounts WHERE id = $1", account_id
+        )
+        observed_seconds = max(
+            1,
+            min(
+                window_seconds,
+                int(
+                    (datetime.now(coverage_started_at.tzinfo) - coverage_started_at).total_seconds()
+                ),
+            ),
+        )
+
+    pool_window = int(rows[0]["pool_window_metric"] or 0) if rows else 0
+    scale = 3600 / max(1, observed_seconds)
+    items: list[UsageConsumer] = []
+    for rank, row in enumerate(rows, start=1):
+        usage = _attributed(row, window_seconds=window_seconds)
+        window_value = (
+            int(row["subtree_window_cost_microusd"])
+            if metric == "cost_microusd"
+            else int(row["subtree_window_total_tokens"])
+        )
+        items.append(
+            UsageConsumer(
+                rank=rank,
+                kind=row["kind"],
+                id=row["id"],
+                label=row["label"],
+                status=row["status"],
+                created_at=row["created_at"],
+                archived_at=row["archived_at"],
+                share=window_value / pool_window if pool_window else 0.0,
+                usage=usage,
+            )
+        )
+    return coverage_started_at, pool_window * scale, items

--- a/src/aios/db/queries/accounting.py
+++ b/src/aios/db/queries/accounting.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import asyncpg
 
+from aios.errors import AiosError
 from aios.models.accounting import (
     AttributedUsage,
     UsageConsumer,
@@ -30,8 +31,11 @@ _COUNTER_NAMES = (
 )
 
 
-def _counters(row: Any, prefix: str) -> UsageCounters:
-    return UsageCounters(**{name: int(row[f"{prefix}_{name}"] or 0) for name in _COUNTER_NAMES})
+def _counters(row: Any, prefix: str, *, tokens_complete: bool = True) -> UsageCounters:
+    return UsageCounters(
+        **{name: int(row[f"{prefix}_{name}"] or 0) for name in _COUNTER_NAMES},
+        tokens_complete=tokens_complete,
+    )
 
 
 def _rate(counters: UsageCounters, *, window_seconds: int, observed_seconds: int) -> UsageRate:
@@ -53,8 +57,8 @@ def _attributed(row: Any, *, window_seconds: int) -> AttributedUsage:
     own_window = _counters(row, "own_window")
     subtree_window = _counters(row, "subtree_window")
     return AttributedUsage(
-        own=_counters(row, "own"),
-        subtree=_counters(row, "subtree"),
+        own=_counters(row, "own", tokens_complete=bool(row["own_tokens_complete"])),
+        subtree=_counters(row, "subtree", tokens_complete=bool(row["subtree_tokens_complete"])),
         own_rate=_rate(
             own_window, window_seconds=window_seconds, observed_seconds=observed_seconds
         ),
@@ -96,14 +100,14 @@ tree(root_kind, root_id, kind, id) AS (
       ) child ON TRUE
 ),
 node_usage(kind, id, cost_microusd, input_tokens, output_tokens,
-           cache_read_input_tokens, cache_creation_input_tokens) AS (
+           cache_read_input_tokens, cache_creation_input_tokens, tokens_complete) AS (
     SELECT 'session', s.id, s.cost_microusd, s.input_tokens, s.output_tokens,
-           s.cache_read_input_tokens, s.cache_creation_input_tokens
+           s.cache_read_input_tokens, s.cache_creation_input_tokens, TRUE
       FROM sessions s WHERE s.account_id = $3
     UNION ALL
     SELECT 'run', w.id, w.call_llm_cost_microusd, w.call_llm_input_tokens,
            w.call_llm_output_tokens, w.call_llm_cache_read_input_tokens,
-           w.call_llm_cache_creation_input_tokens
+           w.call_llm_cache_creation_input_tokens, w.call_llm_tokens_complete
       FROM wf_runs w WHERE w.account_id = $3
 ),
 window_node(kind, id, cost_microusd, input_tokens, output_tokens,
@@ -124,6 +128,7 @@ totals AS (
            SUM(n.output_tokens)::bigint AS subtree_output_tokens,
            SUM(n.cache_read_input_tokens)::bigint AS subtree_cache_read_input_tokens,
            SUM(n.cache_creation_input_tokens)::bigint AS subtree_cache_creation_input_tokens,
+           BOOL_AND(n.tokens_complete) AS subtree_tokens_complete,
            SUM(COALESCE(wn.cost_microusd, 0))::bigint AS subtree_window_cost_microusd,
            SUM(COALESCE(wn.input_tokens, 0))::bigint AS subtree_window_input_tokens,
            SUM(COALESCE(wn.output_tokens, 0))::bigint AS subtree_window_output_tokens,
@@ -153,11 +158,13 @@ SELECT r.kind AS root_kind, r.id AS root_id,
        own.output_tokens AS own_output_tokens,
        own.cache_read_input_tokens AS own_cache_read_input_tokens,
        own.cache_creation_input_tokens AS own_cache_creation_input_tokens,
+       own.tokens_complete AS own_tokens_complete,
        total.subtree_cost_microusd,
        total.subtree_input_tokens,
        total.subtree_output_tokens,
        total.subtree_cache_read_input_tokens,
        total.subtree_cache_creation_input_tokens,
+       total.subtree_tokens_complete,
        COALESCE(own_window.cost_microusd, 0)::bigint AS own_window_cost_microusd,
        COALESCE(own_window.input_tokens, 0)::bigint AS own_window_input_tokens,
        COALESCE(own_window.output_tokens, 0)::bigint AS own_window_output_tokens,
@@ -233,16 +240,43 @@ def _ranked_consumers_sql(metric: UsageMetric) -> str:
     }[metric]
     return rf"""
 WITH RECURSIVE
+tree(root_kind, root_id, kind, id) AS (
+    SELECT 'session', s.id, 'session', s.id
+      FROM sessions s
+     WHERE s.account_id = $1
+       AND s.creator_session_id IS NULL AND s.creator_run_id IS NULL
+    UNION
+    SELECT 'run', w.id, 'run', w.id
+      FROM wf_runs w
+     WHERE w.account_id = $1
+       AND w.creator_session_id IS NULL AND w.creator_run_id IS NULL
+    UNION
+    SELECT t.root_kind, t.root_id, child.kind, child.id
+      FROM tree t
+      JOIN LATERAL (
+           SELECT 'session'::text AS kind, s.id
+             FROM sessions s
+            WHERE s.account_id = $1
+              AND ((t.kind = 'session' AND s.creator_session_id = t.id)
+                OR (t.kind = 'run' AND s.creator_run_id = t.id))
+           UNION ALL
+           SELECT 'run'::text AS kind, w.id
+             FROM wf_runs w
+            WHERE w.account_id = $1
+              AND ((t.kind = 'session' AND w.creator_session_id = t.id)
+                OR (t.kind = 'run' AND w.creator_run_id = t.id))
+      ) child ON TRUE
+),
 nodes(kind, id, parent_kind, parent_id, label, status, created_at, archived_at,
       cost_microusd, input_tokens, output_tokens, cache_read_input_tokens,
-      cache_creation_input_tokens) AS (
+      cache_creation_input_tokens, tokens_complete) AS (
     SELECT 'session', s.id,
            CASE WHEN s.creator_session_id IS NOT NULL THEN 'session'
                 WHEN s.creator_run_id IS NOT NULL THEN 'run' END,
            COALESCE(s.creator_session_id, s.creator_run_id),
            COALESCE(s.title, s.agent_id, s.id), {_SESSION_STATUS_SQL},
            s.created_at, s.archived_at, s.cost_microusd, s.input_tokens,
-           s.output_tokens, s.cache_read_input_tokens, s.cache_creation_input_tokens
+           s.output_tokens, s.cache_read_input_tokens, s.cache_creation_input_tokens, TRUE
       FROM sessions s WHERE s.account_id = $1
     UNION ALL
     SELECT 'run', w.id,
@@ -252,18 +286,9 @@ nodes(kind, id, parent_kind, parent_id, label, status, created_at, archived_at,
            COALESCE(w.workflow_id, 'inline workflow ' || w.id), w.status,
            w.created_at, w.archived_at, w.call_llm_cost_microusd,
            w.call_llm_input_tokens, w.call_llm_output_tokens,
-           w.call_llm_cache_read_input_tokens, w.call_llm_cache_creation_input_tokens
+           w.call_llm_cache_read_input_tokens, w.call_llm_cache_creation_input_tokens,
+           w.call_llm_tokens_complete
       FROM wf_runs w WHERE w.account_id = $1
-),
-closure(ancestor_kind, ancestor_id, descendant_kind, descendant_id) AS (
-    SELECT n.kind, n.id, n.kind, n.id FROM nodes n
-    UNION
-    SELECT parent.kind, parent.id, c.descendant_kind, c.descendant_id
-      FROM closure c
-      JOIN nodes current
-        ON current.kind = c.ancestor_kind AND current.id = c.ancestor_id
-      JOIN nodes parent
-        ON parent.kind = current.parent_kind AND parent.id = current.parent_id
 ),
 window_node(kind, id, cost_microusd, input_tokens, output_tokens,
             cache_read_input_tokens, cache_creation_input_tokens) AS (
@@ -277,13 +302,14 @@ window_node(kind, id, cost_microusd, input_tokens, output_tokens,
      GROUP BY 1, 2
 ),
 rollup AS (
-    SELECT c.ancestor_kind, c.ancestor_id,
+    SELECT t.root_kind, t.root_id,
            SUM(n.cost_microusd)::bigint AS subtree_cost_microusd,
            SUM(n.input_tokens)::bigint AS subtree_input_tokens,
            SUM(n.output_tokens)::bigint AS subtree_output_tokens,
            SUM(n.cache_read_input_tokens)::bigint AS subtree_cache_read_input_tokens,
            SUM(n.cache_creation_input_tokens)::bigint
                AS subtree_cache_creation_input_tokens,
+           BOOL_AND(n.tokens_complete) AS subtree_tokens_complete,
            SUM(COALESCE(wn.cost_microusd, 0))::bigint
                AS subtree_window_cost_microusd,
            SUM(COALESCE(wn.input_tokens, 0))::bigint
@@ -296,11 +322,11 @@ rollup AS (
                AS subtree_window_cache_read_input_tokens,
            SUM(COALESCE(wn.cache_creation_input_tokens, 0))::bigint
                AS subtree_window_cache_creation_input_tokens
-      FROM closure c
-      JOIN nodes n ON n.kind = c.descendant_kind AND n.id = c.descendant_id
+      FROM tree t
+      JOIN nodes n ON n.kind = t.kind AND n.id = t.id
       LEFT JOIN window_node wn
-        ON wn.kind = c.descendant_kind AND wn.id = c.descendant_id
-     GROUP BY c.ancestor_kind, c.ancestor_id
+        ON wn.kind = t.kind AND wn.id = t.id
+     GROUP BY t.root_kind, t.root_id
 ),
 coverage AS (
     SELECT usage_ledger_started_at AS coverage_started_at,
@@ -320,6 +346,7 @@ rankable AS (
            n.output_tokens AS own_output_tokens,
            n.cache_read_input_tokens AS own_cache_read_input_tokens,
            n.cache_creation_input_tokens AS own_cache_creation_input_tokens,
+           n.tokens_complete AS own_tokens_complete,
            COALESCE(wn.cost_microusd, 0)::bigint AS own_window_cost_microusd,
            COALESCE(wn.input_tokens, 0)::bigint AS own_window_input_tokens,
            COALESCE(wn.output_tokens, 0)::bigint AS own_window_output_tokens,
@@ -327,17 +354,29 @@ rankable AS (
                AS own_window_cache_read_input_tokens,
            COALESCE(wn.cache_creation_input_tokens, 0)::bigint
                AS own_window_cache_creation_input_tokens,
-           coverage.coverage_started_at, coverage.observed_seconds,
            SUM(r.{metric_column}) OVER ()::bigint AS pool_window_metric
       FROM nodes n
-      JOIN rollup r ON r.ancestor_kind = n.kind AND r.ancestor_id = n.id
+      JOIN rollup r ON r.root_kind = n.kind AND r.root_id = n.id
       LEFT JOIN window_node wn ON wn.kind = n.kind AND wn.id = n.id
-      CROSS JOIN coverage
      WHERE n.parent_id IS NULL
+),
+graph_state AS (
+    SELECT (SELECT COUNT(*) FROM nodes) = (SELECT COUNT(*) FROM tree) AS graph_complete,
+           (SELECT COUNT(*) FROM nodes)::bigint AS graph_node_count,
+           (SELECT COUNT(*) FROM tree)::bigint AS graph_traversal_rows
 )
-SELECT * FROM rankable
- ORDER BY {metric_column} DESC, created_at DESC, id DESC
- LIMIT $3
+SELECT ranked.*, coverage.coverage_started_at, coverage.observed_seconds,
+       graph_state.graph_complete, graph_state.graph_node_count,
+       graph_state.graph_traversal_rows
+  FROM graph_state
+  CROSS JOIN coverage
+  LEFT JOIN LATERAL (
+       SELECT * FROM rankable
+        ORDER BY {metric_column} DESC, created_at DESC, id DESC
+        LIMIT $3
+  ) ranked ON TRUE
+ ORDER BY ranked.{metric_column} DESC NULLS LAST,
+          ranked.created_at DESC NULLS LAST, ranked.id DESC NULLS LAST
 """
 
 
@@ -351,6 +390,15 @@ async def ranked_consumers(
 ) -> tuple[datetime, float, list[UsageConsumer]]:
     """Rank additive root consumers by rolling subtree rate in one view."""
     rows = await conn.fetch(_ranked_consumers_sql(metric), account_id, window_seconds, limit)
+    if rows and not bool(rows[0]["graph_complete"]):
+        raise AiosError(
+            "usage creation graph contains a rootless component",
+            detail={
+                "account_id": account_id,
+                "node_count": int(rows[0]["graph_node_count"]),
+                "reachable_count": int(rows[0]["graph_traversal_rows"]),
+            },
+        )
     if rows:
         coverage_started_at = rows[0]["coverage_started_at"]
         observed_seconds = int(rows[0]["observed_seconds"])
@@ -368,10 +416,11 @@ async def ranked_consumers(
             ),
         )
 
-    pool_window = int(rows[0]["pool_window_metric"] or 0) if rows else 0
+    ranked_rows = [row for row in rows if row["id"] is not None]
+    pool_window = int(ranked_rows[0]["pool_window_metric"] or 0) if ranked_rows else 0
     scale = 3600 / max(1, observed_seconds)
     items: list[UsageConsumer] = []
-    for rank, row in enumerate(rows, start=1):
+    for rank, row in enumerate(ranked_rows, start=1):
         usage = _attributed(row, window_seconds=window_seconds)
         window_value = (
             int(row["subtree_window_cost_microusd"])

--- a/src/aios/db/queries/clone_policy.py
+++ b/src/aios/db/queries/clone_policy.py
@@ -270,6 +270,10 @@ SESSIONS_POLICY: dict[str, Arm] = {
     # Keep the marker aligned with the copied events. Resetting a v2 clone to
     # v1 would mix old-baseline appends with copied v2 cumulative counters.
     "token_baseline_v": Arm.COPY,
+    # Accounting ownership is creation-specific too. An operator clone is a
+    # fresh root; inheriting either edge would charge it to the source's creator.
+    "creator_session_id": Arm.RESET_DEFAULT,
+    "creator_run_id": Arm.RESET_DEFAULT,
 }
 
 

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -44,6 +44,7 @@ from aios.ids import (
     TRIGGER,
     make_id,
 )
+from aios.models.accounting import UsageCounters, UsageNodeRef
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec, load_tool_specs
 from aios.models.attenuation import Surface
 from aios.models.sessions import (
@@ -167,10 +168,34 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         stop_reason=stop_reason,
         last_event_seq=row["last_event_seq"],
         usage=SessionUsage(
+            cost_microusd=row["cost_microusd"],
             input_tokens=row["input_tokens"],
             output_tokens=row["output_tokens"],
             cache_read_input_tokens=row["cache_read_input_tokens"],
             cache_creation_input_tokens=row["cache_creation_input_tokens"],
+            own=UsageCounters(
+                cost_microusd=row["cost_microusd"],
+                input_tokens=row["input_tokens"],
+                output_tokens=row["output_tokens"],
+                cache_read_input_tokens=row["cache_read_input_tokens"],
+                cache_creation_input_tokens=row["cache_creation_input_tokens"],
+            ),
+            subtree=UsageCounters(
+                cost_microusd=row["cost_microusd"],
+                input_tokens=row["input_tokens"],
+                output_tokens=row["output_tokens"],
+                cache_read_input_tokens=row["cache_read_input_tokens"],
+                cache_creation_input_tokens=row["cache_creation_input_tokens"],
+            ),
+        ),
+        usage_parent=(
+            UsageNodeRef(kind="session", id=row["creator_session_id"])
+            if row.get("creator_session_id") is not None
+            else (
+                UsageNodeRef(kind="run", id=row["creator_run_id"])
+                if row.get("creator_run_id") is not None
+                else None
+            )
         ),
         created_by=actor_from_row(row),
         created_at=row["created_at"],
@@ -224,6 +249,7 @@ async def insert_session(
     outbound_suppression: str = "off",
     frozen_surface: Surface | None = None,
     frozen_litellm_extra: dict[str, Any] | None = None,
+    creator_session_id: str | None = None,
 ) -> Session:
     """Insert a fresh session row.
 
@@ -250,10 +276,11 @@ async def insert_session(
                 workspace_volume_path, env,
                 focal_channel, focal_locked, account_id, archive_when_idle,
                 outbound_suppression, created_by_type, created_by_ref,
-                tools, mcp_servers, http_servers, surface_frozen, litellm_extra
+                tools, mcp_servers, http_servers, surface_frozen, litellm_extra,
+                creator_session_id
             )
             VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9, $10, $11, $12, $13, $14, $15,
-                    $16::jsonb, $17::jsonb, $18::jsonb, $19, $20::jsonb)
+                    $16::jsonb, $17::jsonb, $18::jsonb, $19, $20::jsonb, $21)
             RETURNING *
             """,
             new_id,
@@ -281,6 +308,7 @@ async def insert_session(
             else None,
             frozen_surface is not None,
             json.dumps(frozen_litellm_extra or {}) if frozen_surface else None,
+            creator_session_id,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
@@ -339,11 +367,11 @@ async def insert_child_session(
                 workspace_volume_path, env, focal_channel, focal_locked,
                 account_id, parent_run_id, origin, archive_when_idle,
                 tools, mcp_servers, http_servers, surface_frozen, litellm_extra,
-                tools_vocab_epoch
+                tools_vocab_epoch, creator_run_id
             )
             VALUES ($1, $2, $3, $4, $5, NULL, '{}'::jsonb, $6, '{}'::jsonb,
                     NULL, FALSE, $7, $8, 'background', $9,
-                    $10::jsonb, $11::jsonb, $12::jsonb, TRUE, $13::jsonb, $14)
+                    $10::jsonb, $11::jsonb, $12::jsonb, TRUE, $13::jsonb, $14, $8)
             ON CONFLICT (id) DO NOTHING
             RETURNING *
             """,
@@ -1617,27 +1645,42 @@ async def increment_session_usage(
     cost_microusd: int = 0,
 ) -> int:
     """Atomically add token and spend counts; return the account spend total."""
+    deltas = (
+        max(0, input_tokens),
+        max(0, output_tokens),
+        max(0, cache_read_input_tokens),
+        max(0, cache_creation_input_tokens),
+        max(0, cost_microusd),
+    )
     async with conn.transaction():
-        await conn.execute(
+        charged_session_id = await conn.fetchval(
             "UPDATE sessions SET "
             "input_tokens = input_tokens + $2, "
             "output_tokens = output_tokens + $3, "
             "cache_read_input_tokens = cache_read_input_tokens + $4, "
             "cache_creation_input_tokens = cache_creation_input_tokens + $5, "
             "cost_microusd = cost_microusd + $6 "
-            "WHERE id = $1 AND account_id = $7",
+            "WHERE id = $1 AND account_id = $7 RETURNING id",
             session_id,
-            input_tokens,
-            output_tokens,
-            cache_read_input_tokens,
-            cache_creation_input_tokens,
-            cost_microusd,
+            *deltas,
             account_id,
         )
+        if charged_session_id is None:
+            return 0
+        if any(deltas):
+            await conn.execute(
+                "INSERT INTO inference_usage_ledger "
+                "(account_id, session_id, input_tokens, output_tokens, "
+                " cache_read_input_tokens, cache_creation_input_tokens, cost_microusd) "
+                "VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                account_id,
+                session_id,
+                *deltas,
+            )
         spent = await conn.fetchval(
             "UPDATE accounts SET spent_microusd = spent_microusd + $1 "
             "WHERE id = $2 RETURNING spent_microusd",
-            cost_microusd,
+            deltas[4],
             account_id,
         )
     return int(spent or 0)

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -123,6 +123,7 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
         ),
         default_child_model=row.get("default_child_model"),
         call_llm_cost_microusd=row.get("call_llm_cost_microusd", 0) or 0,
+        call_llm_tokens_complete=bool(row.get("call_llm_tokens_complete", True)),
         last_event_seq=row["last_event_seq"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -871,15 +872,10 @@ async def add_run_call_llm_cost_microusd(
             run_id,
             *deltas,
         )
-        # ``accounts.spent_microusd`` is the canonical all-inference scalar.
-        # Raw workflow inference used to update only the run meter, which made
-        # public usage and spend admission read zero. Keep both projections in
-        # the same transaction so they cannot diverge.
-        await conn.execute(
-            "UPDATE accounts SET spent_microusd = spent_microusd + $1 WHERE id = $2",
-            deltas[4],
-            account_id,
-        )
+        # Migration 0168's wf_runs trigger projects the cost delta into the
+        # canonical account meter in this transaction. Keeping that projection
+        # in the database also covers old workers during rolling cutover and
+        # prevents an old/new application dual-write from charging twice.
 
 
 async def runs_children_usage(

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -31,6 +31,7 @@ from aios.db.queries import (
 )
 from aios.errors import ConflictError, NotFoundError
 from aios.ids import WORKFLOW, WORKFLOW_EVENT, WORKFLOW_RUN, make_id
+from aios.models.accounting import UsageNodeRef
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec, load_tool_specs
 from aios.models.sessions import Err, Ok, Outcome
 from aios.models.workflows import (
@@ -128,6 +129,15 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
         archived_at=row["archived_at"],
         terminal_summary=row.get("terminal_summary"),
         journal_pruned_at=row.get("journal_pruned_at"),
+        usage_parent=(
+            UsageNodeRef(kind="session", id=row["creator_session_id"])
+            if row.get("creator_session_id") is not None
+            else (
+                UsageNodeRef(kind="run", id=row["creator_run_id"])
+                if row.get("creator_run_id") is not None
+                else None
+            )
+        ),
     )
 
 
@@ -671,6 +681,20 @@ async def insert_wf_run(
     replay re-attaches the existing row (re-fetched here) instead of erroring; the
     default (``None``) mints a fresh ULID for which the conflict can never fire."""
     new_id = run_id if run_id is not None else make_id(WORKFLOW_RUN)
+    creator_session_id: str | None = None
+    creator_run_id: str | None = None
+    caller_kind = caller.get("kind") if caller is not None else None
+    caller_id = caller.get("id") if caller is not None else None
+    if caller_kind == "session" and isinstance(caller_id, str):
+        creator_session_id = caller_id
+    elif caller_kind == "run" and isinstance(caller_id, str):
+        creator_run_id = caller_id
+    elif launcher_session_id is not None:
+        # Detached launches have no request caller. Their owning/launching
+        # session is the creator; parent_run_id remains execution lineage.
+        creator_session_id = launcher_session_id
+    elif parent_run_id is not None:
+        creator_run_id = parent_run_id
     try:
         row = await conn.fetchrow(
             """
@@ -680,10 +704,10 @@ async def insert_wf_run(
                  workspace_mode, workspace_path,
                  script, script_sha, source_version, host_semantics_epoch, status, input,
                  tools, mcp_servers, http_servers, budget_total_microusd, default_child_model,
-                 depth, tools_vocab_epoch)
+                 depth, tools_vocab_epoch, creator_session_id, creator_run_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10, $11, $12, $13, $14, $15,
                     'pending', $16::jsonb,
-                    $17::jsonb, $18::jsonb, $19::jsonb, $20, $21, $22, $23)
+                    $17::jsonb, $18::jsonb, $19::jsonb, $20, $21, $22, $23, $24, $25)
             ON CONFLICT (id) DO NOTHING
             RETURNING *
             """,
@@ -710,6 +734,8 @@ async def insert_wf_run(
             default_child_model,
             depth,
             TOOLS_VOCAB_EPOCH,
+            creator_session_id,
+            creator_run_id,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
@@ -795,25 +821,65 @@ async def get_run_call_llm_cost_microusd(
 
 
 async def add_run_call_llm_cost_microusd(
-    conn: asyncpg.Connection[Any], run_id: str, delta_microusd: int, *, account_id: str
+    conn: asyncpg.Connection[Any],
+    run_id: str,
+    delta_microusd: int,
+    *,
+    account_id: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
 ) -> None:
-    """Charge ``delta_microusd`` to the run's ``call_llm`` inference meter (#1633).
+    """Charge one raw ``call_llm`` inference to its run-level meters.
 
-    The increment is a single atomic ``col = col + $delta`` so concurrent charges
-    never lose an update; ``delta_microusd`` is clamped at ``0`` (an unreported
-    LiteLLM cost is ``None`` → charged as 0, never negative). Charge **once at the
-    inference site**, in the same transaction that journals the ``call_llm``
-    result, so a budget read on the next step sees the spend.
+    The cumulative columns and rolling-rate ledger are written atomically, in
+    the same outer transaction as the result signal.  Cost-only callers remain
+    source-compatible; the token kwargs complete the run's own usage vector.
     """
-    if delta_microusd <= 0:
-        return
-    await conn.execute(
-        "UPDATE wf_runs SET call_llm_cost_microusd = call_llm_cost_microusd + $2 "
-        "WHERE id = $1 AND account_id = $3",
-        run_id,
-        delta_microusd,
-        account_id,
+    deltas = (
+        max(0, input_tokens),
+        max(0, output_tokens),
+        max(0, cache_read_input_tokens),
+        max(0, cache_creation_input_tokens),
+        max(0, delta_microusd),
     )
+    if not any(deltas):
+        return
+    async with conn.transaction():
+        charged_run_id = await conn.fetchval(
+            "UPDATE wf_runs SET "
+            "call_llm_input_tokens = call_llm_input_tokens + $2, "
+            "call_llm_output_tokens = call_llm_output_tokens + $3, "
+            "call_llm_cache_read_input_tokens = call_llm_cache_read_input_tokens + $4, "
+            "call_llm_cache_creation_input_tokens = "
+            "call_llm_cache_creation_input_tokens + $5, "
+            "call_llm_cost_microusd = call_llm_cost_microusd + $6 "
+            "WHERE id = $1 AND account_id = $7 RETURNING id",
+            run_id,
+            *deltas,
+            account_id,
+        )
+        if charged_run_id is None:
+            return
+        await conn.execute(
+            "INSERT INTO inference_usage_ledger "
+            "(account_id, run_id, input_tokens, output_tokens, "
+            " cache_read_input_tokens, cache_creation_input_tokens, cost_microusd) "
+            "VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            account_id,
+            run_id,
+            *deltas,
+        )
+        # ``accounts.spent_microusd`` is the canonical all-inference scalar.
+        # Raw workflow inference used to update only the run meter, which made
+        # public usage and spend admission read zero. Keep both projections in
+        # the same transaction so they cannot diverge.
+        await conn.execute(
+            "UPDATE accounts SET spent_microusd = spent_microusd + $1 WHERE id = $2",
+            deltas[4],
+            account_id,
+        )
 
 
 async def runs_children_usage(

--- a/src/aios/models/accounting.py
+++ b/src/aios/models/accounting.py
@@ -36,6 +36,7 @@ class UsageCounters(BaseModel):
     output_tokens: int = 0
     cache_read_input_tokens: int = 0
     cache_creation_input_tokens: int = 0
+    tokens_complete: bool = True
 
     @property
     def total_tokens(self) -> int:

--- a/src/aios/models/accounting.py
+++ b/src/aios/models/accounting.py
@@ -1,0 +1,94 @@
+"""Inference accounting shared by sessions and workflow runs.
+
+Accounting follows the immutable *creation* edge.  Invocation edges are
+deliberately absent: calling an existing session does not transfer ownership of
+that session's spend.  ``own`` is inference performed by the node itself;
+``subtree`` is ``own`` plus every creation descendant, across both session and
+workflow-run boundaries.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+UsageNodeKind = Literal["session", "run"]
+UsageMetric = Literal["cost_microusd", "total_tokens"]
+DEFAULT_USAGE_WINDOW_SECONDS = 86_400
+MIN_USAGE_WINDOW_SECONDS = 60
+MAX_USAGE_WINDOW_SECONDS = 2_592_000
+
+
+class UsageNodeRef(BaseModel):
+    """One immutable parent in the creation-accounting tree."""
+
+    kind: UsageNodeKind
+    id: str
+
+
+class UsageCounters(BaseModel):
+    """Cumulative inference bought at one node or in one subtree."""
+
+    cost_microusd: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+class UsageRate(BaseModel):
+    """Rolling-window inference rate, normalized to one hour.
+
+    The usage ledger starts when the accounting migration lands.  Until one
+    full requested window has elapsed, ``complete`` is false and
+    ``observed_seconds`` states the actual denominator.  Rates remain useful
+    immediately without pretending pre-ledger history was observed.
+    """
+
+    window_seconds: int
+    observed_seconds: int
+    complete: bool
+    cost_microusd_per_hour: float = 0.0
+    input_tokens_per_hour: float = 0.0
+    output_tokens_per_hour: float = 0.0
+    cache_read_input_tokens_per_hour: float = 0.0
+    cache_creation_input_tokens_per_hour: float = 0.0
+
+
+class AttributedUsage(BaseModel):
+    """Own and transitive usage for one node in the accounting tree."""
+
+    own: UsageCounters = Field(default_factory=UsageCounters)
+    subtree: UsageCounters = Field(default_factory=UsageCounters)
+    own_rate: UsageRate | None = None
+    subtree_rate: UsageRate | None = None
+
+
+class UsageConsumer(BaseModel):
+    """One root consumer in the ranked account-wide usage view."""
+
+    rank: int
+    kind: UsageNodeKind
+    id: str
+    label: str
+    status: str
+    created_at: datetime
+    archived_at: datetime | None = None
+    share: float
+    usage: AttributedUsage
+
+
+class UsageConsumersResponse(BaseModel):
+    """Ranked, additive root consumers for one account."""
+
+    metric: UsageMetric
+    window_seconds: int
+    coverage_started_at: datetime
+    total_rate_per_hour: float
+    items: list[UsageConsumer] = Field(default_factory=list)

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -17,6 +17,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from pydantic.json_schema import SkipJsonSchema
 
 from aios.actors import Actor
+from aios.models.accounting import (
+    AttributedUsage,
+    UsageNodeRef,
+)
 from aios.models.events import Event
 from aios.models.github_repositories import (
     MAX_REPOS_PER_SESSION,
@@ -156,9 +160,15 @@ acceptable for short test/cutover windows.
 MAX_USER_MESSAGE_CHARS = 1_000_000
 
 
-class SessionUsage(BaseModel):
-    """Cumulative token usage across all model calls in a session."""
+class SessionUsage(AttributedUsage):
+    """Session inference usage, with backward-compatible own counters.
 
+    The flat counters retain their historical self-only meaning.  New clients
+    should use ``own`` and ``subtree``; those fields cross session/run creation
+    boundaries transitively and include archived descendants.
+    """
+
+    cost_microusd: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
     cache_read_input_tokens: int = 0
@@ -423,6 +433,7 @@ class Session(BaseModel):
     vault_ids: list[str] = Field(default_factory=list)
     last_event_seq: int
     usage: SessionUsage = Field(default_factory=SessionUsage)
+    usage_parent: UsageNodeRef | None = None
     resources: list[SessionResourceEcho] = Field(default_factory=list)
     triggers: list[TriggerEcho] = Field(default_factory=list)
     created_by: Actor | None = None

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from aios.actors import Actor
+from aios.models.accounting import AttributedUsage, UsageNodeRef
 from aios.models.agents import (
     HttpServerRef,
     HttpServerSpec,
@@ -105,7 +106,7 @@ class WorkflowVersion(BaseModel):
     created_at: datetime
 
 
-class WfRunUsage(BaseModel):
+class WfRunUsage(AttributedUsage):
     """Per-run cost / token / iteration / wall-clock — the machine-observer's substrate.
 
     The read-path projection of a run's actual spend (#1324). The numbers are summed
@@ -114,10 +115,12 @@ class WfRunUsage(BaseModel):
     (on ``WfRun``) and its realized ``cost_microusd`` *spend* (here) are finally both
     legible from the read path.
 
-    EVERY field is ``int | None``, and absence is reported as **explicit null**, never
-    a silent ``0`` or an omitted key (cf. the ``vault_ids:null`` read-path disease this
-    must not inherit — see the substrate-different-verdict invariant). The observer
-    reads null as *cannot-determine* and fails loud, NOT as "zero spend":
+    Every legacy flat metric is ``int | None``, and absence is reported as
+    **explicit null**, never a silent ``0`` or an omitted key (cf. the
+    ``vault_ids:null`` read-path disease this must not inherit — see the
+    substrate-different-verdict invariant). The observer reads null as
+    *cannot-determine* and fails loud, NOT as "zero spend". Creation accounting
+    is carried separately by the inherited ``own``/``subtree`` and rate fields:
 
     * ``cost_microusd`` / ``*_tokens`` — summed over the run's child sessions. A run
       with no children sums to ``0`` (a real, observed zero — distinct from null).
@@ -234,6 +237,7 @@ class WfRun(BaseModel):
     # which never needs it and must not pay the extra aggregate query. ``budget_usd``
     # above is the ceiling; ``usage.cost_microusd`` is the spend against it.
     usage: WfRunUsage | None = None
+    usage_parent: UsageNodeRef | None = None
 
 
 class WfRunEvent(BaseModel):

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -225,6 +225,9 @@ class WfRun(BaseModel):
     # in this run-level meter; the ``budget_usd`` gate is the SUM of this and the
     # child-session rollup (``usage.cost_microusd``). Charged once at the inference site.
     call_llm_cost_microusd: int = 0
+    # False on pre-0168 runs unless an explicit bounded repair later proves the
+    # historical journals complete. Never render unavailable tokens as measured zero.
+    call_llm_tokens_complete: bool = True
     last_event_seq: int
     created_at: datetime
     updated_at: datetime

--- a/src/aios/services/accounting.py
+++ b/src/aios/services/accounting.py
@@ -1,0 +1,36 @@
+"""Public inference-accounting service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.db.queries import accounting as accounting_queries
+from aios.models.accounting import UsageConsumersResponse, UsageMetric
+
+
+async def ranked_consumers(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    window_seconds: int,
+    metric: UsageMetric,
+    limit: int,
+) -> UsageConsumersResponse:
+    """Return additive account roots ranked by live subtree rate."""
+    async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
+        coverage_started_at, total_rate, items = await accounting_queries.ranked_consumers(
+            conn,
+            account_id=account_id,
+            window_seconds=window_seconds,
+            metric=metric,
+            limit=limit,
+        )
+    return UsageConsumersResponse(
+        metric=metric,
+        window_seconds=window_seconds,
+        coverage_started_at=coverage_started_at,
+        total_rate_per_hour=total_rate,
+        items=items,
+    )

--- a/src/aios/services/accounting.py
+++ b/src/aios/services/accounting.py
@@ -9,6 +9,8 @@ import asyncpg
 from aios.db.queries import accounting as accounting_queries
 from aios.models.accounting import UsageConsumersResponse, UsageMetric
 
+USAGE_CONSUMERS_STATEMENT_TIMEOUT_MS = 5_000
+
 
 async def ranked_consumers(
     pool: asyncpg.Pool[Any],
@@ -20,6 +22,9 @@ async def ranked_consumers(
 ) -> UsageConsumersResponse:
     """Return additive account roots ranked by live subtree rate."""
     async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
+        await conn.execute(
+            f"SET LOCAL statement_timeout = '{USAGE_CONSUMERS_STATEMENT_TIMEOUT_MS}ms'"
+        )
         coverage_started_at, total_rate, items = await accounting_queries.ranked_consumers(
             conn,
             account_id=account_id,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -21,6 +21,7 @@ from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.db.listen import EVENTS_ARCHIVED_NOTIFY, open_listen_for_events
+from aios.db.queries import accounting as accounting_queries
 from aios.db.queries import workflows as wf_queries
 from aios.errors import (
     ConflictError,
@@ -35,6 +36,7 @@ from aios.harness.window import WindowedEvents
 from aios.ids import GITHUB_REPOSITORY, MEMORY_STORE, REQUEST, make_id, split_id
 from aios.jobs.app import defer_run_wake, defer_wake
 from aios.logging import get_logger
+from aios.models.accounting import DEFAULT_USAGE_WINDOW_SECONDS, UsageNodeRef
 from aios.models.agents import (
     StepSurface,
     is_mcp_tool_name,
@@ -54,6 +56,7 @@ from aios.models.sessions import (
     SessionResource,
     SessionResourceEcho,
     SessionStatus,
+    SessionUsage,
     split_resources_by_type,
 )
 from aios.models.tasks import TaskHandle
@@ -381,6 +384,9 @@ async def create_session(
             account_id=account_id,
             frozen_surface=frozen_surface,
             frozen_litellm_extra=frozen_litellm_extra,
+            # A freshly created call_agent child inherits from exactly one
+            # launcher. Later call_session invocations do not touch this edge.
+            creator_session_id=inherit_from_session_id,
         )
         effective_vault_ids = (
             inherited_vault_ids if inherit_from_session_id is not None else vault_ids
@@ -1182,6 +1188,20 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: s
     async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
         session = await queries.get_session(conn, session_id, account_id=account_id)
         session = await _enrich_session(conn, session, account_id=account_id)
+        attributed = await accounting_queries.usage_for_node(
+            conn,
+            UsageNodeRef(kind="session", id=session.id),
+            account_id=account_id,
+            window_seconds=DEFAULT_USAGE_WINDOW_SECONDS,
+        )
+        if attributed is not None:
+            session = session.model_copy(
+                update={
+                    "usage": SessionUsage.model_validate(
+                        {**session.usage.model_dump(), **attributed.model_dump()}
+                    )
+                }
+            )
     awaiting_by_sid = await compute_awaiting(pool, [session], account_id=account_id)
     obligations_by_sid = await compute_obligations(pool, [session], account_id=account_id)
     return session.model_copy(
@@ -1315,6 +1335,7 @@ async def list_sessions(
             vault_map = None
             echoes_map = None
             trigger_map = None
+            attributed_by_sid = None
         else:
             sid_list = [s.id for s in sessions]
             vault_map = await queries.batch_get_session_vault_ids(
@@ -1324,10 +1345,21 @@ async def list_sessions(
             trigger_map = await queries.batch_list_session_triggers(
                 conn, sid_list, account_id=account_id
             )
+            attributed_by_sid = await accounting_queries.usage_for_nodes(
+                conn,
+                [UsageNodeRef(kind="session", id=sid) for sid in sid_list],
+                account_id=account_id,
+                window_seconds=DEFAULT_USAGE_WINDOW_SECONDS,
+            )
     awaiting_by_sid = await compute_awaiting(pool, sessions, account_id=account_id)
     if view == "lite":
         return [s.model_copy(update={"awaiting": awaiting_by_sid.get(s.id, [])}) for s in sessions]
-    assert vault_map is not None and echoes_map is not None and trigger_map is not None
+    assert (
+        vault_map is not None
+        and echoes_map is not None
+        and trigger_map is not None
+        and attributed_by_sid is not None
+    )
     obligations_by_sid = await compute_obligations(pool, sessions, account_id=account_id)
     enriched: list[Session] = [
         s.model_copy(
@@ -1337,6 +1369,12 @@ async def list_sessions(
                 "triggers": trigger_map[s.id],
                 "awaiting": awaiting_by_sid.get(s.id, []),
                 "obligations": obligations_by_sid.get(s.id, []),
+                "usage": SessionUsage.model_validate(
+                    {
+                        **s.usage.model_dump(),
+                        **attributed_by_sid[("session", s.id)].model_dump(),
+                    }
+                ),
             }
         )
         for s in sessions

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -17,10 +17,16 @@ from typing import Any
 
 import asyncpg
 
+from aios.db.queries import accounting as accounting_queries
 from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, ForbiddenError, NotFoundError, ValidationError
 from aios.ids import REQUEST, make_id
 from aios.jobs.app import defer_run_wake
+from aios.models.accounting import (
+    DEFAULT_USAGE_WINDOW_SECONDS,
+    AttributedUsage,
+    UsageNodeRef,
+)
 from aios.models.agents import (
     HttpServerRef,
     HttpServerSpec,
@@ -513,14 +519,18 @@ def _wall_clock_ms(run: WfRun) -> int | None:
     return max(0, round((run.updated_at - run.created_at).total_seconds() * 1000))
 
 
-def _run_usage(run: WfRun, children: wf_queries.RunChildrenUsage) -> WfRunUsage:
+def _run_usage(
+    run: WfRun,
+    children: wf_queries.RunChildrenUsage,
+    attributed: AttributedUsage | None = None,
+) -> WfRunUsage:
     """Project a run + its summed child usage into the read-path :class:`WfRunUsage`.
 
     cost/tokens are the real summed children; ``iteration_count`` is explicit
     ``None`` (no per-run iteration counter exists on any substrate yet — see the
     model docstring); ``wall_clock_ms`` is terminal-only (:func:`_wall_clock_ms`).
     """
-    return WfRunUsage(
+    usage = WfRunUsage(
         cost_microusd=children.cost_microusd,
         input_tokens=children.input_tokens,
         output_tokens=children.output_tokens,
@@ -529,13 +539,24 @@ def _run_usage(run: WfRun, children: wf_queries.RunChildrenUsage) -> WfRunUsage:
         iteration_count=None,
         wall_clock_ms=_wall_clock_ms(run),
     )
+    return (
+        WfRunUsage.model_validate({**usage.model_dump(), **attributed.model_dump()})
+        if attributed is not None
+        else usage
+    )
 
 
 async def get_run(pool: asyncpg.Pool[Any], run_id: str, *, account_id: str) -> WfRun:
-    async with pool.acquire() as conn:
+    async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
         run = await wf_queries.get_wf_run(conn, run_id, account_id=account_id)
         children = await wf_queries.run_children_usage(conn, run.id, account_id=account_id)
-        return run.model_copy(update={"usage": _run_usage(run, children)})
+        attributed = await accounting_queries.usage_for_node(
+            conn,
+            UsageNodeRef(kind="run", id=run.id),
+            account_id=account_id,
+            window_seconds=DEFAULT_USAGE_WINDOW_SECONDS,
+        )
+        return run.model_copy(update={"usage": _run_usage(run, children, attributed)})
 
 
 async def archive_run(pool: asyncpg.Pool[Any], run_id: str, *, account_id: str) -> WfRun:
@@ -549,7 +570,13 @@ async def archive_run(pool: asyncpg.Pool[Any], run_id: str, *, account_id: str) 
     async with pool.acquire() as conn:
         run = await wf_queries.archive_run(conn, run_id, account_id=account_id)
         children = await wf_queries.run_children_usage(conn, run.id, account_id=account_id)
-        return run.model_copy(update={"usage": _run_usage(run, children)})
+        attributed = await accounting_queries.usage_for_node(
+            conn,
+            UsageNodeRef(kind="run", id=run.id),
+            account_id=account_id,
+            window_seconds=DEFAULT_USAGE_WINDOW_SECONDS,
+        )
+        return run.model_copy(update={"usage": _run_usage(run, children, attributed)})
 
 
 async def list_runs(
@@ -579,7 +606,20 @@ async def list_runs(
         usage_by_run = await wf_queries.runs_children_usage(
             conn, [r.id for r in runs], account_id=account_id
         )
-        return [r.model_copy(update={"usage": _run_usage(r, usage_by_run[r.id])}) for r in runs]
+        attributed_by_run = await accounting_queries.usage_for_nodes(
+            conn,
+            [UsageNodeRef(kind="run", id=run.id) for run in runs],
+            account_id=account_id,
+            window_seconds=DEFAULT_USAGE_WINDOW_SECONDS,
+        )
+        return [
+            r.model_copy(
+                update={
+                    "usage": _run_usage(r, usage_by_run[r.id], attributed_by_run[("run", r.id)])
+                }
+            )
+            for r in runs
+        ]
 
 
 async def list_run_events(

--- a/src/aios/workflows/run_llm.py
+++ b/src/aios/workflows/run_llm.py
@@ -118,13 +118,24 @@ async def _run_call_llm_task(
     """Run one inference, charge its cost, write its result signal, wake the run."""
     try:
         result, cost_microusd = await invoke_call_llm(run=run, spec=spec)
+        raw_usage = result.get("usage")
+        usage: dict[str, Any] = raw_usage if isinstance(raw_usage, dict) else {}
         try:
             # Charge the cost meter and write the signal in ONE transaction so a budget
             # read on the next step never sees the result without its spend (charge once,
             # at the inference site).
             async with pool.acquire() as conn, conn.transaction():
                 await wf_queries.add_run_call_llm_cost_microusd(
-                    conn, run.id, cost_microusd, account_id=run.account_id
+                    conn,
+                    run.id,
+                    cost_microusd,
+                    account_id=run.account_id,
+                    input_tokens=int(usage.get("input_tokens", 0) or 0),
+                    output_tokens=int(usage.get("output_tokens", 0) or 0),
+                    cache_read_input_tokens=int(usage.get("cache_read_input_tokens", 0) or 0),
+                    cache_creation_input_tokens=int(
+                        usage.get("cache_creation_input_tokens", 0) or 0
+                    ),
                 )
                 await wf_queries.insert_run_signal(
                     conn,
@@ -258,7 +269,12 @@ async def invoke_call_llm(*, run: WfRun, spec: dict[str, Any]) -> tuple[dict[str
         # estimates, so a run can't dodge its budget by timing out. Result is the
         # recoverable error value the script branches on.
         cost = estimate_cost_usd(model, exc.usage) if exc.usage else None
-        return {"error": f"call_llm timed out: {exc}"}, _to_microusd(cost)
+        return {
+            "error": f"call_llm timed out: {exc}",
+            # Partial provider counters are still bought inference and feed the
+            # same run meter as a successful raw turn.
+            "usage": exc.usage,
+        }, _to_microusd(cost)
     except Exception as exc:  # provider error — surface as a recoverable value
         log.warning("call_llm.provider_error", run_id=run.id, model=model, error=str(exc))
         return {"error": f"call_llm failed: {type(exc).__name__}: {exc}"}, 0

--- a/tests/e2e/test_accounts_mgmt.py
+++ b/tests/e2e/test_accounts_mgmt.py
@@ -13,6 +13,9 @@ from typing import Any
 import httpx
 import pytest
 
+from aios.db import queries
+from aios.db.queries import workflows as wf_queries
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 from tests.helpers.connections import asgi_client
 
 
@@ -653,6 +656,93 @@ class TestUsage:
         )
         assert r.json()["agents"] == 1
         assert r.json()["environments"] == 1
+
+    async def test_usage_includes_workflow_call_llm_spend(
+        self,
+        http_client: httpx.AsyncClient,
+        aios_env: dict[str, str],
+        pool: Any,
+    ) -> None:
+        minted = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "usage-workflow-spend"},
+        )
+        child_key = minted.json()["plaintext_key"]
+        child_id = minted.json()["account_id"]
+        environment = await http_client.post(
+            "/v1/environments",
+            headers=_bearer(child_key),
+            json={"name": "usage-workflow-env"},
+        )
+        assert environment.status_code == 201, environment.text
+
+        async with pool.acquire() as conn:
+            run = await wf_queries.insert_wf_run(
+                conn,
+                account_id=child_id,
+                workflow_id=None,
+                environment_id=environment.json()["id"],
+                script="async def main(input):\n    return input\n",
+                script_sha="usage-workflow-spend",
+                host_semantics_epoch=HOST_SEMANTICS_EPOCH,
+                depth=10,
+            )
+            await wf_queries.add_run_call_llm_cost_microusd(
+                conn, run.id, 12_345, account_id=child_id
+            )
+
+        usage = await http_client.get(
+            f"/v1/accounts/{child_id}/usage",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+        )
+        assert usage.status_code == 200, usage.text
+        assert usage.json()["spent_usd"] == 0.012345
+
+    async def test_ranked_consumers_is_one_account_scoped_call(
+        self,
+        http_client: httpx.AsyncClient,
+        aios_env: dict[str, str],
+        pool: Any,
+    ) -> None:
+        headers = _bearer(aios_env["AIOS_API_KEY"])
+        agent = await http_client.post(
+            "/v1/agents", headers=headers, json={"name": "usage-hot", "model": "openrouter/test"}
+        )
+        environment = await http_client.post(
+            "/v1/environments", headers=headers, json={"name": "usage-hot"}
+        )
+        session = await http_client.post(
+            "/v1/sessions",
+            headers=headers,
+            json={
+                "agent_id": agent.json()["id"],
+                "environment_id": environment.json()["id"],
+                "title": "known hot consumer",
+            },
+        )
+        assert session.status_code == 201, session.text
+        async with pool.acquire() as conn:
+            await queries.increment_session_usage(
+                conn,
+                session.json()["id"],
+                account_id="acc_test_stub",
+                input_tokens=1_000,
+                output_tokens=100,
+                cost_microusd=50_000,
+            )
+
+        ranked = await http_client.get(
+            "/v1/usage/consumers?window_seconds=3600&metric=cost_microusd",
+            headers=headers,
+        )
+        assert ranked.status_code == 200, ranked.text
+        body = ranked.json()
+        assert body["items"][0]["id"] == session.json()["id"]
+        assert body["items"][0]["usage"]["own"]["cost_microusd"] == 50_000
+        assert body["items"][0]["usage"]["subtree"]["cost_microusd"] == 50_000
+        assert body["items"][0]["usage"]["subtree_rate"]["cost_microusd_per_hour"] > 0
+        assert body["items"][0]["share"] == 1.0
 
     async def test_usage_cross_tenant_404(
         self, http_client: httpx.AsyncClient, aios_env: dict[str, str]

--- a/tests/integration/test_account_subtree_spend.py
+++ b/tests/integration/test_account_subtree_spend.py
@@ -15,6 +15,8 @@ import pytest
 
 from aios.db import queries
 from aios.db.pool import register_jsonb_codec
+from aios.db.queries import workflows as wf_queries
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 
 
 @pytest.fixture
@@ -52,6 +54,29 @@ async def _set_spent(conn: asyncpg.Connection[Any], account_id: str, micro: int)
     await conn.execute("UPDATE accounts SET spent_microusd = $2 WHERE id = $1", account_id, micro)
 
 
+async def _add_workflow_spent(conn: asyncpg.Connection[Any], account_id: str, micro: int) -> None:
+    """Book raw ``call_llm`` spend on an account-owned workflow run."""
+    environment_id = f"env_{account_id}"
+    await conn.execute(
+        "INSERT INTO environments (id, name, config, account_id) "
+        "VALUES ($1, $2, '{}'::jsonb, $3) ON CONFLICT (id) DO NOTHING",
+        environment_id,
+        f"env-{account_id}",
+        account_id,
+    )
+    run = await wf_queries.insert_wf_run(
+        conn,
+        account_id=account_id,
+        workflow_id=None,
+        environment_id=environment_id,
+        script="async def main(input):\n    return input\n",
+        script_sha=f"sha-{account_id}-{micro}",
+        host_semantics_epoch=HOST_SEMANTICS_EPOCH,
+        depth=10,
+    )
+    await wf_queries.add_run_call_llm_cost_microusd(conn, run.id, micro, account_id=account_id)
+
+
 class TestSubtreeSpentMicrousd:
     async def test_leaf_equals_own_spend(self, conn: asyncpg.Connection[Any]) -> None:
         await _make_tree(conn)
@@ -71,6 +96,23 @@ class TestSubtreeSpentMicrousd:
         assert await queries.get_account_subtree_spent_microusd(conn, "childA") == 1010
         # childB is a leaf.
         assert await queries.get_account_subtree_spent_microusd(conn, "childB") == 100
+
+    async def test_sums_workflow_call_llm_spend_at_every_level(
+        self, conn: asyncpg.Connection[Any]
+    ) -> None:
+        await _make_tree(conn)
+        await _set_spent(conn, "root", 1)
+        await _set_spent(conn, "childA", 10)
+        await _set_spent(conn, "childB", 100)
+        await _set_spent(conn, "grand", 1000)
+        await _add_workflow_spent(conn, "root", 2)
+        await _add_workflow_spent(conn, "childA", 20)
+        await _add_workflow_spent(conn, "childB", 200)
+        await _add_workflow_spent(conn, "grand", 2000)
+
+        assert await queries.get_account_subtree_spent_microusd(conn, "root") == 3333
+        assert await queries.get_account_subtree_spent_microusd(conn, "childA") == 3030
+        assert await queries.get_account_subtree_spent_microusd(conn, "childB") == 300
 
     async def test_zero_when_nothing_spent(self, conn: asyncpg.Connection[Any]) -> None:
         await _make_tree(conn)
@@ -98,11 +140,15 @@ class TestSubtreeSpentMicrousd:
 
 
 class TestSubtreeVsFlatRead:
-    async def test_flat_read_unchanged(self, conn: asyncpg.Connection[Any]) -> None:
-        # The flat single-row meter is independent of the subtree rollup:
-        # the ancestor's own meter stays its own write.
+    async def test_account_read_includes_own_workflows_not_descendants(
+        self, conn: asyncpg.Connection[Any]
+    ) -> None:
+        # The account read includes both of that account's inference ledgers,
+        # while the subtree read additionally includes descendant accounts.
         await _make_tree(conn)
         await _set_spent(conn, "root", 7)
         await _set_spent(conn, "grand", 1000)
-        assert await queries.get_account_spent_microusd(conn, "root") == 7
-        assert await queries.get_account_subtree_spent_microusd(conn, "root") == 1007
+        await _add_workflow_spent(conn, "root", 11)
+        await _add_workflow_spent(conn, "grand", 2000)
+        assert await queries.get_account_spent_microusd(conn, "root") == 18
+        assert await queries.get_account_subtree_spent_microusd(conn, "root") == 3018

--- a/tests/integration/test_creation_edge_accounting.py
+++ b/tests/integration/test_creation_edge_accounting.py
@@ -1,0 +1,310 @@
+"""Issue #2151 acceptance tests for creation-edge usage accounting."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.db.queries import accounting as accounting_queries
+from aios.db.queries import workflows as wf_queries
+from aios.models.accounting import UsageNodeRef
+from aios.services import sessions as sessions_service
+from aios.services import workflows as workflows_service
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+ACCOUNT = "acc_creation_accounting"
+
+
+@pytest.fixture
+async def accounting_pool(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, 'creation accounting')",
+                ACCOUNT,
+            )
+        yield pool
+    finally:
+        await pool.close()
+
+
+async def _seed_agent_workflow_agent_chain(
+    pool: asyncpg.Pool[Any],
+) -> tuple[str, str, str, str, str]:
+    """Return ``(root_session, run, child_session, agent, environment)``."""
+    agent, environment, root = await seed_agent_env_session(
+        pool, account_id=ACCOUNT, prefix="creation-accounting"
+    )
+    async with pool.acquire() as conn:
+        run = await wf_queries.insert_wf_run(
+            conn,
+            account_id=ACCOUNT,
+            workflow_id=None,
+            environment_id=environment.id,
+            launcher_session_id=root.id,
+            caller={"kind": "session", "id": root.id, "awaited": True},
+            script="async def main(input):\n    return input\n",
+            script_sha="creation-accounting",
+            host_semantics_epoch=HOST_SEMANTICS_EPOCH,
+            depth=10,
+        )
+        child = await queries.insert_child_session(
+            conn,
+            session_id="ses_creation_child",
+            account_id=ACCOUNT,
+            agent_id=agent.id,
+            environment_id=environment.id,
+            agent_version=agent.version,
+            model="openrouter/test",
+            parent_run_id=run.id,
+            tools=[],
+            mcp_servers=[],
+            http_servers=[],
+        )
+        assert child is not None
+    return root.id, run.id, child.id, agent.id, environment.id
+
+
+async def _charge_known_chain(
+    pool: asyncpg.Pool[Any], root_id: str, run_id: str, child_id: str
+) -> None:
+    async with pool.acquire() as conn:
+        await queries.increment_session_usage(
+            conn,
+            root_id,
+            account_id=ACCOUNT,
+            input_tokens=10,
+            output_tokens=1,
+            cost_microusd=100,
+        )
+        await wf_queries.add_run_call_llm_cost_microusd(
+            conn,
+            run_id,
+            200,
+            account_id=ACCOUNT,
+            input_tokens=20,
+            output_tokens=2,
+        )
+        await queries.increment_session_usage(
+            conn,
+            child_id,
+            account_id=ACCOUNT,
+            input_tokens=30,
+            output_tokens=3,
+            cost_microusd=300,
+        )
+
+
+async def test_agent_workflow_agent_rolls_up_exact_own_sum_live_and_after_archive(
+    accounting_pool: asyncpg.Pool[Any],
+) -> None:
+    root_id, run_id, child_id, _agent_id, _environment_id = await _seed_agent_workflow_agent_chain(
+        accounting_pool
+    )
+    await _charge_known_chain(accounting_pool, root_id, run_id, child_id)
+
+    # The ordinary resource reads expose the same accounting contract at
+    # ``usage.own`` / ``usage.subtree`` on both node types.
+    root_read = await sessions_service.get_session(accounting_pool, root_id, account_id=ACCOUNT)
+    run_read = await workflows_service.get_run(accounting_pool, run_id, account_id=ACCOUNT)
+    assert root_read.usage.own.cost_microusd == 100
+    assert root_read.usage.subtree.cost_microusd == 600
+    assert run_read.usage is not None
+    assert run_read.usage.own.cost_microusd == 200
+    assert run_read.usage.subtree.cost_microusd == 500
+
+    async with accounting_pool.acquire() as conn:
+        root = await accounting_queries.usage_for_node(
+            conn,
+            UsageNodeRef(kind="session", id=root_id),
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+        run = await accounting_queries.usage_for_node(
+            conn,
+            UsageNodeRef(kind="run", id=run_id),
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+        child = await accounting_queries.usage_for_node(
+            conn,
+            UsageNodeRef(kind="session", id=child_id),
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+        assert root is not None and run is not None and child is not None
+        assert [root.own.cost_microusd, run.own.cost_microusd, child.own.cost_microusd] == [
+            100,
+            200,
+            300,
+        ]
+        assert root.subtree.cost_microusd == 600
+        assert root.subtree.input_tokens == 60
+        assert run.subtree.cost_microusd == 500
+        assert root.subtree_rate is not None
+        assert root.subtree_rate.cost_microusd_per_hour > 0
+
+        # Finished work remains owned. A later child charge also updates the
+        # already-finished ancestors live.
+        await conn.execute("UPDATE sessions SET archived_at = now() WHERE id = $1", child_id)
+        await conn.execute(
+            "UPDATE wf_runs SET status = 'errored', archived_at = now() WHERE id = $1", run_id
+        )
+        await queries.increment_session_usage(
+            conn,
+            child_id,
+            account_id=ACCOUNT,
+            input_tokens=4,
+            output_tokens=0,
+            cost_microusd=40,
+        )
+        after_archive = await accounting_queries.usage_for_node(
+            conn,
+            UsageNodeRef(kind="session", id=root_id),
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+        assert after_archive is not None
+        assert after_archive.subtree.cost_microusd == 640
+        assert after_archive.subtree.input_tokens == 64
+
+
+async def test_descendant_mutation_moves_root_by_exact_amount_and_peer_invocation_moves_none(
+    accounting_pool: asyncpg.Pool[Any],
+) -> None:
+    root_id, run_id, child_id, agent_id, environment_id = await _seed_agent_workflow_agent_chain(
+        accounting_pool
+    )
+    await _charge_known_chain(accounting_pool, root_id, run_id, child_id)
+    _agent2, _environment2, peer_caller = await seed_agent_env_session(
+        accounting_pool, account_id=ACCOUNT, prefix="creation-peer"
+    )
+
+    async with accounting_pool.acquire() as conn:
+        before = await accounting_queries.usage_for_nodes(
+            conn,
+            [
+                UsageNodeRef(kind="session", id=root_id),
+                UsageNodeRef(kind="session", id=peer_caller.id),
+            ],
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+
+        grandchild = await queries.insert_session(
+            conn,
+            account_id=ACCOUNT,
+            agent_id=agent_id,
+            environment_id=environment_id,
+            agent_version=None,
+            title="known mutation",
+            metadata={},
+            creator_session_id=child_id,
+        )
+        await queries.increment_session_usage(
+            conn,
+            grandchild.id,
+            account_id=ACCOUNT,
+            input_tokens=5,
+            output_tokens=1,
+            cost_microusd=55,
+        )
+
+        # This is the persisted shape of call_session against an existing peer.
+        # It is an invocation edge only and must not rewrite the creation owner.
+        await queries.append_event(
+            conn,
+            session_id=child_id,
+            kind="lifecycle",
+            data={
+                "event": "request_opened",
+                "request_id": "req_peer_invocation",
+                "caller": {"kind": "session", "id": peer_caller.id, "awaited": True},
+            },
+            account_id=ACCOUNT,
+        )
+
+        after = await accounting_queries.usage_for_nodes(
+            conn,
+            [
+                UsageNodeRef(kind="session", id=root_id),
+                UsageNodeRef(kind="session", id=peer_caller.id),
+            ],
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+        assert after[("session", root_id)].subtree.cost_microusd == (
+            before[("session", root_id)].subtree.cost_microusd + 55
+        )
+        assert (
+            after[("session", peer_caller.id)].subtree
+            == before[("session", peer_caller.id)].subtree
+        )
+
+
+async def test_cycle_is_bounded_and_each_node_counts_once(
+    accounting_pool: asyncpg.Pool[Any],
+) -> None:
+    root_id, run_id, child_id, _agent_id, _environment_id = await _seed_agent_workflow_agent_chain(
+        accounting_pool
+    )
+    await _charge_known_chain(accounting_pool, root_id, run_id, child_id)
+    async with accounting_pool.acquire() as conn:
+        # Simulate a malformed legacy re-entry cycle. Recursive UNION globally
+        # deduplicates (kind,id), so the walk terminates without double counting.
+        await conn.execute(
+            "UPDATE sessions SET creator_session_id = $1 WHERE id = $2", child_id, root_id
+        )
+        usage = await accounting_queries.usage_for_node(
+            conn,
+            UsageNodeRef(kind="session", id=root_id),
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+        assert usage is not None
+        assert usage.subtree.cost_microusd == 600
+
+
+async def test_ranked_view_fingers_known_hot_root_in_one_query(
+    accounting_pool: asyncpg.Pool[Any],
+) -> None:
+    root_id, run_id, child_id, _agent_id, _environment_id = await _seed_agent_workflow_agent_chain(
+        accounting_pool
+    )
+    await _charge_known_chain(accounting_pool, root_id, run_id, child_id)
+    _agent2, _environment2, hot = await seed_agent_env_session(
+        accounting_pool, account_id=ACCOUNT, prefix="creation-hot"
+    )
+    async with accounting_pool.acquire() as conn:
+        await queries.increment_session_usage(
+            conn,
+            hot.id,
+            account_id=ACCOUNT,
+            input_tokens=1_000,
+            output_tokens=100,
+            cost_microusd=10_000,
+        )
+        coverage, total_rate, consumers = await accounting_queries.ranked_consumers(
+            conn,
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+            metric="cost_microusd",
+            limit=20,
+        )
+        assert coverage is not None
+        assert total_rate > 0
+        assert consumers[0].id == hot.id
+        assert consumers[0].usage.subtree.cost_microusd == 10_000
+        assert sum(item.share for item in consumers) == pytest.approx(1.0)

--- a/tests/integration/test_creation_edge_accounting.py
+++ b/tests/integration/test_creation_edge_accounting.py
@@ -12,7 +12,9 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.db.queries import accounting as accounting_queries
 from aios.db.queries import workflows as wf_queries
+from aios.errors import AiosError
 from aios.models.accounting import UsageNodeRef
+from aios.services import accounting as accounting_service
 from aios.services import sessions as sessions_service
 from aios.services import workflows as workflows_service
 from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
@@ -275,6 +277,14 @@ async def test_cycle_is_bounded_and_each_node_counts_once(
         )
         assert usage is not None
         assert usage.subtree.cost_microusd == 600
+        with pytest.raises(AiosError, match="rootless component"):
+            await accounting_queries.ranked_consumers(
+                conn,
+                account_id=ACCOUNT,
+                window_seconds=86_400,
+                metric="cost_microusd",
+                limit=1,
+            )
 
 
 async def test_ranked_view_fingers_known_hot_root_in_one_query(
@@ -308,3 +318,70 @@ async def test_ranked_view_fingers_known_hot_root_in_one_query(
         assert consumers[0].id == hot.id
         assert consumers[0].usage.subtree.cost_microusd == 10_000
         assert sum(item.share for item in consumers) == pytest.approx(1.0)
+
+
+async def test_ranked_limit_one_traverses_one_row_per_account_node(
+    accounting_pool: asyncpg.Pool[Any],
+) -> None:
+    root_id, _run_id, child_id, agent_id, environment_id = await _seed_agent_workflow_agent_chain(
+        accounting_pool
+    )
+    depth = 256
+    rows: list[tuple[str, str, str, str, str, str]] = []
+    parent = child_id
+    for index in range(depth):
+        session_id = f"ses_linear_{index:04d}"
+        rows.append(
+            (
+                session_id,
+                agent_id,
+                environment_id,
+                f"/tmp/{session_id}",
+                ACCOUNT,
+                parent,
+            )
+        )
+        parent = session_id
+
+    async with accounting_pool.acquire() as conn:
+        await conn.executemany(
+            "INSERT INTO sessions "
+            "(id, agent_id, environment_id, workspace_volume_path, account_id, "
+            " creator_session_id) VALUES ($1, $2, $3, $4, $5, $6)",
+            rows,
+        )
+        result = await conn.fetch(
+            accounting_queries._ranked_consumers_sql("cost_microusd"),
+            ACCOUNT,
+            86_400,
+            1,
+        )
+        assert len(result) == 1
+        # root + run + child + the deep descendants: the recursive work table
+        # is linear even though the response limit is one.
+        expected_nodes = depth + 3
+        assert int(result[0]["graph_node_count"]) == expected_nodes
+        assert int(result[0]["graph_traversal_rows"]) == expected_nodes
+        assert result[0]["id"] == root_id
+
+
+async def test_ranked_timeout_rolls_back_and_releases_pool_connection(
+    accounting_pool: asyncpg.Pool[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _slow_query(conn: asyncpg.Connection[Any], **_kwargs: Any) -> Any:
+        await conn.execute("SELECT pg_sleep(0.05)")
+        raise AssertionError("statement timeout did not fire")
+
+    monkeypatch.setattr(accounting_service, "USAGE_CONSUMERS_STATEMENT_TIMEOUT_MS", 1)
+    monkeypatch.setattr(accounting_queries, "ranked_consumers", _slow_query)
+    with pytest.raises(asyncpg.QueryCanceledError):
+        await accounting_service.ranked_consumers(
+            accounting_pool,
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+            metric="cost_microusd",
+            limit=1,
+        )
+
+    async with accounting_pool.acquire() as conn:
+        assert await conn.fetchval("SELECT 1") == 1

--- a/tests/integration/test_migrations_0168_creation_edge_usage.py
+++ b/tests/integration/test_migrations_0168_creation_edge_usage.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from typing import cast
 
 import asyncpg
+import psycopg
 import pytest
 
 from tests.conftest import _docker_available, needs_docker
@@ -85,6 +87,41 @@ async def _creator(db_url: str, session_id: str) -> str | None:
         await conn.close()
 
 
+async def _seed_workflow_spend(db_url: str, *, spent_microusd: int, run_cost_microusd: int) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(
+            "INSERT INTO accounts "
+            "(id, parent_account_id, can_mint_children, display_name, spent_microusd) "
+            "VALUES ('acc_spend_0168', NULL, TRUE, '0168 spend', $1)",
+            spent_microusd,
+        )
+        await conn.execute(
+            "INSERT INTO environments (id, name, account_id) "
+            "VALUES ('env_spend_0168', 'env-spend-0168', 'acc_spend_0168')"
+        )
+        await conn.execute(
+            "INSERT INTO wf_runs "
+            "(id, workflow_id, account_id, environment_id, script, script_sha, "
+            " host_semantics_epoch, call_llm_cost_microusd) "
+            "VALUES ('run_spend_0168', NULL, 'acc_spend_0168', 'env_spend_0168', "
+            " 'async def main(i): return i', 'sha-spend-0168', 0, $1)",
+            run_cost_microusd,
+        )
+    finally:
+        await conn.close()
+
+
+async def _account_spend(db_url: str) -> int:
+    conn = await asyncpg.connect(db_url)
+    try:
+        return int(
+            await conn.fetchval("SELECT spent_microusd FROM accounts WHERE id = 'acc_spend_0168'")
+        )
+    finally:
+        await conn.close()
+
+
 @needs_docker
 @pytest.mark.integration
 def test_backfill_does_not_infer_creation_from_archive_when_idle(postgres: object) -> None:
@@ -101,3 +138,181 @@ def test_backfill_does_not_infer_creation_from_archive_when_idle(postgres: objec
     # into self-archival. Only explicit creation provenance is backfilled.
     assert asyncio.run(_creator(db_url, "ses_api_target_0168")) is None
     assert asyncio.run(_creator(db_url, "ses_provenance_target_0168")) == "ses_caller_0168"
+
+
+@needs_docker
+@pytest.mark.integration
+@pytest.mark.parametrize("already_repaired", [False, True])
+def test_historical_workflow_spend_is_reconciled_exactly_once(
+    postgres: object, *, already_repaired: bool
+) -> None:
+    db_url = _alembic_url(postgres)
+    up = _run_alembic(["upgrade", "0166"], db_url)
+    assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(
+        _seed_workflow_spend(
+            db_url,
+            spent_microusd=100 if already_repaired else 0,
+            run_cost_microusd=100,
+        )
+    )
+
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    assert asyncio.run(_account_spend(db_url)) == 100
+
+    # A legacy writer knows only the run meter. The database trigger installed
+    # at cutover still projects its post-migration delta exactly once.
+    asyncio.run(
+        _execute(
+            db_url,
+            "UPDATE wf_runs SET call_llm_cost_microusd = "
+            "call_llm_cost_microusd + 40 WHERE id = 'run_spend_0168'",
+        )
+    )
+    assert asyncio.run(_account_spend(db_url)) == 140
+
+
+@needs_docker
+@pytest.mark.integration
+def test_old_writer_commit_across_migration_snapshot_is_not_lost(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+    up = _run_alembic(["upgrade", "0166"], db_url)
+    assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend(db_url, spent_microusd=0, run_cost_microusd=100))
+
+    # Hold an old-writer update open. The migration must wait for that writer,
+    # then reconcile the committed 140 total rather than its earlier 100 view.
+    with psycopg.connect(db_url) as writer, ThreadPoolExecutor(max_workers=1) as executor:
+        writer.execute(
+            "UPDATE wf_runs SET call_llm_cost_microusd = "
+            "call_llm_cost_microusd + 40 WHERE id = 'run_spend_0168'"
+        )
+        future = executor.submit(_run_alembic, ["upgrade", "0168"], db_url)
+        assert not future.done()
+        writer.commit()
+        up = future.result(timeout=30)
+
+    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    assert asyncio.run(_account_spend(db_url)) == 140
+
+
+@needs_docker
+@pytest.mark.integration
+def test_ambiguous_partial_repair_fails_closed(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+    up = _run_alembic(["upgrade", "0166"], db_url)
+    assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend(db_url, spent_microusd=50, run_cost_microusd=100))
+
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode != 0
+    assert "ambiguous historical workflow spend" in up.stderr
+    assert asyncio.run(_account_spend(db_url)) == 50
+
+
+@needs_docker
+@pytest.mark.integration
+def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
+    postgres: object,
+) -> None:
+    db_url = _alembic_url(postgres)
+    up = _run_alembic(["upgrade", "0166"], db_url)
+    assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend(db_url, spent_microusd=0, run_cost_microusd=100))
+    asyncio.run(
+        _execute(
+            db_url,
+            "INSERT INTO wf_run_events (id, run_id, seq, type, call_key, payload) VALUES "
+            "('evt_started_0168', 'run_spend_0168', 1, 'call_started', 'call_0168', "
+            ' \'{"capability":"call_llm"}\'::jsonb), '
+            "('evt_result_0168', 'run_spend_0168', 2, 'call_result', 'call_0168', "
+            ' \'{"result":{"usage":{"input_tokens":"17"}}}\'::jsonb)',
+        )
+    )
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+
+    async def _usage_state() -> tuple[tuple[int, int, bool], int, object]:
+        conn = await asyncpg.connect(db_url)
+        try:
+            row = await conn.fetchrow(
+                "SELECT call_llm_input_tokens, call_llm_output_tokens, "
+                "call_llm_tokens_complete "
+                "FROM wf_runs WHERE id = 'run_spend_0168'"
+            )
+            assert row is not None
+            ledger_cost = await conn.fetchval(
+                "SELECT COALESCE(SUM(cost_microusd), 0) "
+                "FROM inference_usage_ledger WHERE run_id = 'run_spend_0168'"
+            )
+            coverage = await conn.fetchval(
+                "SELECT usage_ledger_started_at FROM accounts WHERE id = 'acc_spend_0168'"
+            )
+            return (
+                (
+                    int(row["call_llm_input_tokens"]),
+                    int(row["call_llm_output_tokens"]),
+                    bool(row["call_llm_tokens_complete"]),
+                ),
+                int(ledger_cost),
+                coverage,
+            )
+        finally:
+            await conn.close()
+
+    initial = asyncio.run(_usage_state())
+    assert initial[0] == (0, 0, False)
+    asyncio.run(
+        _execute(
+            db_url,
+            "UPDATE wf_runs SET call_llm_input_tokens = 17, "
+            "call_llm_output_tokens = 9 WHERE id = 'run_spend_0168'; "
+            "INSERT INTO inference_usage_ledger "
+            "(account_id, run_id, input_tokens, output_tokens, cost_microusd) "
+            "VALUES ('acc_spend_0168', 'run_spend_0168', 17, 9, 23)",
+        )
+    )
+    before_downgrade = asyncio.run(_usage_state())
+    assert before_downgrade[:2] == ((17, 9, False), 23)
+
+    down = _run_alembic(["downgrade", "0166"], db_url)
+    assert down.returncode == 0, f"downgrade to 0166 failed:\n{down.stderr}\n{down.stdout}"
+
+    async def _archived_state() -> tuple[tuple[int, int, bool], int, int]:
+        conn = await asyncpg.connect(db_url)
+        try:
+            row = await conn.fetchrow(
+                "SELECT call_llm_input_tokens, call_llm_output_tokens, "
+                "call_llm_tokens_complete FROM _aios_0168_wf_run_usage_archive "
+                "WHERE run_id = 'run_spend_0168'"
+            )
+            assert row is not None
+            ledger_cost = await conn.fetchval(
+                "SELECT SUM(cost_microusd) "
+                "FROM _aios_0168_inference_usage_ledger_archive "
+                "WHERE run_id = 'run_spend_0168'"
+            )
+            spend = await conn.fetchval(
+                "SELECT spent_microusd FROM accounts WHERE id = 'acc_spend_0168'"
+            )
+            return (
+                (
+                    int(row["call_llm_input_tokens"]),
+                    int(row["call_llm_output_tokens"]),
+                    bool(row["call_llm_tokens_complete"]),
+                ),
+                int(ledger_cost),
+                int(spend),
+            )
+        finally:
+            await conn.close()
+
+    assert asyncio.run(_archived_state()) == ((17, 9, False), 23, 100)
+
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode == 0, f"re-upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    restored = asyncio.run(_usage_state())
+    assert restored[:2] == ((17, 9, False), 23)
+    assert restored[2] == before_downgrade[2]
+    assert asyncio.run(_account_spend(db_url)) == 100

--- a/tests/integration/test_migrations_0168_creation_edge_usage.py
+++ b/tests/integration/test_migrations_0168_creation_edge_usage.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
+from typing import cast
 
 import asyncpg
 import pytest
@@ -74,8 +75,11 @@ async def _execute(db_url: str, sql: str) -> None:
 async def _creator(db_url: str, session_id: str) -> str | None:
     conn = await asyncpg.connect(db_url)
     try:
-        return await conn.fetchval(
-            "SELECT creator_session_id FROM sessions WHERE id = $1", session_id
+        return cast(
+            "str | None",
+            await conn.fetchval(
+                "SELECT creator_session_id FROM sessions WHERE id = $1", session_id
+            ),
         )
     finally:
         await conn.close()

--- a/tests/integration/test_migrations_0168_creation_edge_usage.py
+++ b/tests/integration/test_migrations_0168_creation_edge_usage.py
@@ -1,0 +1,99 @@
+"""Migration 0168 backfills only durable creation evidence.
+
+``archive_when_idle`` is a lifetime choice, not ownership provenance. A public
+API client can create a self-archiving root and another session can invoke it
+later. The resulting first ``request_opened`` event must not transfer the
+target's historical or future subtree spend to that caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+_SEED_SQL = r"""
+INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+VALUES ('acc_0168', NULL, TRUE, '0168 migration');
+INSERT INTO environments (id, name, account_id)
+VALUES ('env_0168', 'env-0168', 'acc_0168');
+INSERT INTO agents (id, name, model, account_id)
+VALUES ('agent_0168', 'agent-0168', 'test/model', 'acc_0168');
+
+INSERT INTO sessions (
+    id, agent_id, environment_id, workspace_volume_path, account_id,
+    archive_when_idle, last_event_seq, created_by_type, created_by_ref
+)
+VALUES
+    ('ses_caller_0168', 'agent_0168', 'env_0168', '/tmp/caller-0168', 'acc_0168',
+     FALSE, 0, 'api_actor', 'key_caller_0168'),
+    -- Public API creation: lifetime is ephemeral, ownership is still root.
+    ('ses_api_target_0168', 'agent_0168', 'env_0168', '/tmp/api-target-0168', 'acc_0168',
+     TRUE, 1, 'api_actor', 'key_target_0168'),
+    -- Explicit resource provenance is creation-specific and safe to recover.
+    ('ses_provenance_target_0168', 'agent_0168', 'env_0168',
+     '/tmp/provenance-target-0168', 'acc_0168', TRUE, 1,
+     'session_actor', 'ses_caller_0168');
+
+INSERT INTO events (id, session_id, seq, kind, data, account_id)
+VALUES
+    ('evt_api_later_0168', 'ses_api_target_0168', 1, 'lifecycle',
+     '{"event":"request_opened","request_id":"req_api_later_0168",'
+     '"caller":{"kind":"session","id":"ses_caller_0168","awaited":true}}'::jsonb,
+     'acc_0168'),
+    ('evt_provenance_0168', 'ses_provenance_target_0168', 1, 'lifecycle',
+     '{"event":"request_opened","request_id":"req_provenance_0168",'
+     '"caller":{"kind":"session","id":"ses_caller_0168","awaited":true}}'::jsonb,
+     'acc_0168');
+"""
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+async def _execute(db_url: str, sql: str) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(sql)
+    finally:
+        await conn.close()
+
+
+async def _creator(db_url: str, session_id: str) -> str | None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        return await conn.fetchval(
+            "SELECT creator_session_id FROM sessions WHERE id = $1", session_id
+        )
+    finally:
+        await conn.close()
+
+
+@needs_docker
+@pytest.mark.integration
+def test_backfill_does_not_infer_creation_from_archive_when_idle(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "0166"], db_url)
+    assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_execute(db_url, _SEED_SQL))
+
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+
+    # The invocation-only edge remains unowned even though the target opted
+    # into self-archival. Only explicit creation provenance is backfilled.
+    assert asyncio.run(_creator(db_url, "ses_api_target_0168")) is None
+    assert asyncio.run(_creator(db_url, "ses_provenance_target_0168")) == "ses_caller_0168"

--- a/tests/integration/test_migrations_0168_creation_edge_usage.py
+++ b/tests/integration/test_migrations_0168_creation_edge_usage.py
@@ -122,6 +122,37 @@ async def _account_spend(db_url: str) -> int:
         await conn.close()
 
 
+async def _seed_workflow_spend_watermark(db_url: str, accounted_microusd: int) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(
+            "INSERT INTO workflow_spend_accounting_watermarks "
+            "(account_id, accounted_run_cost_microusd) VALUES ($1, $2)",
+            "acc_spend_0168",
+            accounted_microusd,
+        )
+    finally:
+        await conn.close()
+
+
+async def _workflow_spend_watermark(db_url: str) -> tuple[int, int, int]:
+    conn = await asyncpg.connect(db_url)
+    try:
+        row = await conn.fetchrow(
+            "SELECT accounted_run_cost_microusd, last_observed_run_cost_microusd, "
+            "last_applied_delta_microusd FROM workflow_spend_accounting_watermarks "
+            "WHERE account_id = 'acc_spend_0168'"
+        )
+        assert row is not None
+        return (
+            int(row["accounted_run_cost_microusd"]),
+            int(row["last_observed_run_cost_microusd"]),
+            int(row["last_applied_delta_microusd"]),
+        )
+    finally:
+        await conn.close()
+
+
 @needs_docker
 @pytest.mark.integration
 def test_backfill_does_not_infer_creation_from_archive_when_idle(postgres: object) -> None:
@@ -142,9 +173,12 @@ def test_backfill_does_not_infer_creation_from_archive_when_idle(postgres: objec
 
 @needs_docker
 @pytest.mark.integration
-@pytest.mark.parametrize("already_repaired", [False, True])
+@pytest.mark.parametrize(
+    ("spent_microusd", "accounted_microusd"),
+    [(0, 0), (100, 100), (50, 50)],
+)
 def test_historical_workflow_spend_is_reconciled_exactly_once(
-    postgres: object, *, already_repaired: bool
+    postgres: object, *, spent_microusd: int, accounted_microusd: int
 ) -> None:
     db_url = _alembic_url(postgres)
     up = _run_alembic(["upgrade", "0166"], db_url)
@@ -152,14 +186,22 @@ def test_historical_workflow_spend_is_reconciled_exactly_once(
     asyncio.run(
         _seed_workflow_spend(
             db_url,
-            spent_microusd=100 if already_repaired else 0,
+            spent_microusd=spent_microusd,
             run_cost_microusd=100,
         )
     )
+    up = _run_alembic(["upgrade", "0167"], db_url)
+    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend_watermark(db_url, accounted_microusd))
 
     up = _run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     assert asyncio.run(_account_spend(db_url)) == 100
+    assert asyncio.run(_workflow_spend_watermark(db_url)) == (
+        100,
+        100,
+        100 - accounted_microusd,
+    )
 
     # A legacy writer knows only the run meter. The database trigger installed
     # at cutover still projects its post-migration delta exactly once.
@@ -171,6 +213,7 @@ def test_historical_workflow_spend_is_reconciled_exactly_once(
         )
     )
     assert asyncio.run(_account_spend(db_url)) == 140
+    assert asyncio.run(_workflow_spend_watermark(db_url)) == (140, 140, 40)
 
 
 @needs_docker
@@ -180,6 +223,9 @@ def test_old_writer_commit_across_migration_snapshot_is_not_lost(postgres: objec
     up = _run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=0, run_cost_microusd=100))
+    up = _run_alembic(["upgrade", "0167"], db_url)
+    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
 
     # Hold an old-writer update open. The migration must wait for that writer,
     # then reconcile the committed 140 total rather than its earlier 100 view.
@@ -195,20 +241,59 @@ def test_old_writer_commit_across_migration_snapshot_is_not_lost(postgres: objec
 
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     assert asyncio.run(_account_spend(db_url)) == 140
+    assert asyncio.run(_workflow_spend_watermark(db_url)) == (140, 140, 140)
 
 
 @needs_docker
 @pytest.mark.integration
-def test_ambiguous_partial_repair_fails_closed(postgres: object) -> None:
+def test_missing_workflow_spend_watermark_fails_closed(postgres: object) -> None:
     db_url = _alembic_url(postgres)
     up = _run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=50, run_cost_microusd=100))
+    up = _run_alembic(["upgrade", "0167"], db_url)
+    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
 
     up = _run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode != 0
-    assert "ambiguous historical workflow spend" in up.stderr
+    assert "missing workflow spend accounting watermark" in up.stderr
     assert asyncio.run(_account_spend(db_url)) == 50
+
+
+@needs_docker
+@pytest.mark.integration
+def test_workflow_spend_watermark_above_retained_cost_fails_closed(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+    up = _run_alembic(["upgrade", "0166"], db_url)
+    assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend(db_url, spent_microusd=101, run_cost_microusd=100))
+    up = _run_alembic(["upgrade", "0167"], db_url)
+    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend_watermark(db_url, 101))
+
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode != 0
+    assert "workflow spend accounting watermark exceeds retained run cost" in up.stderr
+    assert asyncio.run(_account_spend(db_url)) == 101
+
+
+@needs_docker
+@pytest.mark.integration
+def test_coincidental_aggregate_equality_does_not_fake_provenance(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+    up = _run_alembic(["upgrade", "0166"], db_url)
+    assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
+    # The existing 100 is unrelated spend. Its equality with the retained run
+    # meter proves nothing about whether that run was charged.
+    asyncio.run(_seed_workflow_spend(db_url, spent_microusd=100, run_cost_microusd=100))
+    up = _run_alembic(["upgrade", "0167"], db_url)
+    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
+
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    assert asyncio.run(_account_spend(db_url)) == 200
+    assert asyncio.run(_workflow_spend_watermark(db_url)) == (100, 100, 100)
 
 
 @needs_docker
@@ -230,6 +315,9 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
             ' \'{"result":{"usage":{"input_tokens":"17"}}}\'::jsonb)',
         )
     )
+    up = _run_alembic(["upgrade", "0167"], db_url)
+    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
     up = _run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
 
@@ -279,7 +367,7 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
     down = _run_alembic(["downgrade", "0166"], db_url)
     assert down.returncode == 0, f"downgrade to 0166 failed:\n{down.stderr}\n{down.stdout}"
 
-    async def _archived_state() -> tuple[tuple[int, int, bool], int, int]:
+    async def _archived_state() -> tuple[tuple[int, int, bool], int, int, int]:
         conn = await asyncpg.connect(db_url)
         try:
             row = await conn.fetchrow(
@@ -296,6 +384,11 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
             spend = await conn.fetchval(
                 "SELECT spent_microusd FROM accounts WHERE id = 'acc_spend_0168'"
             )
+            accounted = await conn.fetchval(
+                "SELECT accounted_run_cost_microusd "
+                "FROM _aios_0167_workflow_spend_watermarks_archive "
+                "WHERE account_id = 'acc_spend_0168'"
+            )
             return (
                 (
                     int(row["call_llm_input_tokens"]),
@@ -304,11 +397,12 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
                 ),
                 int(ledger_cost),
                 int(spend),
+                int(accounted),
             )
         finally:
             await conn.close()
 
-    assert asyncio.run(_archived_state()) == ((17, 9, False), 23, 100)
+    assert asyncio.run(_archived_state()) == ((17, 9, False), 23, 100, 100)
 
     up = _run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"re-upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
@@ -316,3 +410,4 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
     assert restored[:2] == ((17, 9, False), 23)
     assert restored[2] == before_downgrade[2]
     assert asyncio.run(_account_spend(db_url)) == 100
+    assert asyncio.run(_workflow_spend_watermark(db_url)) == (100, 100, 0)

--- a/tests/integration/test_migrations_0169_creation_edge_usage.py
+++ b/tests/integration/test_migrations_0169_creation_edge_usage.py
@@ -1,4 +1,4 @@
-"""Migration 0168 backfills only durable creation evidence.
+"""Migration 0169 backfills only durable creation evidence.
 
 ``archive_when_idle`` is a lifetime choice, not ownership provenance. A public
 API client can create a self-archiving root and another session can invoke it
@@ -22,37 +22,37 @@ from tests.integration.test_migrations import _alembic_url, _run_alembic
 
 _SEED_SQL = r"""
 INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
-VALUES ('acc_0168', NULL, TRUE, '0168 migration');
+VALUES ('acc_0169', NULL, TRUE, '0169 migration');
 INSERT INTO environments (id, name, account_id)
-VALUES ('env_0168', 'env-0168', 'acc_0168');
+VALUES ('env_0169', 'env-0169', 'acc_0169');
 INSERT INTO agents (id, name, model, account_id)
-VALUES ('agent_0168', 'agent-0168', 'test/model', 'acc_0168');
+VALUES ('agent_0169', 'agent-0169', 'test/model', 'acc_0169');
 
 INSERT INTO sessions (
     id, agent_id, environment_id, workspace_volume_path, account_id,
     archive_when_idle, last_event_seq, created_by_type, created_by_ref
 )
 VALUES
-    ('ses_caller_0168', 'agent_0168', 'env_0168', '/tmp/caller-0168', 'acc_0168',
-     FALSE, 0, 'api_actor', 'key_caller_0168'),
+    ('ses_caller_0169', 'agent_0169', 'env_0169', '/tmp/caller-0169', 'acc_0169',
+     FALSE, 0, 'api_actor', 'key_caller_0169'),
     -- Public API creation: lifetime is ephemeral, ownership is still root.
-    ('ses_api_target_0168', 'agent_0168', 'env_0168', '/tmp/api-target-0168', 'acc_0168',
-     TRUE, 1, 'api_actor', 'key_target_0168'),
+    ('ses_api_target_0169', 'agent_0169', 'env_0169', '/tmp/api-target-0169', 'acc_0169',
+     TRUE, 1, 'api_actor', 'key_target_0169'),
     -- Explicit resource provenance is creation-specific and safe to recover.
-    ('ses_provenance_target_0168', 'agent_0168', 'env_0168',
-     '/tmp/provenance-target-0168', 'acc_0168', TRUE, 1,
-     'session_actor', 'ses_caller_0168');
+    ('ses_provenance_target_0169', 'agent_0169', 'env_0169',
+     '/tmp/provenance-target-0169', 'acc_0169', TRUE, 1,
+     'session_actor', 'ses_caller_0169');
 
 INSERT INTO events (id, session_id, seq, kind, data, account_id)
 VALUES
-    ('evt_api_later_0168', 'ses_api_target_0168', 1, 'lifecycle',
-     '{"event":"request_opened","request_id":"req_api_later_0168",'
-     '"caller":{"kind":"session","id":"ses_caller_0168","awaited":true}}'::jsonb,
-     'acc_0168'),
-    ('evt_provenance_0168', 'ses_provenance_target_0168', 1, 'lifecycle',
-     '{"event":"request_opened","request_id":"req_provenance_0168",'
-     '"caller":{"kind":"session","id":"ses_caller_0168","awaited":true}}'::jsonb,
-     'acc_0168');
+    ('evt_api_later_0169', 'ses_api_target_0169', 1, 'lifecycle',
+     '{"event":"request_opened","request_id":"req_api_later_0169",'
+     '"caller":{"kind":"session","id":"ses_caller_0169","awaited":true}}'::jsonb,
+     'acc_0169'),
+    ('evt_provenance_0169', 'ses_provenance_target_0169', 1, 'lifecycle',
+     '{"event":"request_opened","request_id":"req_provenance_0169",'
+     '"caller":{"kind":"session","id":"ses_caller_0169","awaited":true}}'::jsonb,
+     'acc_0169');
 """
 
 
@@ -93,19 +93,19 @@ async def _seed_workflow_spend(db_url: str, *, spent_microusd: int, run_cost_mic
         await conn.execute(
             "INSERT INTO accounts "
             "(id, parent_account_id, can_mint_children, display_name, spent_microusd) "
-            "VALUES ('acc_spend_0168', NULL, TRUE, '0168 spend', $1)",
+            "VALUES ('acc_spend_0169', NULL, TRUE, '0169 spend', $1)",
             spent_microusd,
         )
         await conn.execute(
             "INSERT INTO environments (id, name, account_id) "
-            "VALUES ('env_spend_0168', 'env-spend-0168', 'acc_spend_0168')"
+            "VALUES ('env_spend_0169', 'env-spend-0169', 'acc_spend_0169')"
         )
         await conn.execute(
             "INSERT INTO wf_runs "
             "(id, workflow_id, account_id, environment_id, script, script_sha, "
             " host_semantics_epoch, call_llm_cost_microusd) "
-            "VALUES ('run_spend_0168', NULL, 'acc_spend_0168', 'env_spend_0168', "
-            " 'async def main(i): return i', 'sha-spend-0168', 0, $1)",
+            "VALUES ('run_spend_0169', NULL, 'acc_spend_0169', 'env_spend_0169', "
+            " 'async def main(i): return i', 'sha-spend-0169', 0, $1)",
             run_cost_microusd,
         )
     finally:
@@ -116,7 +116,7 @@ async def _account_spend(db_url: str) -> int:
     conn = await asyncpg.connect(db_url)
     try:
         return int(
-            await conn.fetchval("SELECT spent_microusd FROM accounts WHERE id = 'acc_spend_0168'")
+            await conn.fetchval("SELECT spent_microusd FROM accounts WHERE id = 'acc_spend_0169'")
         )
     finally:
         await conn.close()
@@ -128,7 +128,7 @@ async def _seed_workflow_spend_watermark(db_url: str, accounted_microusd: int) -
         await conn.execute(
             "INSERT INTO workflow_spend_accounting_watermarks "
             "(account_id, accounted_run_cost_microusd) VALUES ($1, $2)",
-            "acc_spend_0168",
+            "acc_spend_0169",
             accounted_microusd,
         )
     finally:
@@ -141,7 +141,7 @@ async def _workflow_spend_watermark(db_url: str) -> tuple[int, int, int]:
         row = await conn.fetchrow(
             "SELECT accounted_run_cost_microusd, last_observed_run_cost_microusd, "
             "last_applied_delta_microusd FROM workflow_spend_accounting_watermarks "
-            "WHERE account_id = 'acc_spend_0168'"
+            "WHERE account_id = 'acc_spend_0169'"
         )
         assert row is not None
         return (
@@ -162,13 +162,13 @@ def test_backfill_does_not_infer_creation_from_archive_when_idle(postgres: objec
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0168"], db_url)
-    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    up = _run_alembic(["upgrade", "0169"], db_url)
+    assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
 
     # The invocation-only edge remains unowned even though the target opted
     # into self-archival. Only explicit creation provenance is backfilled.
-    assert asyncio.run(_creator(db_url, "ses_api_target_0168")) is None
-    assert asyncio.run(_creator(db_url, "ses_provenance_target_0168")) == "ses_caller_0168"
+    assert asyncio.run(_creator(db_url, "ses_api_target_0169")) is None
+    assert asyncio.run(_creator(db_url, "ses_provenance_target_0169")) == "ses_caller_0169"
 
 
 @needs_docker
@@ -190,12 +190,12 @@ def test_historical_workflow_spend_is_reconciled_exactly_once(
             run_cost_microusd=100,
         )
     )
-    up = _run_alembic(["upgrade", "0167"], db_url)
-    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
-    asyncio.run(_seed_workflow_spend_watermark(db_url, accounted_microusd))
-
     up = _run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend_watermark(db_url, accounted_microusd))
+
+    up = _run_alembic(["upgrade", "0169"], db_url)
+    assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
     assert asyncio.run(_account_spend(db_url)) == 100
     assert asyncio.run(_workflow_spend_watermark(db_url)) == (
         100,
@@ -209,7 +209,7 @@ def test_historical_workflow_spend_is_reconciled_exactly_once(
         _execute(
             db_url,
             "UPDATE wf_runs SET call_llm_cost_microusd = "
-            "call_llm_cost_microusd + 40 WHERE id = 'run_spend_0168'",
+            "call_llm_cost_microusd + 40 WHERE id = 'run_spend_0169'",
         )
     )
     assert asyncio.run(_account_spend(db_url)) == 140
@@ -223,8 +223,8 @@ def test_old_writer_commit_across_migration_snapshot_is_not_lost(postgres: objec
     up = _run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=0, run_cost_microusd=100))
-    up = _run_alembic(["upgrade", "0167"], db_url)
-    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
 
     # Hold an old-writer update open. The migration must wait for that writer,
@@ -232,14 +232,14 @@ def test_old_writer_commit_across_migration_snapshot_is_not_lost(postgres: objec
     with psycopg.connect(db_url) as writer, ThreadPoolExecutor(max_workers=1) as executor:
         writer.execute(
             "UPDATE wf_runs SET call_llm_cost_microusd = "
-            "call_llm_cost_microusd + 40 WHERE id = 'run_spend_0168'"
+            "call_llm_cost_microusd + 40 WHERE id = 'run_spend_0169'"
         )
-        future = executor.submit(_run_alembic, ["upgrade", "0168"], db_url)
+        future = executor.submit(_run_alembic, ["upgrade", "0169"], db_url)
         assert not future.done()
         writer.commit()
         up = future.result(timeout=30)
 
-    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
     assert asyncio.run(_account_spend(db_url)) == 140
     assert asyncio.run(_workflow_spend_watermark(db_url)) == (140, 140, 140)
 
@@ -251,10 +251,10 @@ def test_missing_workflow_spend_watermark_fails_closed(postgres: object) -> None
     up = _run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=50, run_cost_microusd=100))
-    up = _run_alembic(["upgrade", "0167"], db_url)
-    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
-
     up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+
+    up = _run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode != 0
     assert "missing workflow spend accounting watermark" in up.stderr
     assert asyncio.run(_account_spend(db_url)) == 50
@@ -267,11 +267,11 @@ def test_workflow_spend_watermark_above_retained_cost_fails_closed(postgres: obj
     up = _run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=101, run_cost_microusd=100))
-    up = _run_alembic(["upgrade", "0167"], db_url)
-    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
+    up = _run_alembic(["upgrade", "0168"], db_url)
+    assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend_watermark(db_url, 101))
 
-    up = _run_alembic(["upgrade", "0168"], db_url)
+    up = _run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode != 0
     assert "workflow spend accounting watermark exceeds retained run cost" in up.stderr
     assert asyncio.run(_account_spend(db_url)) == 101
@@ -286,12 +286,12 @@ def test_coincidental_aggregate_equality_does_not_fake_provenance(postgres: obje
     # The existing 100 is unrelated spend. Its equality with the retained run
     # meter proves nothing about whether that run was charged.
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=100, run_cost_microusd=100))
-    up = _run_alembic(["upgrade", "0167"], db_url)
-    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
-    asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
-
     up = _run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
+
+    up = _run_alembic(["upgrade", "0169"], db_url)
+    assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
     assert asyncio.run(_account_spend(db_url)) == 200
     assert asyncio.run(_workflow_spend_watermark(db_url)) == (100, 100, 100)
 
@@ -309,17 +309,17 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
         _execute(
             db_url,
             "INSERT INTO wf_run_events (id, run_id, seq, type, call_key, payload) VALUES "
-            "('evt_started_0168', 'run_spend_0168', 1, 'call_started', 'call_0168', "
+            "('evt_started_0169', 'run_spend_0169', 1, 'call_started', 'call_0169', "
             ' \'{"capability":"call_llm"}\'::jsonb), '
-            "('evt_result_0168', 'run_spend_0168', 2, 'call_result', 'call_0168', "
+            "('evt_result_0169', 'run_spend_0169', 2, 'call_result', 'call_0169', "
             ' \'{"result":{"usage":{"input_tokens":"17"}}}\'::jsonb)',
         )
     )
-    up = _run_alembic(["upgrade", "0167"], db_url)
-    assert up.returncode == 0, f"upgrade to 0167 failed:\n{up.stderr}\n{up.stdout}"
-    asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
     up = _run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
+    up = _run_alembic(["upgrade", "0169"], db_url)
+    assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
 
     async def _usage_state() -> tuple[tuple[int, int, bool], int, object]:
         conn = await asyncpg.connect(db_url)
@@ -327,15 +327,15 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
             row = await conn.fetchrow(
                 "SELECT call_llm_input_tokens, call_llm_output_tokens, "
                 "call_llm_tokens_complete "
-                "FROM wf_runs WHERE id = 'run_spend_0168'"
+                "FROM wf_runs WHERE id = 'run_spend_0169'"
             )
             assert row is not None
             ledger_cost = await conn.fetchval(
                 "SELECT COALESCE(SUM(cost_microusd), 0) "
-                "FROM inference_usage_ledger WHERE run_id = 'run_spend_0168'"
+                "FROM inference_usage_ledger WHERE run_id = 'run_spend_0169'"
             )
             coverage = await conn.fetchval(
-                "SELECT usage_ledger_started_at FROM accounts WHERE id = 'acc_spend_0168'"
+                "SELECT usage_ledger_started_at FROM accounts WHERE id = 'acc_spend_0169'"
             )
             return (
                 (
@@ -355,10 +355,10 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
         _execute(
             db_url,
             "UPDATE wf_runs SET call_llm_input_tokens = 17, "
-            "call_llm_output_tokens = 9 WHERE id = 'run_spend_0168'; "
+            "call_llm_output_tokens = 9 WHERE id = 'run_spend_0169'; "
             "INSERT INTO inference_usage_ledger "
             "(account_id, run_id, input_tokens, output_tokens, cost_microusd) "
-            "VALUES ('acc_spend_0168', 'run_spend_0168', 17, 9, 23)",
+            "VALUES ('acc_spend_0169', 'run_spend_0169', 17, 9, 23)",
         )
     )
     before_downgrade = asyncio.run(_usage_state())
@@ -372,22 +372,22 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
         try:
             row = await conn.fetchrow(
                 "SELECT call_llm_input_tokens, call_llm_output_tokens, "
-                "call_llm_tokens_complete FROM _aios_0168_wf_run_usage_archive "
-                "WHERE run_id = 'run_spend_0168'"
+                "call_llm_tokens_complete FROM _aios_0169_wf_run_usage_archive "
+                "WHERE run_id = 'run_spend_0169'"
             )
             assert row is not None
             ledger_cost = await conn.fetchval(
                 "SELECT SUM(cost_microusd) "
-                "FROM _aios_0168_inference_usage_ledger_archive "
-                "WHERE run_id = 'run_spend_0168'"
+                "FROM _aios_0169_inference_usage_ledger_archive "
+                "WHERE run_id = 'run_spend_0169'"
             )
             spend = await conn.fetchval(
-                "SELECT spent_microusd FROM accounts WHERE id = 'acc_spend_0168'"
+                "SELECT spent_microusd FROM accounts WHERE id = 'acc_spend_0169'"
             )
             accounted = await conn.fetchval(
                 "SELECT accounted_run_cost_microusd "
-                "FROM _aios_0167_workflow_spend_watermarks_archive "
-                "WHERE account_id = 'acc_spend_0168'"
+                "FROM _aios_0168_workflow_spend_watermarks_archive "
+                "WHERE account_id = 'acc_spend_0169'"
             )
             return (
                 (
@@ -404,8 +404,8 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
 
     assert asyncio.run(_archived_state()) == ((17, 9, False), 23, 100, 100)
 
-    up = _run_alembic(["upgrade", "0168"], db_url)
-    assert up.returncode == 0, f"re-upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
+    up = _run_alembic(["upgrade", "0169"], db_url)
+    assert up.returncode == 0, f"re-upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
     restored = asyncio.run(_usage_state())
     assert restored[:2] == ((17, 9, False), 23)
     assert restored[2] == before_downgrade[2]

--- a/tests/unit/cli/test_cli_usage.py
+++ b/tests/unit/cli/test_cli_usage.py
@@ -1,0 +1,49 @@
+"""Tests for ``aios usage consumers``."""
+
+from __future__ import annotations
+
+import httpx
+from typer.testing import CliRunner
+
+from aios.cli.app import app
+from tests.unit.cli.conftest import MockedCli
+
+runner = CliRunner()
+
+
+def test_consumers_forwards_window_metric_and_limit(mocked_cli: MockedCli) -> None:
+    mocked_cli.queue_response(
+        httpx.Response(
+            200,
+            json={
+                "metric": "total_tokens",
+                "window_seconds": 3600,
+                "coverage_started_at": "2026-08-23T00:00:00Z",
+                "total_rate_per_hour": 0,
+                "items": [],
+            },
+        )
+    )
+    result = runner.invoke(
+        app,
+        [
+            "usage",
+            "consumers",
+            "--window-seconds",
+            "3600",
+            "--metric",
+            "total_tokens",
+            "--limit",
+            "7",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert mocked_cli.captured.method == "GET"
+    assert mocked_cli.captured.path == "/v1/usage/consumers"
+    assert mocked_cli.captured.query == {
+        "window_seconds": ["3600"],
+        "metric": ["total_tokens"],
+        "limit": ["7"],
+    }
+    assert '"metric": "total_tokens"' in result.output

--- a/tests/unit/test_check_migration_heads.py
+++ b/tests/unit/test_check_migration_heads.py
@@ -63,5 +63,5 @@ def test_known_good_repository_has_expected_revision_count_and_one_head() -> Non
     versions = Path(__file__).resolve().parents[2] / "migrations" / "versions"
     revisions = load_revisions(versions)
 
-    assert len(revisions) == 156
+    assert len(revisions) == 157
     assert check_history(revisions) in revisions

--- a/tests/unit/test_check_migration_heads.py
+++ b/tests/unit/test_check_migration_heads.py
@@ -63,5 +63,5 @@ def test_known_good_repository_has_expected_revision_count_and_one_head() -> Non
     versions = Path(__file__).resolve().parents[2] / "migrations" / "versions"
     revisions = load_revisions(versions)
 
-    assert len(revisions) == 155
+    assert len(revisions) == 156
     assert check_history(revisions) in revisions

--- a/tests/unit/test_list_sessions_lite.py
+++ b/tests/unit/test_list_sessions_lite.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aios.db.queries import sessions as session_queries
+from aios.models.accounting import AttributedUsage
 from aios.models.sessions import AwaitingToolCall, Session
 from aios.services import sessions as sessions_service
 
@@ -166,6 +167,9 @@ class TestListSessionsLiteSkipsFatHydration:
         async def awaiting(*_: Any, **__: Any) -> dict[str, list[Any]]:
             return {}
 
+        async def usage(*_: Any, **__: Any) -> dict[tuple[str, str], AttributedUsage]:
+            return {("session", "sess_1"): AttributedUsage()}
+
         with (
             patch("aios.services.sessions.queries.list_sessions", list_rows),
             patch("aios.services.sessions.queries.batch_get_session_vault_ids", vaults),
@@ -173,6 +177,7 @@ class TestListSessionsLiteSkipsFatHydration:
             patch("aios.services.sessions.queries.batch_list_session_triggers", triggers),
             patch("aios.services.sessions.compute_awaiting", awaiting),
             patch("aios.services.sessions.compute_obligations", obligations),
+            patch("aios.services.sessions.accounting_queries.usage_for_nodes", usage),
         ):
             out = await sessions_service.list_sessions(
                 _Pool(),


### PR DESCRIPTION
Closes #2151.

## What changed

- Adds one immutable, account-scoped creation parent to sessions and workflow runs. Invocation edges such as later `call_session` calls do not transfer ownership.
- Treats sessions and runs as one recursive accounting graph, with cycle-safe/deduplicated traversal across arbitrary session → run → session chains.
- Exposes `usage.own`, `usage.subtree`, `usage.own_rate`, `usage.subtree_rate`, and `usage_parent` on public session and workflow-run reads.
- Includes active, archived, errored, cancelled, and otherwise terminated descendants. A finished ancestor's subtree continues to grow while an owned descendant spends.
- Adds `GET /v1/usage/consumers`, a single account-scoped call that ranks additive root consumers by rolling subtree cost or token rate and reports pool share.
- Adds `aios usage consumers` with the same window, metric, and limit controls for incident response.
- Regenerates the OpenAPI document and Python SDK.

## Workflow inference accounting repair

Raw workflow `call_llm` inference previously updated only `wf_runs.call_llm_cost_microusd`, so canonical account usage and spend admission could report zero. This change:

- repairs `accounts.spent_microusd` from existing run meters during migration;
- atomically dual-writes future raw workflow charges to run and account meters;
- adds run-level raw token counters and backfills recoverable historical values from durable `call_llm` journal results;
- records session and run deltas in an append-only ledger for rolling rates.

Rate responses explicitly report `observed_seconds` and `complete=false` until the new ledger covers the full requested window; pre-ledger history is not presented as measured rate data.

## Acceptance coverage

The issue-focused tests prove:

- a known agent → workflow → agent chain equals the hand-computed sum of all three nodes' own usage;
- archived/terminated descendants remain included;
- adding known descendant spend moves the root by the exact delta;
- post-deadline/late descendant charges keep accruing to the immutable creator;
- invoking an existing peer moves no cost to the caller;
- malformed mixed-node cycles terminate and count each node once;
- one ranked API request places a deliberately hot consumer first.

## Verification

- `130 passed` across accounting, account API, workflow runtime/recovery, clone policy, OpenAPI, and SDK suites
- `33 passed` across pooled-connection lint, migration-head, CLI coverage, and CLI command suites
- `ruff check .`
- `ruff format --check .`
- `mypy src tests` — 997 source files
- migration history check — one head (`0168`)
- local Jarbot migration/API/UI smoke test: account usage repaired from `$0` to `$2.948976`; the UI renders `$2.95`
