### PR TITLE
fix(vaults): opt the OAuth token-endpoint POST into a JSON response

### DIFF
--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -157,15 +157,18 @@ def build_token_endpoint_post(
 
     Mutates ``body`` in place (``client_id`` is always added — it identifies the
     public client; ``client_secret`` is added for the ``client_secret_post``
-    method) and returns the kwargs for ``httpx.AsyncClient.post`` (``data``,
-    plus ``auth`` for ``client_secret_basic``). Shared by the refresh path
-    (:func:`refresh_credential`) and the authorization-code exchange
-    (:mod:`aios.services.vault_oauth`) so the two never drift.
+    method) and returns the kwargs for ``httpx.AsyncClient.post`` (``data`` and
+    a JSON-requesting ``headers``, plus ``auth`` for ``client_secret_basic``).
+    Shared by the refresh path (:func:`refresh_credential`) and the
+    authorization-code exchange (:mod:`aios.services.vault_oauth`) so the two
+    never drift.
     """
     auth = endpoint_auth or {"method": "none"}
     method = auth.get("method", "none")
     body["client_id"] = client_id
-    post_kwargs: dict[str, Any] = {"data": body}
+    # RFC 6749 §5.1 token responses are JSON, but GitHub's token endpoint
+    # answers form-encoded unless the request opts into JSON explicitly.
+    post_kwargs: dict[str, Any] = {"data": body, "headers": {"Accept": "application/json"}}
     if method == "client_secret_basic":
         post_kwargs["auth"] = httpx.BasicAuth(client_id, auth.get("client_secret", ""))
     elif method == "client_secret_post":

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -34,6 +34,7 @@ from aios.services.vaults import (
     SECRET_PLACEHOLDER_PREFIX,
     _extract_auth_payload,
     _merge_auth_payload,
+    build_token_endpoint_post,
     env_var_credential_containment_error,
     is_expiring,
     mint_secret_placeholder,
@@ -809,6 +810,53 @@ def _expiring_oauth_payload(**overrides: Any) -> dict[str, Any]:
     return base
 
 
+class TestBuildTokenEndpointPost:
+    """The shared token-endpoint POST kwargs — one seam, two callers.
+
+    ``refresh_credential`` and the authorization-code exchange in
+    :mod:`aios.services.vault_oauth` both build their POST here precisely so the
+    two never drift, so the content-negotiation and client-auth guarantees are
+    pinned once, at the seam.
+    """
+
+    def test_opts_into_json_for_every_auth_method(self) -> None:
+        """RFC 6749 5.1 says token responses are JSON, but GitHub's token
+        endpoint answers form-encoded unless the request asks for JSON. Both
+        callers parse the response as JSON, so the ``Accept`` header is not
+        optional — it is what makes that parse well-founded."""
+        for auth in (
+            None,
+            {"method": "none"},
+            {"method": "client_secret_basic", "client_secret": "shh"},
+            {"method": "client_secret_post", "client_secret": "shh"},
+        ):
+            kwargs = build_token_endpoint_post(
+                {"grant_type": "refresh_token"}, client_id="cid", endpoint_auth=auth
+            )
+            assert kwargs["headers"]["Accept"] == "application/json", auth
+
+    def test_json_opt_in_does_not_disturb_client_auth(self) -> None:
+        """The header rides alongside the auth method, never in place of it."""
+        basic = build_token_endpoint_post(
+            {"grant_type": "refresh_token"},
+            client_id="cid",
+            endpoint_auth={"method": "client_secret_basic", "client_secret": "shh"},
+        )
+        assert isinstance(basic["auth"], httpx.BasicAuth)
+        assert basic["data"]["client_id"] == "cid"
+        assert "client_secret" not in basic["data"]
+
+        post_body: dict[str, str] = {"grant_type": "refresh_token"}
+        post = build_token_endpoint_post(
+            post_body,
+            client_id="cid",
+            endpoint_auth={"method": "client_secret_post", "client_secret": "shh"},
+        )
+        assert "auth" not in post
+        assert post["data"] is post_body
+        assert post_body["client_secret"] == "shh"
+
+
 class TestIsExpiring:
     def test_far_future_is_not_expiring(self) -> None:
 
@@ -942,6 +990,42 @@ class TestRefreshCredential:
         assert "client_secret" not in kwargs["data"]
         assert kwargs["data"]["grant_type"] == "refresh_token"
         assert kwargs["data"]["refresh_token"] == "rt-1"
+
+    @pytest.mark.asyncio
+    async def test_refresh_post_asks_for_json(self, crypto_box: CryptoBox) -> None:
+        """The JSON opt-in survives the call site's ``**post_kwargs`` splat.
+
+        ``build_token_endpoint_post`` sets ``Accept: application/json`` and this
+        path parses the reply with ``response.json()``. A form-encoded 200 fails
+        that parse with a ``JSONDecodeError`` — which is not an ``httpx.HTTPError``
+        and so escapes the handler below entirely. Pinned here, at the caller,
+        because the seam test cannot see a ``headers=`` kwarg added alongside the
+        splat that would silently override it.
+        """
+        account_id = "acc_test_stub"
+
+        payload = _expiring_oauth_payload()
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
+        conn = _conn_with_transaction()
+        client = _async_client_returning(_http_response(body={"access_token": "new"}))
+
+        with (
+            patch.object(
+                queries,
+                "lock_oauth_credential_for_refresh",
+                AsyncMock(return_value=("vc_1", blob)),
+            ),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
+        ):
+            await refresh_credential(
+                crypto_box,
+                fake_pool_yielding_conn(conn),
+                vault_id="vlt_1",
+                target_url="https://mcp.example.com",
+                account_id=account_id,
+            )
+
+        assert client.post.await_args.kwargs["headers"]["Accept"] == "application/json"
 
     @pytest.mark.asyncio
     async def test_post_method_includes_secret_in_body(self, crypto_box: CryptoBox) -> None:


### PR DESCRIPTION
## What

`build_token_endpoint_post` sent only `data`, leaving content negotiation to the provider's default. RFC 6749 §5.1 specifies JSON token responses, but **GitHub's token endpoint answers `application/x-www-form-urlencoded` unless the request carries `Accept: application/json`** — and both callers parse the reply as JSON.

One line in the shared helper, plus tests.

## Why it matters

The **refresh path** is the sharp edge. `refresh_credential` calls `response.json()` (`vaults.py:322`) inside a `try` that catches only `httpx.HTTPError`. A form-encoded 200 raises `json.JSONDecodeError` — *not* an `httpx.HTTPError` — so it escapes the handler entirely as an unhandled error.

The **exchange path** (`vault_oauth.py:482`) degrades better: it hands the response to the MCP library's `handle_token_response_scopes`, whose parse failure surfaces as `OAuthTokenError` and is converted to `OAuthFlowError`.

### Deliberately not "fixed": the escaping parse error

Failing hard on an unparseable 200 is correct and left alone. That handler's recovery path exists for the *rotating-provider race loser* (the peer consumed `refresh_token` while our POST was in flight) — which an unparseable 200 is not. Adding a form-decode fallback would paper over a token endpoint answering in a format we never asked for, against the repo's fail-hard stance. The right fix is to ask for JSON, which is what this does.

## Where the change goes

In the shared helper, not at either call site. Its docstring already names *"so the two never drift"* as its reason to exist, and both sites splat `**post_kwargs` with no headers of their own, so nothing is clobbered. Docstring updated to enumerate the added kwarg.

## Tests

Pinned at the **seam** (one helper, two callers):
- `Accept: application/json` present for all four auth-method spellings (`None`, `none`, `client_secret_basic`, `client_secret_post`)
- the header doesn't disturb client auth — `BasicAuth` still set, `client_secret` still kept out of the basic-method form body, still injected for the post method

Plus one at the **refresh call site**, covering what the seam test structurally cannot: a `headers=` kwarg added alongside the splat would silently override the helper's. 

Both new tests verified **red** without the one-line change, green with it.

## Checks

`mypy` ✅ · `ruff check` + `format` ✅ · `pytest tests/unit` 5184 passed ✅ · connector suites ✅ · SDK/openapi drift guard green (service-layer only, no regen needed).

## Provenance

Found as an uncommitted edit stranded in the primary checkout from 2026-08-20, on a branch whose own work had already merged as #2194. Verified as a real fix rather than a stale experiment, then rebased onto fresh master with the tests it was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)