### PR TITLE
Sanitize MCP tools for Anthropic: 64-char names, strip outputSchema

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -45,6 +45,7 @@ from aios.harness.request_body_budget import (
     is_request_too_large_error,
 )
 from aios.logging import get_logger
+from aios.mcp.schema import sanitize_tools_for_provider
 from aios.models.attenuation import api_base_of
 from aios.models.model_providers import ProviderAuth
 from aios.services.litellm_params import openai_params_in, silent_drop_controls_in
@@ -685,7 +686,7 @@ def _build_litellm_kwargs(
         # and drops it for adapters which do not.
         kwargs["stream_options"] = {"include_usage": True}
     if tools:
-        kwargs["tools"] = tools
+        kwargs["tools"] = sanitize_tools_for_provider(tools)
     effective_extra = dict(extra or {})
     # Never permit LiteLLM's silent unsupported-parameter path, even when an
     # agent explicitly requests it through ``litellm_extra``.

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -2386,6 +2386,7 @@ async def _latch_errored_turn(
         ERRORED_LIFECYCLE_STATUS,
         ERRORED_LIFECYCLE_STOP_REASON,
         account_id=account_id,
+        message=stop_message,
     )
 
 
@@ -2711,12 +2712,16 @@ async def _append_lifecycle(
     stop_reason: str,
     *,
     account_id: str,
+    message: str | None = None,
 ) -> None:
     """Append a lifecycle event."""
+    data: dict[str, Any] = {"event": event, "status": status, "stop_reason": stop_reason}
+    if message is not None:
+        data["message"] = message
     await sessions_service.append_event(
         pool,
         session_id,
         "lifecycle",
-        {"event": event, "status": status, "stop_reason": stop_reason},
+        data,
         account_id=account_id,
     )

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -42,6 +42,7 @@ import asyncpg
 from aios.errors import AiosError, NotFoundError
 from aios.harness import runtime
 from aios.logging import get_logger
+from aios.mcp.schema import mcp_origin_for
 from aios.models.agents import McpServerSpec
 from aios.services import sessions as sessions_service
 from aios.tools.invoke import ToolBail, invoke_builtin, parse_arguments, prepare_builtin
@@ -1106,7 +1107,8 @@ async def _execute_mcp_tool_admitted(
         raise ToolBail("arguments were not valid JSON")
 
     try:
-        server_name, tool_name = _parse_mcp_tool_name(tc.name)
+        origin = mcp_origin_for(tc.name, mcp_tools)
+        server_name, tool_name = origin if origin is not None else _parse_mcp_tool_name(tc.name)
     except ValueError as err:
         raise ToolBail(str(err)) from err
 

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -38,7 +38,7 @@ from aios.db import queries
 from aios.logging import get_logger
 from aios.mcp._constants import _MCP_HTTPX_TIMEOUT as _MCP_HTTPX_TIMEOUT_SHARED
 from aios.mcp.pool import HttpErrorSink
-from aios.mcp.schema import make_function_tool
+from aios.mcp.schema import make_function_tool, qualify_mcp_tool_name
 from aios.models.vaults import AuthType
 from aios.pinned_transport import PinnedTransport
 from aios.services.vaults import is_expiring, refresh_credential
@@ -580,10 +580,15 @@ async def discover_mcp_tools(
             limit=MAX_TOOLS_PER_SERVER,
         )
 
-    tools: list[dict[str, Any]] = [
-        make_function_tool(f"mcp__{server_name}__{tool.name}", tool)
-        for tool in result.tools[:MAX_TOOLS_PER_SERVER]
-    ]
+    tools: list[dict[str, Any]] = []
+    for tool in result.tools[:MAX_TOOLS_PER_SERVER]:
+        advertised, origin_server, origin_tool = qualify_mcp_tool_name(server_name, tool.name)
+        origin = (
+            {"origin_server": origin_server, "origin_tool": origin_tool}
+            if advertised != f"mcp__{server_name}__{tool.name}"
+            else {}
+        )
+        tools.append(make_function_tool(advertised, tool, **origin))
     if _pool is not None and binding_id is not None:
         # Cache the freshly-discovered result so the next step (same binding
         # identity, no list_changed) serves it without a list_tools() RPC (#1391).

--- a/src/aios/mcp/schema.py
+++ b/src/aios/mcp/schema.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
+import copy
+import hashlib
+import re
 from typing import Any
 
 from mcp.types import Tool
+
+# Anthropic (and OpenAI) function-tool names: ``^[a-zA-Z0-9_-]{1,64}$``.
+# MCP SEP-986 is more permissive (``.`` / ``/``) and does not enforce 64; the
+# provider 400s. Qualified names are ``mcp__<server>__<tool>``.
+PROVIDER_TOOL_NAME_MAX = 64
+_PROVIDER_TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+_UNSAFE_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]+")
+
+# Envelope key (sibling of ``function``, never inside it) mapping an advertised
+# name back to the MCP server + raw tool. Stripped before the provider call.
+MCP_ORIGIN_KEY = "_mcp_origin"
 
 
 def sanitize_mcp_schema(node: Any) -> Any:
@@ -31,13 +45,51 @@ def sanitize_mcp_schema(node: Any) -> Any:
     return node
 
 
-def make_function_tool(qualified_name: str, tool: Tool) -> dict[str, Any]:
+def _sanitize_name_segment(raw: str) -> str:
+    cleaned = _UNSAFE_NAME_CHARS.sub("_", raw).strip("_")
+    return cleaned or "x"
+
+
+def qualify_mcp_tool_name(server_name: str, tool_name: str) -> tuple[str, str, str]:
+    """Fit ``mcp__<server>__<tool>`` to the provider name regex.
+
+    Returns ``(advertised, origin_server, origin_tool)``. Dispatch must call the
+    origin tool on the origin server; the advertised name is what the model sees.
+    """
+    server = _sanitize_name_segment(server_name)
+    tool = _sanitize_name_segment(tool_name)
+    advertised = f"mcp__{server}__{tool}"
+    if len(advertised) <= PROVIDER_TOOL_NAME_MAX and _PROVIDER_TOOL_NAME_RE.match(advertised):
+        return advertised, server_name, tool_name
+    digest = hashlib.sha1(f"{server_name}\0{tool_name}".encode()).hexdigest()
+    prefix = f"mcp__{server}__"
+    # ``<truncated>_<hash6>`` must fit after the prefix.
+    room = PROVIDER_TOOL_NAME_MAX - len(prefix) - 7
+    if room >= 1:
+        fitted = f"{prefix}{tool[:room]}_{digest[:6]}"
+        return fitted, server_name, tool_name
+    # Server segment itself leaves no room for a tool — hash the server too.
+    server_h = hashlib.sha1(server_name.encode()).hexdigest()[:8]
+    prefix = f"mcp__{server_h}__"
+    room = max(PROVIDER_TOOL_NAME_MAX - len(prefix) - 7, 1)
+    fitted = f"{prefix}{tool[:room]}_{digest[:6]}"
+    return fitted[:PROVIDER_TOOL_NAME_MAX], server_name, tool_name
+
+
+def make_function_tool(
+    qualified_name: str,
+    tool: Tool,
+    *,
+    origin_server: str | None = None,
+    origin_tool: str | None = None,
+) -> dict[str, Any]:
     """Build the envelope, applying :func:`sanitize_mcp_schema` to ``tool.inputSchema``.
 
     When the tool declares an ``outputSchema`` (MCP 2025-06-18 structured
-    output), propagate it so the model is told the tool produces structured
-    output. Without this the model only ever sees ``inputSchema`` and is blind
-    to the structured payload it will receive (#1493).
+    output), keep it on the *internal* envelope so result-shaping and tests
+    can see it (#1493). :func:`sanitize_tools_for_provider` strips it before
+    the LiteLLM call — Anthropic rejects the unknown field with a 400
+    (``drop_params`` is forced off, so LiteLLM will not silently drop it).
     """
     function: dict[str, Any] = {
         "name": qualified_name,
@@ -51,7 +103,63 @@ def make_function_tool(qualified_name: str, tool: Tool) -> dict[str, Any]:
     output_schema = getattr(tool, "outputSchema", None)
     if output_schema is not None:
         function["outputSchema"] = sanitize_mcp_schema(output_schema)
-    return {
+    envelope: dict[str, Any] = {
         "type": "function",
         "function": function,
     }
+    if origin_server and origin_tool:
+        envelope[MCP_ORIGIN_KEY] = {"server": origin_server, "tool": origin_tool}
+    return envelope
+
+
+def _tool_needs_provider_sanitize(tool: dict[str, Any]) -> bool:
+    if MCP_ORIGIN_KEY in tool:
+        return True
+    function = tool.get("function")
+    if not isinstance(function, dict):
+        return False
+    if "outputSchema" in function:
+        return True
+    name = function.get("name")
+    return isinstance(name, str) and _PROVIDER_TOOL_NAME_RE.match(name) is None
+
+
+def sanitize_tools_for_provider(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Copy-on-write: drop fields / names Anthropic (and OpenAI) 400 on.
+
+    Returns the input list object when nothing needs changing so existing
+    identity assertions on a clean toolset keep holding.
+    """
+    if not any(_tool_needs_provider_sanitize(tool) for tool in tools):
+        return tools
+    cleaned: list[dict[str, Any]] = []
+    for tool in tools:
+        item = copy.deepcopy(tool)
+        item.pop(MCP_ORIGIN_KEY, None)
+        function = item.get("function")
+        if isinstance(function, dict):
+            function.pop("outputSchema", None)
+            name = function.get("name")
+            if isinstance(name, str) and _PROVIDER_TOOL_NAME_RE.match(name) is None:
+                function["name"] = _sanitize_name_segment(name)[:PROVIDER_TOOL_NAME_MAX]
+        cleaned.append(item)
+    return cleaned
+
+
+def mcp_origin_for(
+    qualified_name: str, tools: list[dict[str, Any]] | None
+) -> tuple[str, str] | None:
+    """Look up the raw ``(server, tool)`` for an advertised name, if stored."""
+    for tool in tools or []:
+        function = tool.get("function") or {}
+        if function.get("name") != qualified_name:
+            continue
+        origin = tool.get(MCP_ORIGIN_KEY)
+        if not isinstance(origin, dict):
+            return None
+        server = origin.get("server")
+        name = origin.get("tool")
+        if isinstance(server, str) and server and isinstance(name, str) and name:
+            return server, name
+        return None
+    return None

--- a/tests/unit/test_mcp_provider_tool_names.py
+++ b/tests/unit/test_mcp_provider_tool_names.py
@@ -1,0 +1,123 @@
+"""Provider-facing MCP tool names and envelope sanitization."""
+
+from __future__ import annotations
+
+import re
+
+from mcp.types import Tool
+
+from aios.harness.completion import _build_litellm_kwargs
+from aios.mcp.schema import (
+    PROVIDER_TOOL_NAME_MAX,
+    make_function_tool,
+    mcp_origin_for,
+    qualify_mcp_tool_name,
+    sanitize_tools_for_provider,
+)
+
+_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+class TestQualifyMcpToolName:
+    def test_short_legal_name_is_unchanged(self) -> None:
+        advertised, server, tool = qualify_mcp_tool_name("x", "search_posts")
+        assert advertised == "mcp__x__search_posts"
+        assert (server, tool) == ("x", "search_posts")
+        assert len(advertised) <= PROVIDER_TOOL_NAME_MAX
+
+    def test_dots_and_slashes_become_underscores(self) -> None:
+        advertised, server, tool = qualify_mcp_tool_name("api.x.com", "users/lookup")
+        assert advertised == "mcp__api_x_com__users_lookup"
+        assert (server, tool) == ("api.x.com", "users/lookup")
+
+    def test_long_custom_server_plus_tool_fits_64(self) -> None:
+        server = "custom_api_x_com_QFZ6ZWJR"
+        tool = "get_user_bookmark_folder_items_by_id"
+        advertised, origin_server, origin_tool = qualify_mcp_tool_name(server, tool)
+        assert len(advertised) <= PROVIDER_TOOL_NAME_MAX
+        assert _NAME_RE.match(advertised)
+        assert (origin_server, origin_tool) == (server, tool)
+        assert len(f"mcp__{server}__{tool}") > PROVIDER_TOOL_NAME_MAX
+
+    def test_huge_server_name_still_fits(self) -> None:
+        server = "s" * 80
+        advertised, origin_server, origin_tool = qualify_mcp_tool_name(server, "t")
+        assert len(advertised) <= PROVIDER_TOOL_NAME_MAX
+        assert _NAME_RE.match(advertised)
+        assert (origin_server, origin_tool) == (server, "t")
+
+
+class TestSanitizeToolsForProvider:
+    def test_clean_list_is_same_object(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp__x__search",
+                    "description": "",
+                    "parameters": {"type": "object"},
+                    "strict": False,
+                },
+            }
+        ]
+        assert sanitize_tools_for_provider(tools) is tools
+
+    def test_strips_output_schema_and_origin(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp__x__search",
+                    "description": "",
+                    "parameters": {"type": "object"},
+                    "strict": False,
+                    "outputSchema": {"type": "object", "properties": {"n": {"type": "number"}}},
+                },
+                "_mcp_origin": {"server": "x", "tool": "search"},
+            }
+        ]
+        cleaned = sanitize_tools_for_provider(tools)
+        assert cleaned is not tools
+        assert "outputSchema" not in cleaned[0]["function"]
+        assert "_mcp_origin" not in cleaned[0]
+        assert cleaned[0]["function"]["name"] == "mcp__x__search"
+        assert "outputSchema" in tools[0]["function"]
+        assert tools[0]["_mcp_origin"]["tool"] == "search"
+
+    def test_origin_lookup(self) -> None:
+        advertised, server, tool = qualify_mcp_tool_name(
+            "custom_api_x_com_QFZ6ZWJR", "get_user_bookmark_folder_items_by_id"
+        )
+        env = make_function_tool(
+            advertised,
+            Tool(name=tool, description="", inputSchema={"type": "object"}),
+            origin_server=server,
+            origin_tool=tool,
+        )
+        assert mcp_origin_for(advertised, [env]) == (server, tool)
+        assert mcp_origin_for("mcp__other__x", [env]) is None
+
+    def test_build_kwargs_strips_output_schema(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp__x__search",
+                    "description": "",
+                    "parameters": {"type": "object"},
+                    "strict": False,
+                    "outputSchema": {"type": "object"},
+                },
+            }
+        ]
+        kwargs = _build_litellm_kwargs(
+            model="anthropic/claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+            auth=None,
+            extra=None,
+            session_id=None,
+            stream=False,
+        )
+        assert "outputSchema" not in kwargs["tools"][0]["function"]
+        assert "outputSchema" in tools[0]["function"]

--- a/tests/unit/test_mcp_provider_tool_names.py
+++ b/tests/unit/test_mcp_provider_tool_names.py
@@ -82,7 +82,7 @@ class TestSanitizeToolsForProvider:
         assert "_mcp_origin" not in cleaned[0]
         assert cleaned[0]["function"]["name"] == "mcp__x__search"
         assert "outputSchema" in tools[0]["function"]
-        assert tools[0]["_mcp_origin"]["tool"] == "search"
+        assert tools[0]["_mcp_origin"] == {"server": "x", "tool": "search"}
 
     def test_origin_lookup(self) -> None:
         advertised, server, tool = qualify_mcp_tool_name(


### PR DESCRIPTION
## Summary
- Hosted MCP servers (X at `https://api.x.com/mcp`, protocol 2025-06-18) advertise `outputSchema` and names that, after `mcp__<server>__<tool>` qualification, overflow Anthropic's `^[a-zA-Z0-9_-]{1,64}$` cap. With `drop_params` forced off, LiteLLM forwards both and Claude 400s every completion (`step.model_terminal_error` → `_latch_errored_turn`).
- Discovery now fits advertised names to the provider regex (illegal chars → `_`, overflow → truncated + hash) and stores `_mcp_origin` so dispatch still calls the raw server/tool.
- `_build_litellm_kwargs` copy-on-write strips `outputSchema` and `_mcp_origin` before the wire. Clean tool lists stay the same object (passthrough identity).
- Errored `turn_ended` lifecycle events now carry the stop_reason `message` so clients (jarbot) can render it.

## Test plan
- [x] `pytest tests/unit/test_mcp_provider_tool_names.py tests/unit/test_mcp_schema_sanitize.py tests/unit/test_completion_tool_schema_passthrough.py tests/unit/test_errored_lifecycle_coupling.py`