### PR TITLE
Uniquify advertised MCP tool names so a double-mount cannot 400 Anthropic

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -2109,7 +2109,9 @@ async def discover_session_mcp_tools(
                     },
                     account_id=account_id,
                 )
-    return tools, instructions_by_server
+    from aios.mcp.schema import uniquify_advertised_tool_names
+
+    return uniquify_advertised_tool_names(tools), instructions_by_server
 
 
 async def _dispatch_confirmed_tools(

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -583,12 +583,11 @@ async def discover_mcp_tools(
     tools: list[dict[str, Any]] = []
     for tool in result.tools[:MAX_TOOLS_PER_SERVER]:
         advertised, origin_server, origin_tool = qualify_mcp_tool_name(server_name, tool.name)
-        origin = (
-            {"origin_server": origin_server, "origin_tool": origin_tool}
-            if advertised != f"mcp__{server_name}__{tool.name}"
-            else {}
+        tools.append(
+            make_function_tool(
+                advertised, tool, origin_server=origin_server, origin_tool=origin_tool
+            )
         )
-        tools.append(make_function_tool(advertised, tool, **origin))
     if _pool is not None and binding_id is not None:
         # Cache the freshly-discovered result so the next step (same binding
         # identity, no list_changed) serves it without a list_tools() RPC (#1391).

--- a/src/aios/mcp/schema.py
+++ b/src/aios/mcp/schema.py
@@ -112,6 +112,99 @@ def make_function_tool(
     return envelope
 
 
+def _function_name(tool: dict[str, Any]) -> str | None:
+    function = tool.get("function")
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    return name if isinstance(name, str) else None
+
+
+def _advertised_names_are_unique(tools: list[dict[str, Any]]) -> bool:
+    seen: set[str] = set()
+    for tool in tools:
+        name = _function_name(tool)
+        if name is None:
+            continue
+        if name in seen:
+            return False
+        seen.add(name)
+    return True
+
+
+def _origin_pair(tool: dict[str, Any]) -> tuple[str, str] | None:
+    origin = tool.get(MCP_ORIGIN_KEY)
+    if not isinstance(origin, dict):
+        return None
+    server = origin.get("server")
+    name = origin.get("tool")
+    if isinstance(server, str) and server and isinstance(name, str) and name:
+        return server, name
+    return None
+
+
+def _fit_name_with_suffix(base: str, tag: str) -> str:
+    tag = _sanitize_name_segment(tag)
+    suffix = f"_{tag}"
+    room = PROVIDER_TOOL_NAME_MAX - len(suffix)
+    if room < 1:
+        tag = hashlib.sha1(tag.encode()).hexdigest()[:6]
+        suffix = f"_{tag}"
+        room = PROVIDER_TOOL_NAME_MAX - len(suffix)
+    stem = base[:room].rstrip("_") or "mcp"
+    return f"{stem}{suffix}"[:PROVIDER_TOOL_NAME_MAX]
+
+
+def _disambiguate_advertised_name(base: str, server: str, used: set[str], *, salt: int) -> str:
+    """Fold a short server-derived suffix (then hash) into ``base`` until unique."""
+    server_seg = _sanitize_name_segment(server)
+    digest = hashlib.sha1(f"{server}\0{base}\0{salt}".encode()).hexdigest()
+    tags: list[str] = []
+    for raw in (server_seg[-8:], digest[:6], digest[:8], f"{digest[:4]}{salt}"):
+        tag = _sanitize_name_segment(raw)
+        if tag and tag not in tags:
+            tags.append(tag)
+    for tag in tags:
+        candidate = _fit_name_with_suffix(base, tag)
+        if candidate not in used and _PROVIDER_TOOL_NAME_RE.match(candidate):
+            return candidate
+    raise RuntimeError(f"could not uniquify tool name {base!r}")
+
+
+def uniquify_advertised_tool_names(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep the first advertised ``function.name``; rewrite later collisions.
+
+    Copy-on-write: returns the input list when names are already unique.
+    Rewritten envelopes keep/gain ``_mcp_origin`` so dispatch can map the
+    new advertised name back to the raw server + tool.
+    """
+    if _advertised_names_are_unique(tools):
+        return tools
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for index, tool in enumerate(tools):
+        name = _function_name(tool)
+        if name is None or name not in seen:
+            if name is not None:
+                seen.add(name)
+            out.append(tool)
+            continue
+        item = copy.deepcopy(tool)
+        function = item.get("function")
+        if not isinstance(function, dict):
+            out.append(item)
+            continue
+        origin = _origin_pair(item)
+        server = origin[0] if origin else f"s{index}"
+        new_name = _disambiguate_advertised_name(name, server, seen, salt=index)
+        function["name"] = new_name
+        if origin:
+            item[MCP_ORIGIN_KEY] = {"server": origin[0], "tool": origin[1]}
+        seen.add(new_name)
+        out.append(item)
+    return out
+
+
 def _tool_needs_provider_sanitize(tool: dict[str, Any]) -> bool:
     if MCP_ORIGIN_KEY in tool:
         return True
@@ -128,22 +221,25 @@ def sanitize_tools_for_provider(tools: list[dict[str, Any]]) -> list[dict[str, A
     """Copy-on-write: drop fields / names Anthropic (and OpenAI) 400 on.
 
     Returns the input list object when nothing needs changing so existing
-    identity assertions on a clean toolset keep holding.
+    identity assertions on a clean toolset keep holding. Advertised
+    ``function.name`` values on the returned list are unique.
     """
-    if not any(_tool_needs_provider_sanitize(tool) for tool in tools):
+    needs_copy = any(_tool_needs_provider_sanitize(tool) for tool in tools)
+    if not needs_copy and _advertised_names_are_unique(tools):
         return tools
     cleaned: list[dict[str, Any]] = []
     for tool in tools:
-        item = copy.deepcopy(tool)
-        item.pop(MCP_ORIGIN_KEY, None)
-        function = item.get("function")
-        if isinstance(function, dict):
-            function.pop("outputSchema", None)
-            name = function.get("name")
-            if isinstance(name, str) and _PROVIDER_TOOL_NAME_RE.match(name) is None:
-                function["name"] = _sanitize_name_segment(name)[:PROVIDER_TOOL_NAME_MAX]
+        item = copy.deepcopy(tool) if needs_copy else tool
+        if needs_copy:
+            item.pop(MCP_ORIGIN_KEY, None)
+            function = item.get("function")
+            if isinstance(function, dict):
+                function.pop("outputSchema", None)
+                name = function.get("name")
+                if isinstance(name, str) and _PROVIDER_TOOL_NAME_RE.match(name) is None:
+                    function["name"] = _sanitize_name_segment(name)[:PROVIDER_TOOL_NAME_MAX]
         cleaned.append(item)
-    return cleaned
+    return uniquify_advertised_tool_names(cleaned)
 
 
 def mcp_origin_for(

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -496,3 +496,62 @@ class TestDiscoverSessionMcpTools:
         assert ev["is_error"] is False
         # Deduped: the edge queue is drained, so a re-run emits nothing.
         assert pool.drain_degraded_events() == []
+
+    async def test_colliding_server_tool_names_are_uniquified(self) -> None:
+        """Two servers advertising the same function.name stay dispatchable."""
+        from aios.harness.loop import discover_session_mcp_tools
+        from aios.mcp.schema import mcp_origin_for
+
+        agent = _agent(
+            mcp_servers=[
+                McpServerSpec(name="x", url="https://api.x.com/mcp"),
+                McpServerSpec(name="custom_api_x_com_QFZ6ZWJR", url="https://api.x.com/mcp"),
+            ],
+            tools=[
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="x"),
+                ToolSpec(
+                    type="mcp_toolset",
+                    enabled=True,
+                    mcp_server_name="custom_api_x_com_QFZ6ZWJR",
+                ),
+            ],
+        )
+
+        def _envelope(server: str) -> dict[str, Any]:
+            return {
+                "type": "function",
+                "function": {
+                    "name": "mcp__x__search_posts",
+                    "description": "",
+                    "parameters": {"type": "object"},
+                    "strict": False,
+                },
+                "_mcp_origin": {"server": server, "tool": "search_posts"},
+            }
+
+        async def _discover(
+            _url: str,
+            _vault_id: str | None,
+            _headers: dict[str, str],
+            name: str,
+            **_kwargs: Any,
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            return [_envelope(name)], None
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_target_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = (None, {})
+            tools, _instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                account_id="acc_test_stub",
+            )
+
+        names = [item["function"]["name"] for item in tools]
+        assert names[0] == "mcp__x__search_posts"
+        assert names[1] != names[0]
+        assert mcp_origin_for(names[0], tools) == ("x", "search_posts")
+        assert mcp_origin_for(names[1], tools) == ("custom_api_x_com_QFZ6ZWJR", "search_posts")

--- a/tests/unit/test_mcp_provider_tool_names.py
+++ b/tests/unit/test_mcp_provider_tool_names.py
@@ -13,6 +13,7 @@ from aios.mcp.schema import (
     mcp_origin_for,
     qualify_mcp_tool_name,
     sanitize_tools_for_provider,
+    uniquify_advertised_tool_names,
 )
 
 _NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
@@ -121,3 +122,122 @@ class TestSanitizeToolsForProvider:
         )
         assert "outputSchema" not in kwargs["tools"][0]["function"]
         assert "outputSchema" in tools[0]["function"]
+
+
+def _fn_envelope(name: str, *, server: str, tool: str) -> dict:
+    return make_function_tool(
+        name,
+        Tool(name=tool, description="", inputSchema={"type": "object"}),
+        origin_server=server,
+        origin_tool=tool,
+    )
+
+
+class TestUniquifyAdvertisedToolNames:
+    def test_already_unique_list_is_same_object(self) -> None:
+        t = Tool(name="search_posts", description="", inputSchema={"type": "object"})
+        catalog, s1, t1 = qualify_mcp_tool_name("x", "search_posts")
+        custom, s2, t2 = qualify_mcp_tool_name("custom_api_x_com_QFZ6ZWJR", "search_posts")
+        tools = [
+            make_function_tool(catalog, t, origin_server=s1, origin_tool=t1),
+            make_function_tool(custom, t, origin_server=s2, origin_tool=t2),
+        ]
+        assert catalog != custom
+        assert uniquify_advertised_tool_names(tools) is tools
+
+    def test_catalog_x_and_leftover_custom_collision(self) -> None:
+        """Production mute: both mounts advertised the same name after sanitize."""
+        collided = "mcp__x__search_posts"
+        tools = [
+            _fn_envelope(collided, server="x", tool="search_posts"),
+            _fn_envelope(collided, server="custom_api_x_com_QFZ6ZWJR", tool="search_posts"),
+        ]
+        out = uniquify_advertised_tool_names(tools)
+        names = [item["function"]["name"] for item in out]
+        assert names[0] == collided
+        assert names[1] != names[0]
+        assert len(names) == len(set(names))
+        assert all(_NAME_RE.match(name) and len(name) <= PROVIDER_TOOL_NAME_MAX for name in names)
+        assert mcp_origin_for(names[0], out) == ("x", "search_posts")
+        assert mcp_origin_for(names[1], out) == ("custom_api_x_com_QFZ6ZWJR", "search_posts")
+        cleaned = sanitize_tools_for_provider(out)
+        assert [item["function"]["name"] for item in cleaned] == names
+
+    def test_sanitized_server_segments_that_qualify_identically(self) -> None:
+        t = Tool(name="search_posts", description="", inputSchema={"type": "object"})
+        a, s1, t1 = qualify_mcp_tool_name("api.x.com", "search_posts")
+        b, s2, t2 = qualify_mcp_tool_name("api_x_com", "search_posts")
+        assert a == b == "mcp__api_x_com__search_posts"
+        tools = [
+            make_function_tool(a, t, origin_server=s1, origin_tool=t1),
+            make_function_tool(b, t, origin_server=s2, origin_tool=t2),
+        ]
+        out = uniquify_advertised_tool_names(tools)
+        names = [item["function"]["name"] for item in out]
+        assert names[0] == a
+        assert names[1] != names[0]
+        assert all(_NAME_RE.match(name) and len(name) <= PROVIDER_TOOL_NAME_MAX for name in names)
+        assert mcp_origin_for(names[0], out) == (s1, t1)
+        assert mcp_origin_for(names[1], out) == (s2, t2)
+
+    def test_sixty_four_char_cap_collision(self) -> None:
+        collided = "n" * PROVIDER_TOOL_NAME_MAX
+        tools = [
+            _fn_envelope(collided, server="server_one", tool="long_tool"),
+            _fn_envelope(collided, server="server_two", tool="long_tool"),
+        ]
+        out = uniquify_advertised_tool_names(tools)
+        names = [item["function"]["name"] for item in out]
+        assert names[0] == collided
+        assert names[1] != names[0]
+        assert all(_NAME_RE.match(name) and len(name) <= PROVIDER_TOOL_NAME_MAX for name in names)
+        assert mcp_origin_for(names[0], out) == ("server_one", "long_tool")
+        assert mcp_origin_for(names[1], out) == ("server_two", "long_tool")
+
+    def test_sanitize_uniquifies_even_without_prior_origin_rewrite(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp__x__search_posts",
+                    "description": "",
+                    "parameters": {"type": "object"},
+                    "strict": False,
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp__x__search_posts",
+                    "description": "",
+                    "parameters": {"type": "object"},
+                    "strict": False,
+                },
+            },
+        ]
+        cleaned = sanitize_tools_for_provider(tools)
+        names = [item["function"]["name"] for item in cleaned]
+        assert names[0] == "mcp__x__search_posts"
+        assert names[1] != names[0]
+        assert all(_NAME_RE.match(name) and len(name) <= PROVIDER_TOOL_NAME_MAX for name in names)
+        assert cleaned is not tools
+
+    def test_build_kwargs_never_sends_duplicate_names(self) -> None:
+        collided = "mcp__x__search_posts"
+        tools = [
+            _fn_envelope(collided, server="x", tool="search_posts"),
+            _fn_envelope(collided, server="custom_api_x_com_QFZ6ZWJR", tool="search_posts"),
+        ]
+        unique = uniquify_advertised_tool_names(tools)
+        kwargs = _build_litellm_kwargs(
+            model="anthropic/claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=unique,
+            auth=None,
+            extra=None,
+            session_id=None,
+            stream=False,
+        )
+        names = [item["function"]["name"] for item in kwargs["tools"]]
+        assert len(names) == len(set(names))
+        assert all(_NAME_RE.match(name) for name in names)

--- a/tests/unit/test_mcp_provider_tool_names.py
+++ b/tests/unit/test_mcp_provider_tool_names.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from mcp.types import Tool
 
@@ -124,7 +125,7 @@ class TestSanitizeToolsForProvider:
         assert "outputSchema" in tools[0]["function"]
 
 
-def _fn_envelope(name: str, *, server: str, tool: str) -> dict:
+def _fn_envelope(name: str, *, server: str, tool: str) -> dict[str, Any]:
     return make_function_tool(
         name,
         Tool(name=tool, description="", inputSchema={"type": "object"}),


### PR DESCRIPTION
## Summary
- After qualify/sanitize, advertised `function.name` values sent to LiteLLM/Anthropic are uniquified: keep the first name, rewrite later collisions with a short server-derived suffix (then hash) that stays in `^[a-zA-Z0-9_-]{1,64}$`.
- `_mcp_origin` / dispatch still maps the rewritten advertised name back to the raw server + tool. Uniquify runs at the sanitize layer and again after combining servers so a cached per-server list is not mutated.
- Production mute: catalog X + leftover custom `custom_api_x_com_QFZ6ZWJR` (same URL) both advertised identical names after #2229 sanitize → Anthropic `tools: Tool names must be unique`.

## Test plan
- [x] `tests/unit/test_mcp_provider_tool_names.py` — colliding envelopes (catalog x + leftover custom, `api.x.com` vs `api_x_com`, 64-char cap) produce unique names; origin lookup still works; clean unique lists stay same-object
- [x] `tests/unit/test_discover_session_mcp_tools.py` — combined discovery uniquifies and origin lookup still works
- [ ] CI unit + typecheck