### PR TITLE
perf(tests): cut the integration CI job from ~19 min toward ~2-3 min

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -322,18 +322,22 @@ jobs:
         run: uv sync --dev
 
       - name: Integration tests
-        # Run serially: each xdist worker owns a session Postgres container,
-        # while migration tests start additional containers. Even two workers
-        # can exhaust hosted-runner Docker resources and make healthy container
-        # startups time out. Retry only pytest's recorded failures once so a
+        # ``-n 4`` matches the 4 vCPUs on public-repo ubuntu-latest runners.
+        # Each xdist worker owns its own session testcontainer Postgres
+        # (tests/conftest.py). The per-test containers that once exhausted
+        # hosted-runner Docker under even two workers are gone — migration
+        # tests now mint databases on their worker's shared server — so the
+        # old serial-only constraint no longer applies. ``--dist=loadfile``
+        # keeps module-scoped DB fixtures (test_migrations_0144_search_views)
+        # worker-local. Retry only pytest's recorded failures once so a
         # transient testcontainer startup cannot fail the entire suite; a real
         # regression fails both attempts and remains blocking.
         run: |
-          if ! uv run pytest tests/integration -q --durations=25 -o faulthandler_timeout=120; then
+          if ! uv run pytest tests/integration -q -n 4 --dist=loadfile --durations=25 -o faulthandler_timeout=120; then
             echo "::warning::FLAKE_RETRY integration"
             echo "FLAKE_RETRY integration" >> "$GITHUB_STEP_SUMMARY"
             echo "FLAKE_RETRY integration" >> flake-retry-integration.txt
-            uv run pytest tests/integration -q --durations=25 -o faulthandler_timeout=120 --lf
+            uv run pytest tests/integration -q -n 4 --dist=loadfile --durations=25 -o faulthandler_timeout=120 --lf
           fi
 
       - name: Upload integration flake-retry marker

--- a/src/aios/db/migrations.py
+++ b/src/aios/db/migrations.py
@@ -12,20 +12,37 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, TextIO
 from unittest import mock
 
+if TYPE_CHECKING:
+    from alembic.config import Config
+
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def alembic_config(*, stdout: TextIO | None = None) -> Config:
+    """Alembic ``Config`` bound to the repo's ``alembic.ini`` + ``migrations/``.
+
+    The one home for where the migration ladder lives on disk — shared by
+    :func:`upgrade_to_head` and the test-side runner
+    (``tests/helpers/alembic.py``) so the two cannot drift.
+    """
+    from alembic.config import Config
+
+    cfg = Config(
+        str(_REPO_ROOT / "alembic.ini"), stdout=stdout if stdout is not None else sys.stdout
+    )
+    cfg.set_main_option("script_location", str(_REPO_ROOT / "migrations"))
+    return cfg
 
 
 def upgrade_to_head(db_url: str) -> None:
     """In-process equivalent of ``alembic upgrade head`` against ``db_url``."""
     from alembic import command
-    from alembic.config import Config
 
-    cfg = Config(str(_REPO_ROOT / "alembic.ini"))
-    cfg.set_main_option("script_location", str(_REPO_ROOT / "migrations"))
     with mock.patch.dict(os.environ, {"AIOS_DB_URL": db_url}):
-        command.upgrade(cfg, "head")
+        command.upgrade(alembic_config(), "head")
 
 
 async def apply_procrastinate_schema(db_url: str, *, verbose: bool = False) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,13 @@ def postgres_container() -> Iterator[Any]:
         pytest.skip("Docker not available")
     from testcontainers.postgres import PostgresContainer
 
-    with PostgresContainer("postgres:16-alpine") as pg:
+    # Ephemeral test server: crash-durability is meaningless for a throwaway
+    # container, so trade it for markedly cheaper commits and DDL.  This
+    # speeds the TRUNCATE-per-test reset and every alembic replay, most
+    # visibly on fsync-slow CI runner disks.
+    with PostgresContainer("postgres:16-alpine").with_command(
+        "postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off"
+    ) as pg:
         yield pg
 
 

--- a/tests/helpers/alembic.py
+++ b/tests/helpers/alembic.py
@@ -1,0 +1,51 @@
+"""In-process alembic runner for the ``test_migrations_*`` modules.
+
+Mirrors the CLI contract the migration tests are written against —
+``returncode`` 0/1, captured ``stdout``, failure text in ``stderr`` — while
+skipping the ``uv run`` + interpreter + import cost every invocation used to
+pay as a subprocess (~1 s x ~150 call sites).  A migration that raises (e.g.
+a guarded downgrade) surfaces as ``returncode`` 1 with the traceback in
+``stderr``, which is where the tests grep for messages like
+``"cannot downgrade"``.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import traceback
+from unittest import mock
+
+from aios.db.migrations import alembic_config
+
+
+def run_alembic(
+    args: list[str], db_url: str, *, extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """In-process ``alembic upgrade|downgrade <revision>`` against ``db_url``.
+
+    ``extra_env`` is for migrations that read configuration from the
+    environment (0057 reads ``AIOS_WORKSPACE_ROOT``; 0154 reads
+    ``AIOS_VAULT_KEY``).
+    """
+    from alembic import command
+
+    action, revision = args
+    runner = {"upgrade": command.upgrade, "downgrade": command.downgrade}[action]
+    out = io.StringIO()
+    cfg = alembic_config(stdout=out)
+    # ``migrations/env.py`` reads the URL from ``AIOS_DB_URL``.
+    with mock.patch.dict(os.environ, {"AIOS_DB_URL": db_url, **(extra_env or {})}):
+        try:
+            runner(cfg, revision)
+        except Exception:
+            return subprocess.CompletedProcess(
+                ["alembic", *args],
+                returncode=1,
+                stdout=out.getvalue(),
+                stderr=traceback.format_exc(),
+            )
+    return subprocess.CompletedProcess(
+        ["alembic", *args], returncode=0, stdout=out.getvalue(), stderr=""
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,10 +6,12 @@ individual test modules don't re-roll the same scaffolding.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+import itertools
+from collections.abc import AsyncIterator, Callable, Iterator
 from typing import Any
 
 import asyncpg
+import psycopg
 import pytest
 
 from aios.db import queries
@@ -123,3 +125,40 @@ async def live_conn(request: pytest.FixtureRequest) -> AsyncIterator[asyncpg.Con
         yield conn
     finally:
         await conn.close()
+
+
+@pytest.fixture(scope="session")
+def migration_db_factory(postgres_container: Any) -> Iterator[Callable[[], str]]:
+    """Mint fresh, empty databases on the shared session Postgres server.
+
+    Migration tests replay alembic chains from zero, so they can't share the
+    already-migrated ``migrated_db_url`` database — but they don't need their
+    own *server* either: aios migrations touch only database-local state
+    (tables, indexes, extensions), never cluster state.  ``CREATE DATABASE``
+    on the shared container (~50 ms) replaces the per-test
+    ``PostgresContainer`` boot (~1.5-4 s) the migration files used to pay.
+    No per-database teardown — the container's session teardown is the
+    cleanup.
+
+    A session-scoped factory (rather than only a function-scoped URL fixture)
+    so a module of read-only tests sharing one replayed schema can mint a
+    single database at module scope.
+    """
+    host = postgres_container.get_container_host_ip()
+    port = postgres_container.get_exposed_port(5432)
+    base = f"postgresql://{postgres_container.username}:{postgres_container.password}@{host}:{port}"
+    counter = itertools.count()
+    with psycopg.connect(f"{base}/{postgres_container.dbname}", autocommit=True) as admin:
+
+        def make() -> str:
+            name = f"aios_mig_{next(counter)}"
+            admin.execute(f'CREATE DATABASE "{name}"')
+            return f"{base}/{name}"
+
+        yield make
+
+
+@pytest.fixture
+def migration_db_url(migration_db_factory: Callable[[], str]) -> str:
+    """A fresh empty database for one test — see ``migration_db_factory``."""
+    return migration_db_factory()

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -2,66 +2,18 @@
 
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-from collections.abc import Iterator
-from pathlib import Path
-
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-
-
-@pytest.fixture(scope="module")
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
-def _alembic_url(pg: object) -> str:
-    """Return the connection URL alembic env.py expects."""
-    from testcontainers.postgres import PostgresContainer
-
-    assert isinstance(pg, PostgresContainer)
-    host = pg.get_container_host_ip()
-    port = pg.get_exposed_port(5432)
-    user = pg.username
-    password = pg.password
-    db = pg.dbname
-    return f"postgresql://{user}:{password}@{host}:{port}/{db}"
-
-
-def _run_alembic(args: list[str], db_url: str) -> subprocess.CompletedProcess[str]:
-    uv = shutil.which("uv")
-    if uv is None:
-        raise FileNotFoundError("uv not found on PATH")
-    return subprocess.run(
-        [uv, "run", "alembic", *args],
-        cwd=PROJECT_ROOT,
-        env={
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin:/usr/local/bin"),
-            "AIOS_DB_URL": db_url,
-            "HOME": str(Path.home()),
-        },
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 
 @needs_docker
 @pytest.mark.integration
-def test_migration_creates_all_tables(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
-    result = _run_alembic(["upgrade", "head"], db_url)
+def test_migration_creates_all_tables(migration_db_url: str) -> None:
+    db_url = migration_db_url
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
 
     # Now connect with asyncpg and verify all 5 tables + key indexes exist.

--- a/tests/integration/test_migrations_0083_triggers.py
+++ b/tests/integration/test_migrations_0083_triggers.py
@@ -10,21 +10,20 @@ serialization, the verbatim ``sandbox_command`` assembly (a schedule_wake-
 origin ``tool wake_self`` row STAYS ``sandbox_command`` — ``wake_owner`` is
 opt-in going forward, never backfilled), and the fail-hard validating SELECT.
 
-Each test mutates ``alembic_version``, so the container is function-scoped.
+Each test mutates ``alembic_version``, so each test gets its own database.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # The FK chain required to land a session_scheduled_tasks row at revision 0081
 # (columns introspected from a 0081 DB): accounts → environments → agents →
@@ -60,17 +59,6 @@ VALUES ('sched_wake', 'ses_mig', 'acc_mig', 'wake-row',
         '2026-06-12 09:00:00+00'::timestamptz,
         'tool wake_self ''{"content":"poll done"}''');
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _execute(db_url: str, sql: str) -> None:
@@ -110,17 +98,17 @@ async def _table_exists(db_url: str, name: str) -> bool:
 
 @needs_docker
 @pytest.mark.integration
-def test_backfill_maps_old_rows_verbatim(postgres: object) -> None:
+def test_backfill_maps_old_rows_verbatim(migration_db_url: str) -> None:
     """Seed cron / one_shot / schedule_wake-origin rows at 0081, upgrade to 0083,
     assert the backfill mapping + verbatim sandbox_command assembly."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0081"], db_url)
+    up = run_alembic(["upgrade", "0081"], db_url)
     assert up.returncode == 0, f"upgrade to 0081 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _OLD_ROWS_SQL))
 
-    up = _run_alembic(["upgrade", "0083"], db_url)
+    up = run_alembic(["upgrade", "0083"], db_url)
     assert up.returncode == 0, f"upgrade to 0083 failed:\n{up.stderr}\n{up.stdout}"
 
     # Table + owner column renamed.
@@ -162,14 +150,14 @@ def test_backfill_maps_old_rows_verbatim(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_validating_select_fails_hard_on_malformed_row(postgres: object) -> None:
+def test_validating_select_fails_hard_on_malformed_row(migration_db_url: str) -> None:
     """A pre-0083 row that backfills to an invalid shape (both schedule and
     fire_at NULL — only reachable by dropping the 0059 XOR) is named by the
     in-migration validating SELECT, which aborts the upgrade BEFORE the new
     columns are made NOT NULL / the CHECKs are added."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0081"], db_url)
+    up = run_alembic(["upgrade", "0081"], db_url)
     assert up.returncode == 0, f"upgrade to 0081 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     # Drop the 0059 XOR so a both-NULL row can land; the backfill turns it into a
@@ -185,7 +173,7 @@ def test_validating_select_fails_hard_on_malformed_row(postgres: object) -> None
         )
     )
 
-    up = _run_alembic(["upgrade", "0083"], db_url)
+    up = run_alembic(["upgrade", "0083"], db_url)
     assert up.returncode != 0, f"upgrade should have failed loud:\n{up.stdout}"
     assert "violating the shape contract" in up.stderr
     assert "sched_bad" in up.stderr

--- a/tests/integration/test_migrations_0086_triggers_slice2.py
+++ b/tests/integration/test_migrations_0086_triggers_slice2.py
@@ -7,19 +7,18 @@ and the ``triggers_run_completion_no_next_fire`` guard (the DB half of the §3
 "reactive rows are unschedulable by the tick" invariant — a service-layer slip
 here would be a tick-speed hot re-claim runaway, hence the constraint).
 
-Each test mutates ``alembic_version``, so the container is function-scoped.
+Each test mutates ``alembic_version``, so each test gets its own database.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # FK chain for seeding a trigger row at head (NOT-NULL-without-default columns
 # only; mirrors test_migrations_0083_triggers.py).
@@ -46,17 +45,6 @@ VALUES
      '{"kind": "wake_owner", "content": "a run completed"}'::jsonb,
      TRUE, NULL);
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _execute(db_url: str, sql: str) -> None:
@@ -92,17 +80,17 @@ async def _column_exists(db_url: str, table: str, column: str) -> bool:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_and_clean_downgrade_round_trip(postgres: object) -> None:
+def test_upgrade_and_clean_downgrade_round_trip(migration_db_url: str) -> None:
     """With zero slice-2 rows, 0086 upgrades and downgrades cleanly: the audit
     table and the env column appear at head and vanish on downgrade."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0086"], db_url)
+    up = run_alembic(["upgrade", "0086"], db_url)
     assert up.returncode == 0, f"upgrade to 0086 failed:\n{up.stderr}\n{up.stdout}"
     assert asyncio.run(_table_exists(db_url, "trigger_runs"))
     assert asyncio.run(_column_exists(db_url, "triggers", "environment_id"))
 
-    down = _run_alembic(["downgrade", "0085"], db_url)
+    down = run_alembic(["downgrade", "0085"], db_url)
     assert down.returncode == 0, f"downgrade to 0085 failed:\n{down.stderr}\n{down.stdout}"
     assert not asyncio.run(_table_exists(db_url, "trigger_runs"))
     assert not asyncio.run(_column_exists(db_url, "triggers", "environment_id"))
@@ -110,17 +98,17 @@ def test_upgrade_and_clean_downgrade_round_trip(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_refuses_slice2_rows(postgres: object) -> None:
+def test_downgrade_refuses_slice2_rows(migration_db_url: str) -> None:
     """A run_completion row is unrepresentable under the 0083 predicates, so
     the downgrade fails hard and rolls back (the 0083 wake_owner stance)."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0086"], db_url)
+    up = run_alembic(["upgrade", "0086"], db_url)
     assert up.returncode == 0, f"upgrade to 0086 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _RUN_COMPLETION_ROW_SQL))
 
-    down = _run_alembic(["downgrade", "0085"], db_url)
+    down = run_alembic(["downgrade", "0085"], db_url)
     assert down.returncode != 0, f"downgrade should have failed loud:\n{down.stdout}"
     assert "cannot downgrade" in down.stderr
 
@@ -131,13 +119,13 @@ def test_downgrade_refuses_slice2_rows(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_run_completion_rows_reject_next_fire(postgres: object) -> None:
+def test_run_completion_rows_reject_next_fire(migration_db_url: str) -> None:
     """The resolved sign-off #2 guard: a run_completion row can never carry a
     next_fire, so it is unschedulable by the scheduler tick BY CONSTRAINT, not
     merely by service-layer discipline."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0086"], db_url)
+    up = run_alembic(["upgrade", "0086"], db_url)
     assert up.returncode == 0, f"upgrade to 0086 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _RUN_COMPLETION_ROW_SQL))

--- a/tests/integration/test_migrations_0087_notify_next_fire.py
+++ b/tests/integration/test_migrations_0087_notify_next_fire.py
@@ -13,19 +13,18 @@ and assert a PURE ``next_fire`` UPDATE produces a NOTIFY on
 silent behavior. The e2e suite runs at head where ``triggers`` is created
 empty, so the NOTIFY-on-next_fire edge is only exercised here.
 
-Each test mutates ``alembic_version``, so the container is function-scoped.
+Each test mutates ``alembic_version``, so each test gets its own database.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # FK chain required to land a ``triggers`` row at revision 0087:
 # accounts → environments → agents → sessions → triggers. Only NOT-NULL-
@@ -60,17 +59,6 @@ VALUES (
 _NEXT_FIRE_ONLY_UPDATE = (
     "UPDATE triggers SET next_fire = next_fire + interval '7 minutes' WHERE id = 'trg_nf'"
 )
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _execute(db_url: str, sql: str) -> None:
@@ -110,11 +98,11 @@ async def _next_fire_update_notifies(db_url: str, *, timeout_s: float) -> bool:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_0087_next_fire_only_update_notifies(postgres: object) -> None:
+def test_upgrade_0087_next_fire_only_update_notifies(migration_db_url: str) -> None:
     """At 0087, a pure ``next_fire`` UPDATE emits a NOTIFY within ~2s."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0087"], db_url)
+    up = run_alembic(["upgrade", "0087"], db_url)
     assert up.returncode == 0, f"upgrade to 0087 failed:\n{up.stderr}\n{up.stdout}"
 
     asyncio.run(_execute(db_url, _CHAIN_SQL))
@@ -127,18 +115,18 @@ def test_upgrade_0087_next_fire_only_update_notifies(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_0086_next_fire_only_update_does_not_notify(postgres: object) -> None:
+def test_downgrade_0086_next_fire_only_update_does_not_notify(migration_db_url: str) -> None:
     """Downgrading to 0086 restores the pre-fix body: a pure ``next_fire``
     UPDATE is silent (mirrors the action-only negative test)."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0087"], db_url)
+    up = run_alembic(["upgrade", "0087"], db_url)
     assert up.returncode == 0, f"upgrade to 0087 failed:\n{up.stderr}\n{up.stdout}"
 
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _TRIGGER_SQL))
 
-    down = _run_alembic(["downgrade", "0086"], db_url)
+    down = run_alembic(["downgrade", "0086"], db_url)
     assert down.returncode == 0, f"downgrade to 0086 failed:\n{down.stderr}\n{down.stdout}"
 
     assert not asyncio.run(_next_fire_update_notifies(db_url, timeout_s=0.5)), (

--- a/tests/integration/test_migrations_0093_composite_fk_backstop.py
+++ b/tests/integration/test_migrations_0093_composite_fk_backstop.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 _CHAIN_SQL = """
 INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
@@ -32,17 +31,6 @@ VALUES ('sess_a', 'vault_b', 0, 'acc_a');
 """
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres; each test mutates alembic_version."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -53,24 +41,24 @@ async def _execute(db_url: str, sql: str) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_clean_database_upgrades_to_composite_fk_backstop(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_clean_database_upgrades_to_composite_fk_backstop(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
 
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
 
 
 @needs_docker
 @pytest.mark.integration
-def test_legacy_cross_tenant_session_vault_fails_validation(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_legacy_cross_tenant_session_vault_fails_validation(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0092"], db_url)
+    up = run_alembic(["upgrade", "0092"], db_url)
     assert up.returncode == 0, f"upgrade to 0092 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL + _LEGACY_CROSS_TENANT_SESSION_VAULT_SQL))
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
 
     assert up.returncode != 0, f"upgrade should have failed loud:\n{up.stdout}"
     output = up.stderr + up.stdout

--- a/tests/integration/test_migrations_0097_unique_tool_result.py
+++ b/tests/integration/test_migrations_0097_unique_tool_result.py
@@ -6,13 +6,12 @@ backfills out any pre-existing duplicate rows (keeping the lowest-seq row).
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # A minimal account/agent/env/session chain plus an assistant tool_call so a
 # tool-role event has a parent to attach to. Two tool-role rows for the SAME
@@ -49,17 +48,6 @@ VALUES ('evt_x', 'sess_a', 3, 'message',
 """
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres; each test mutates alembic_version."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -78,10 +66,10 @@ async def _fetchval(db_url: str, sql: str) -> object:
 
 @needs_docker
 @pytest.mark.integration
-def test_clean_database_upgrades_to_unique_tool_result_idx(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_clean_database_upgrades_to_unique_tool_result_idx(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
 
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
     indexdef = asyncio.run(
@@ -96,14 +84,14 @@ def test_clean_database_upgrades_to_unique_tool_result_idx(postgres: object) -> 
 
 @needs_docker
 @pytest.mark.integration
-def test_preexisting_duplicate_backfilled_keeping_lowest_seq(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_preexisting_duplicate_backfilled_keeping_lowest_seq(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0095"], db_url)
+    up = run_alembic(["upgrade", "0095"], db_url)
     assert up.returncode == 0, f"upgrade to 0095 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL + _DUP_ROWS_SQL))
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
 
     # Exactly one tool-role row survives — the lowest-seq (winning) one.
@@ -129,10 +117,10 @@ def test_preexisting_duplicate_backfilled_keeping_lowest_seq(postgres: object) -
 
 @needs_docker
 @pytest.mark.integration
-def test_unique_index_rejects_second_tool_result(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_unique_index_rejects_second_tool_result(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(
         _execute(

--- a/tests/integration/test_migrations_0107_triggers_wake_session.py
+++ b/tests/integration/test_migrations_0107_triggers_wake_session.py
@@ -5,20 +5,19 @@ downgrade refusal once a ``wake_session`` row exists, that a ``wake_session``
 row INSERTs under the new CHECK and is REJECTED under the old, and that every
 pre-existing action kind still inserts under the new CHECK.
 
-Each test mutates ``alembic_version``, so the container is function-scoped.
+Each test mutates ``alembic_version``, so each test gets its own database.
 Modeled on tests/integration/test_migrations_0086_triggers_slice2.py.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # FK chain for seeding a trigger row at head (NOT-NULL-without-default columns).
 _CHAIN_SQL = """
@@ -47,17 +46,6 @@ VALUES
 """
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -81,26 +69,28 @@ async def _insert_raises(db_url: str, sql: str) -> bool:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_and_clean_downgrade_round_trip(postgres: object) -> None:
+def test_upgrade_and_clean_downgrade_round_trip(migration_db_url: str) -> None:
     """With zero wake_session rows, 0107 upgrades and downgrades cleanly."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0107"], db_url)
+    up = run_alembic(["upgrade", "0107"], db_url)
     assert up.returncode == 0, f"upgrade to 0107 failed:\n{up.stderr}\n{up.stdout}"
 
-    down = _run_alembic(["downgrade", "0106"], db_url)
+    down = run_alembic(["downgrade", "0106"], db_url)
     assert down.returncode == 0, f"downgrade to 0106 failed:\n{down.stderr}\n{down.stdout}"
 
 
 @needs_docker
 @pytest.mark.integration
-def test_wake_session_row_accepted_under_new_check_rejected_under_old(postgres: object) -> None:
+def test_wake_session_row_accepted_under_new_check_rejected_under_old(
+    migration_db_url: str,
+) -> None:
     """A wake_session row INSERTs at head (0107) and is rejected at the prior
     revision (0106) — the CHECK swap is what makes the kind representable."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
     # Under 0106 (prior head) the row is unrepresentable: ELSE false.
-    up106 = _run_alembic(["upgrade", "0106"], db_url)
+    up106 = run_alembic(["upgrade", "0106"], db_url)
     assert up106.returncode == 0, f"upgrade to 0106 failed:\n{up106.stderr}\n{up106.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     assert asyncio.run(_insert_raises(db_url, _WAKE_SESSION_ROW_SQL)), (
@@ -108,18 +98,18 @@ def test_wake_session_row_accepted_under_new_check_rejected_under_old(postgres: 
     )
 
     # Under 0107 the same row inserts.
-    up107 = _run_alembic(["upgrade", "0107"], db_url)
+    up107 = run_alembic(["upgrade", "0107"], db_url)
     assert up107.returncode == 0, f"upgrade to 0107 failed:\n{up107.stderr}\n{up107.stdout}"
     asyncio.run(_execute(db_url, _WAKE_SESSION_ROW_SQL))
 
 
 @needs_docker
 @pytest.mark.integration
-def test_every_prior_kind_still_inserts_under_new_check(postgres: object) -> None:
+def test_every_prior_kind_still_inserts_under_new_check(migration_db_url: str) -> None:
     """The four pre-existing branches stay byte-identical, so every prior
     action kind still inserts under the 0107 CHECK."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0107"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0107"], db_url)
     assert up.returncode == 0, f"upgrade to 0107 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
 
@@ -165,16 +155,16 @@ def test_every_prior_kind_still_inserts_under_new_check(postgres: object) -> Non
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_refuses_wake_session_rows(postgres: object) -> None:
+def test_downgrade_refuses_wake_session_rows(migration_db_url: str) -> None:
     """A wake_session row is unrepresentable under the prior predicate, so the
     downgrade fails hard and rolls back (the 0086 stance)."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0107"], db_url)
+    up = run_alembic(["upgrade", "0107"], db_url)
     assert up.returncode == 0, f"upgrade to 0107 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _WAKE_SESSION_ROW_SQL))
 
-    down = _run_alembic(["downgrade", "0106"], db_url)
+    down = run_alembic(["downgrade", "0106"], db_url)
     assert down.returncode != 0, f"downgrade should have failed loud:\n{down.stdout}"
     assert "cannot downgrade" in down.stderr

--- a/tests/integration/test_migrations_0108_triggers_external_event.py
+++ b/tests/integration/test_migrations_0108_triggers_external_event.py
@@ -7,20 +7,19 @@ the old, the ingest-token iff constraint and the unique-hash index, the
 broadened reactive-no-next-fire guard, the extended ``trigger_runs``
 trigger_context CHECK, and that every pre-existing source kind still inserts.
 
-Each test mutates ``alembic_version``, so the container is function-scoped.
+Each test mutates ``alembic_version``, so each test gets its own database.
 Modeled on tests/integration/test_migrations_0107_triggers_wake_session.py.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # FK chain for seeding a trigger row at head (NOT-NULL-without-default columns).
 _CHAIN_SQL = """
@@ -50,17 +49,6 @@ VALUES
 """
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -84,26 +72,26 @@ async def _insert_raises(db_url: str, sql: str) -> bool:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_and_clean_downgrade_round_trip(postgres: object) -> None:
+def test_upgrade_and_clean_downgrade_round_trip(migration_db_url: str) -> None:
     """With zero external_event rows, 0108 upgrades and downgrades cleanly."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0108"], db_url)
+    up = run_alembic(["upgrade", "0108"], db_url)
     assert up.returncode == 0, f"upgrade to 0108 failed:\n{up.stderr}\n{up.stdout}"
 
-    down = _run_alembic(["downgrade", "0107"], db_url)
+    down = run_alembic(["downgrade", "0107"], db_url)
     assert down.returncode == 0, f"downgrade to 0107 failed:\n{down.stderr}\n{down.stdout}"
 
 
 @needs_docker
 @pytest.mark.integration
-def test_cron_row_with_timezone_key_accepted_under_check(postgres: object) -> None:
+def test_cron_row_with_timezone_key_accepted_under_check(migration_db_url: str) -> None:
     """Zero-migration proof for CronSource.timezone (#1378): a cron row carrying
     a ``timezone`` key in ``source_spec`` satisfies ``triggers_source_spec_shape``
     with NO DDL — the cron arm only asserts ``schedule`` is a string and
     ``fire_at`` is absent, and the COALESCE wrapper tolerates additive keys."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0108"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0108"], db_url)
     assert up.returncode == 0, f"upgrade to 0108 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
 
@@ -122,14 +110,16 @@ def test_cron_row_with_timezone_key_accepted_under_check(postgres: object) -> No
 
 @needs_docker
 @pytest.mark.integration
-def test_external_event_row_accepted_under_new_check_rejected_under_old(postgres: object) -> None:
+def test_external_event_row_accepted_under_new_check_rejected_under_old(
+    migration_db_url: str,
+) -> None:
     """An external_event row INSERTs at head (0108) and is rejected at the prior
     revision (0107) — the shape CHECK swap is what makes the kind representable."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
     # Under 0107 (prior head) the row is unrepresentable: source_spec ELSE false
     # AND there is no ingest_token_hash column.
-    up107 = _run_alembic(["upgrade", "0107"], db_url)
+    up107 = run_alembic(["upgrade", "0107"], db_url)
     assert up107.returncode == 0, f"upgrade to 0107 failed:\n{up107.stderr}\n{up107.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     # Column does not exist yet → UndefinedColumnError (not a CHECK violation).
@@ -138,7 +128,7 @@ def test_external_event_row_accepted_under_new_check_rejected_under_old(postgres
     )
 
     # Under 0108 the same row inserts.
-    up108 = _run_alembic(["upgrade", "0108"], db_url)
+    up108 = run_alembic(["upgrade", "0108"], db_url)
     assert up108.returncode == 0, f"upgrade to 0108 failed:\n{up108.stderr}\n{up108.stdout}"
     asyncio.run(_execute(db_url, _EXTERNAL_EVENT_ROW_SQL))
 
@@ -160,11 +150,11 @@ async def _column_absent_or_rejected(db_url: str, sql: str) -> bool:
 
 @needs_docker
 @pytest.mark.integration
-def test_ingest_token_iff_external_event_constraint(postgres: object) -> None:
+def test_ingest_token_iff_external_event_constraint(migration_db_url: str) -> None:
     """The iff constraint binds both directions: an external_event row WITHOUT a
     hash is rejected, and a non-external_event row WITH a hash is rejected."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0108"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0108"], db_url)
     assert up.returncode == 0, f"upgrade to 0108 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
 
@@ -194,10 +184,10 @@ def test_ingest_token_iff_external_event_constraint(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_ingest_token_hash_is_unique(postgres: object) -> None:
+def test_ingest_token_hash_is_unique(migration_db_url: str) -> None:
     """The partial unique index is the double-mint collision guard."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0108"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0108"], db_url)
     assert up.returncode == 0, f"upgrade to 0108 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _EXTERNAL_EVENT_ROW_SQL))  # hash 'deadbeef'
@@ -215,11 +205,11 @@ def test_ingest_token_hash_is_unique(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_external_event_with_next_fire_rejected(postgres: object) -> None:
+def test_external_event_with_next_fire_rejected(migration_db_url: str) -> None:
     """The broadened reactive-no-next-fire guard forbids a non-NULL next_fire on
     an external_event row (same carve-out as run_completion)."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0108"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0108"], db_url)
     assert up.returncode == 0, f"upgrade to 0108 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
 
@@ -236,13 +226,13 @@ def test_external_event_with_next_fire_rejected(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_trigger_runs_external_event_context_accepted(postgres: object) -> None:
+def test_trigger_runs_external_event_context_accepted(migration_db_url: str) -> None:
     """The extended trigger_runs.trigger_context CHECK admits 'external_event'
     (rejected before 0108)."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
     # Prior revision rejects the new context value.
-    up107 = _run_alembic(["upgrade", "0107"], db_url)
+    up107 = run_alembic(["upgrade", "0107"], db_url)
     assert up107.returncode == 0, f"upgrade to 0107 failed:\n{up107.stderr}\n{up107.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     run_row = """
@@ -255,18 +245,18 @@ def test_trigger_runs_external_event_context_accepted(postgres: object) -> None:
     assert asyncio.run(_insert_raises(db_url, run_row))
 
     # Head admits it.
-    up108 = _run_alembic(["upgrade", "0108"], db_url)
+    up108 = run_alembic(["upgrade", "0108"], db_url)
     assert up108.returncode == 0, f"upgrade to 0108 failed:\n{up108.stderr}\n{up108.stdout}"
     asyncio.run(_execute(db_url, run_row))
 
 
 @needs_docker
 @pytest.mark.integration
-def test_every_prior_source_kind_still_inserts_under_new_check(postgres: object) -> None:
+def test_every_prior_source_kind_still_inserts_under_new_check(migration_db_url: str) -> None:
     """The three pre-existing source branches stay byte-identical, so every
     prior source kind still inserts under the 0108 shape CHECK."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0108"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0108"], db_url)
     assert up.returncode == 0, f"upgrade to 0108 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
 
@@ -307,16 +297,16 @@ def test_every_prior_source_kind_still_inserts_under_new_check(postgres: object)
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_refuses_external_event_rows(postgres: object) -> None:
+def test_downgrade_refuses_external_event_rows(migration_db_url: str) -> None:
     """An external_event row is unrepresentable under the prior predicate, so the
     downgrade fails hard and rolls back (the 0086 stance)."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0108"], db_url)
+    up = run_alembic(["upgrade", "0108"], db_url)
     assert up.returncode == 0, f"upgrade to 0108 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _EXTERNAL_EVENT_ROW_SQL))
 
-    down = _run_alembic(["downgrade", "0107"], db_url)
+    down = run_alembic(["downgrade", "0107"], db_url)
     assert down.returncode != 0, f"downgrade should have failed loud:\n{down.stdout}"
     assert "cannot downgrade" in down.stderr

--- a/tests/integration/test_migrations_0110_bindings_cascade.py
+++ b/tests/integration/test_migrations_0110_bindings_cascade.py
@@ -18,24 +18,12 @@ through the service/query layer.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres; each test mutates alembic_version."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 
 async def _fetchval(db_url: str, sql: str) -> object:
@@ -69,16 +57,16 @@ def _bindings_fk_def(db_url: str) -> str:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_swaps_to_cascade_fk(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_upgrade_swaps_to_cascade_fk(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
     # Before 0110: the bare single-column FK with no ON DELETE action.
-    up = _run_alembic(["upgrade", "0108"], db_url)
+    up = run_alembic(["upgrade", "0108"], db_url)
     assert up.returncode == 0, f"upgrade to 0108 failed:\n{up.stderr}\n{up.stdout}"
     before = _bindings_fk_def(db_url)
     assert "ON DELETE CASCADE" not in before, f"unexpected cascade pre-0110: {before}"
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
     after = _bindings_fk_def(db_url)
     assert "ON DELETE CASCADE" in after, f"cascade missing after 0110: {after}"
@@ -93,13 +81,13 @@ def test_upgrade_swaps_to_cascade_fk(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_restores_bare_fk(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_downgrade_restores_bare_fk(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
 
-    down = _run_alembic(["downgrade", "0108"], db_url)
+    down = run_alembic(["downgrade", "0108"], db_url)
     assert down.returncode == 0, f"downgrade to 0108 failed:\n{down.stderr}\n{down.stdout}"
 
     restored = _bindings_fk_def(db_url)

--- a/tests/integration/test_migrations_0112_workflow_versions.py
+++ b/tests/integration/test_migrations_0112_workflow_versions.py
@@ -11,13 +11,12 @@ Covers the two halves the migration must get right:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # Two pre-existing workflows at different versions (0075-era in-place updates: the
 # head survives on the row, older snapshots are gone). The backfill snapshots the
@@ -29,16 +28,6 @@ INSERT INTO workflows (id, account_id, name, version, script)
 VALUES ('wf_a', 'acc_root', 'alpha', 1, 'SCRIPT_A'),
        ('wf_b', 'acc_root', 'beta', 5, 'SCRIPT_B');
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _fetch(db_url: str, sql: str, *args: object) -> list[asyncpg.Record]:
@@ -60,14 +49,14 @@ async def _execute(db_url: str, sql: str, *args: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_backfill_snapshots_each_workflow_head(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_backfill_snapshots_each_workflow_head(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0111"], db_url)
+    up = run_alembic(["upgrade", "0111"], db_url)
     assert up.returncode == 0, f"upgrade to 0111 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0112"], db_url)
+    up = run_alembic(["upgrade", "0112"], db_url)
     assert up.returncode == 0, f"upgrade to 0112 failed:\n{up.stderr}\n{up.stdout}"
 
     rows = asyncio.run(
@@ -87,10 +76,10 @@ def test_backfill_snapshots_each_workflow_head(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_version_rows_are_insert_only(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_version_rows_are_insert_only(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0112"], db_url)
+    up = run_alembic(["upgrade", "0112"], db_url)
     assert up.returncode == 0, f"upgrade to 0112 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
     asyncio.run(
@@ -113,11 +102,11 @@ def test_version_rows_are_insert_only(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_drops_table_and_constraint(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_downgrade_drops_table_and_constraint(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    assert _run_alembic(["upgrade", "0112"], db_url).returncode == 0
-    down = _run_alembic(["downgrade", "0111"], db_url)
+    assert run_alembic(["upgrade", "0112"], db_url).returncode == 0
+    down = run_alembic(["downgrade", "0111"], db_url)
     assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
 
     exists = asyncio.run(_fetch(db_url, "SELECT to_regclass('public.workflow_versions') AS t"))

--- a/tests/integration/test_migrations_0116_legacy_tool_names.py
+++ b/tests/integration/test_migrations_0116_legacy_tool_names.py
@@ -10,14 +10,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any, cast
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # A workflow whose declared surface mixes a plain builtin, two legacy names that collapse
 # to call_workflow, a renamed builtin, and a custom tool — plus a CLEAN workflow the gate
@@ -34,16 +33,6 @@ VALUES
   ('wf_clean', 'acc_root', 'clean', 1, 'S',
    '[{"type":"bash"},{"type":"call_workflow"}]'::jsonb);
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _fetch_tools(db_url: str, wf_id: str) -> list[dict[str, Any]]:
@@ -66,14 +55,14 @@ async def _execute(db_url: str, sql: str) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_legacy_tool_names_normalized_and_deduped(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_legacy_tool_names_normalized_and_deduped(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0115"], db_url)
+    up = run_alembic(["upgrade", "0115"], db_url)
     assert up.returncode == 0, f"upgrade to 0115 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0116"], db_url)
+    up = run_alembic(["upgrade", "0116"], db_url)
     assert up.returncode == 0, f"upgrade to 0116 failed:\n{up.stderr}\n{up.stdout}"
 
     # Legacy row: invoke_workflow + create_run collapse to ONE call_workflow (first wins),

--- a/tests/integration/test_migrations_0117_cancel_run_tool_name.py
+++ b/tests/integration/test_migrations_0117_cancel_run_tool_name.py
@@ -10,14 +10,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any, cast
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # wf_cxl: a legacy cancel_run amid a plain builtin + a custom tool. wf_both: already carries
 # stop_task too (the rename would duplicate it → dedupe to one). wf_clean: no legacy name.
@@ -34,16 +33,6 @@ VALUES
   ('wf_clean', 'acc_root', 'clean', 1, 'S',
    '[{"type":"bash"},{"type":"stop_task"}]'::jsonb);
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _fetch_tools(db_url: str, wf_id: str) -> list[dict[str, Any]]:
@@ -66,15 +55,15 @@ async def _execute(db_url: str, sql: str) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_cancel_run_tool_name_normalized_and_deduped(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_cancel_run_tool_name_normalized_and_deduped(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
     # Seed AFTER 0116 (which only touches the invoke* names) so the cancel_run rows are pristine.
-    up = _run_alembic(["upgrade", "0116"], db_url)
+    up = run_alembic(["upgrade", "0116"], db_url)
     assert up.returncode == 0, f"upgrade to 0116 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0117"], db_url)
+    up = run_alembic(["upgrade", "0117"], db_url)
     assert up.returncode == 0, f"upgrade to 0117 failed:\n{up.stderr}\n{up.stdout}"
 
     # Legacy row: cancel_run → stop_task, bash + custom untouched, original order preserved.

--- a/tests/integration/test_migrations_0118_wf_runs_source_version.py
+++ b/tests/integration/test_migrations_0118_wf_runs_source_version.py
@@ -14,13 +14,12 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 _SCRIPT_UNIQ = "async def main(input):\n    return 1\n"
 _SCRIPT_DUP = "async def main(input):\n    return 2\n"  # byte-identical across v1+v2 of wf_b
@@ -54,16 +53,6 @@ VALUES
 """
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _fetch(db_url: str, sql: str, *args: object) -> list[asyncpg.Record]:
     conn = await asyncpg.connect(db_url)
     try:
@@ -82,14 +71,14 @@ async def _execute(db_url: str, sql: str, *args: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_backfill_sets_unambiguous_and_leaves_ambiguous_null(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_backfill_sets_unambiguous_and_leaves_ambiguous_null(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0116"], db_url)
+    up = run_alembic(["upgrade", "0116"], db_url)
     assert up.returncode == 0, f"upgrade to 0116 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0118"], db_url)
+    up = run_alembic(["upgrade", "0118"], db_url)
     assert up.returncode == 0, f"upgrade to 0118 failed:\n{up.stderr}\n{up.stdout}"
 
     rows = asyncio.run(_fetch(db_url, "SELECT id, source_version FROM wf_runs ORDER BY id"))
@@ -102,10 +91,10 @@ def test_backfill_sets_unambiguous_and_leaves_ambiguous_null(postgres: object) -
 
 @needs_docker
 @pytest.mark.integration
-def test_composite_fk_rejects_dangling_pointer(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_composite_fk_rejects_dangling_pointer(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0118"], db_url)
+    up = run_alembic(["upgrade", "0118"], db_url)
     assert up.returncode == 0, f"upgrade to 0118 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
@@ -140,11 +129,11 @@ def test_composite_fk_rejects_dangling_pointer(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_drops_column_and_constraint(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_downgrade_drops_column_and_constraint(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    assert _run_alembic(["upgrade", "0118"], db_url).returncode == 0
-    down = _run_alembic(["downgrade", "0116"], db_url)
+    assert run_alembic(["upgrade", "0118"], db_url).returncode == 0
+    down = run_alembic(["downgrade", "0116"], db_url)
     assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
 
     cols = asyncio.run(

--- a/tests/integration/test_migrations_0119_memories_fts.py
+++ b/tests/integration/test_migrations_0119_memories_fts.py
@@ -21,13 +21,12 @@ Covers the deterministic acceptance from the design:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # Two tenants, two stores, two sessions; each session is attached to exactly
 # one store. The isolation invariant: a session only ever sees memories of its
@@ -78,16 +77,6 @@ def _insert_memory_sql(
     )
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _fetch(db_url: str, sql: str, *args: object) -> list[asyncpg.Record]:
     conn = await asyncpg.connect(db_url)
     try:
@@ -106,11 +95,11 @@ async def _execute(db_url: str, sql: str, *args: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_generated_column_and_gin_index_exist_and_populate(postgres: object) -> None:
+def test_generated_column_and_gin_index_exist_and_populate(migration_db_url: str) -> None:
     """The generated STORED column + GIN index exist and the vector is
     populated on insert with no trigger (generated-by-construction)."""
-    db_url = _alembic_url(postgres)
-    assert _run_alembic(["upgrade", "head"], db_url).returncode == 0
+    db_url = migration_db_url
+    assert run_alembic(["upgrade", "head"], db_url).returncode == 0
     asyncio.run(_execute(db_url, _SEED_SQL))
 
     # Column exists and is GENERATED STORED.
@@ -160,10 +149,10 @@ def test_generated_column_and_gin_index_exist_and_populate(postgres: object) -> 
 
 @needs_docker
 @pytest.mark.integration
-def test_memory_search_scoping(postgres: object) -> None:
+def test_memory_search_scoping(migration_db_url: str) -> None:
     """A session only sees memories of its own attached stores."""
-    db_url = _alembic_url(postgres)
-    assert _run_alembic(["upgrade", "head"], db_url).returncode == 0
+    db_url = migration_db_url
+    assert run_alembic(["upgrade", "head"], db_url).returncode == 0
     asyncio.run(_execute(db_url, _SEED_SQL))
     asyncio.run(
         _execute(
@@ -208,10 +197,10 @@ def test_memory_search_scoping(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_memory_search_rank_and_handler(postgres: object) -> None:
+def test_memory_search_rank_and_handler(migration_db_url: str) -> None:
     """The tool handler returns ts_rank DESC ordering, scoped to the session."""
-    db_url = _alembic_url(postgres)
-    assert _run_alembic(["upgrade", "head"], db_url).returncode == 0
+    db_url = migration_db_url
+    assert run_alembic(["upgrade", "head"], db_url).returncode == 0
     asyncio.run(_execute(db_url, _SEED_SQL))
     # mem_hi mentions the keyword many times → higher ts_rank than mem_lo.
     asyncio.run(
@@ -266,10 +255,10 @@ def test_memory_search_rank_and_handler(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_memory_search_soft_deleted_excluded(postgres: object) -> None:
+def test_memory_search_soft_deleted_excluded(migration_db_url: str) -> None:
     """A ``deleted_at``-stamped memory does not appear in the view."""
-    db_url = _alembic_url(postgres)
-    assert _run_alembic(["upgrade", "head"], db_url).returncode == 0
+    db_url = migration_db_url
+    assert run_alembic(["upgrade", "head"], db_url).returncode == 0
     asyncio.run(_execute(db_url, _SEED_SQL))
     asyncio.run(
         _execute(
@@ -314,11 +303,11 @@ def test_memory_search_soft_deleted_excluded(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_memory_search_runs_read_only(postgres: object) -> None:
+def test_memory_search_runs_read_only(migration_db_url: str) -> None:
     """The handler's execution path is READ ONLY — no mutation is possible
     even though the surface is a narrowed ``{query}`` (not raw SQL)."""
-    db_url = _alembic_url(postgres)
-    assert _run_alembic(["upgrade", "head"], db_url).returncode == 0
+    db_url = migration_db_url
+    assert run_alembic(["upgrade", "head"], db_url).returncode == 0
     asyncio.run(_execute(db_url, _SEED_SQL))
 
     async def _attempt_write() -> None:
@@ -337,10 +326,10 @@ def test_memory_search_runs_read_only(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_drops_view_index_and_column(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
-    assert _run_alembic(["upgrade", "0119"], db_url).returncode == 0
-    down = _run_alembic(["downgrade", "0118"], db_url)
+def test_downgrade_drops_view_index_and_column(migration_db_url: str) -> None:
+    db_url = migration_db_url
+    assert run_alembic(["upgrade", "0119"], db_url).returncode == 0
+    down = run_alembic(["downgrade", "0118"], db_url)
     assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
 
     cols = asyncio.run(

--- a/tests/integration/test_migrations_0120_drop_cancel_tool_name.py
+++ b/tests/integration/test_migrations_0120_drop_cancel_tool_name.py
@@ -10,14 +10,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any, cast
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # wf_cxl: cancel amid a plain builtin + a custom tool. wf_only: cancel alone → collapses to [].
 # wf_clean: no cancel (left untouched by the EXISTS gate).
@@ -34,16 +33,6 @@ VALUES
   ('wf_clean', 'acc_root', 'clean', 1, 'S',
    '[{"type":"bash"},{"type":"stop_task"}]'::jsonb);
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _fetch_tools(db_url: str, wf_id: str) -> list[dict[str, Any]]:
@@ -66,15 +55,15 @@ async def _execute(db_url: str, sql: str) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_cancel_tool_name_dropped(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_cancel_tool_name_dropped(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
     # Seed AFTER 0119 (the pre-0120 head) so the cancel rows are pristine.
-    up = _run_alembic(["upgrade", "0119"], db_url)
+    up = run_alembic(["upgrade", "0119"], db_url)
     assert up.returncode == 0, f"upgrade to 0119 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0120"], db_url)
+    up = run_alembic(["upgrade", "0120"], db_url)
     assert up.returncode == 0, f"upgrade to 0120 failed:\n{up.stderr}\n{up.stdout}"
 
     # cancel removed; bash + custom untouched, original order preserved.

--- a/tests/integration/test_migrations_0121_inbound_policy.py
+++ b/tests/integration/test_migrations_0121_inbound_policy.py
@@ -14,21 +14,20 @@ out of their own agent. These tests pin:
   leak into this connection's AllowList, and LIKE metacharacters are escaped;
 * a zero-history connection backfills fail-closed (NULL → resolves to DenyAll).
 
-Each test mutates ``alembic_version`` / seeds rows, so the container is
-function-scoped. Modeled on tests/integration/test_migrations_0108_*.
+Each test mutates ``alembic_version`` / seeds rows, so each test gets its
+own database. Modeled on tests/integration/test_migrations_0108_*.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # FK chain to head, then seed connections + chat_sessions + events at revision
 # 0120 (one BELOW our migration) so the 0120→0121 upgrade runs the backfill over
@@ -92,16 +91,6 @@ _EVENTS_SQL = (
 )
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -123,35 +112,35 @@ async def _fetch_policy(db_url: str, connection_id: str) -> object:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_and_clean_downgrade_round_trip(postgres: object) -> None:
+def test_upgrade_and_clean_downgrade_round_trip(migration_db_url: str) -> None:
     """0121 upgrades and downgrades cleanly with zero connection rows."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0121"], db_url)
+    up = run_alembic(["upgrade", "0121"], db_url)
     assert up.returncode == 0, f"upgrade to 0121 failed:\n{up.stderr}\n{up.stdout}"
 
-    down = _run_alembic(["downgrade", "0120"], db_url)
+    down = run_alembic(["downgrade", "0120"], db_url)
     assert down.returncode == 0, f"downgrade to 0120 failed:\n{down.stderr}\n{down.stdout}"
 
 
 @needs_docker
 @pytest.mark.integration
-def test_backfill_unions_ledger_and_slash_safe_history(postgres: object) -> None:
+def test_backfill_unions_ledger_and_slash_safe_history(migration_db_url: str) -> None:
     """The backfill writes an AllowList that is the UNION of the ledger and the
     slash-safe events scan, scoped to the connection's own prefix; a
     zero-history connection stays NULL (→ DenyAll)."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
     # Seed at 0120 (one below our migration) so the 0120→0121 upgrade backfills
     # over pre-existing rows.
-    up120 = _run_alembic(["upgrade", "0120"], db_url)
+    up120 = run_alembic(["upgrade", "0120"], db_url)
     assert up120.returncode == 0, f"upgrade to 0120 failed:\n{up120.stderr}\n{up120.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _CONNECTIONS_SQL))
     asyncio.run(_execute(db_url, _CHAT_SESSIONS_SQL))
     asyncio.run(_execute(db_url, _EVENTS_SQL))
 
-    up121 = _run_alembic(["upgrade", "0121"], db_url)
+    up121 = run_alembic(["upgrade", "0121"], db_url)
     assert up121.returncode == 0, f"upgrade to 0121 failed:\n{up121.stderr}\n{up121.stdout}"
 
     signal_policy = asyncio.run(_fetch_policy(db_url, "conn_signal"))

--- a/tests/integration/test_migrations_0122_drop_retired_goal_tool_names.py
+++ b/tests/integration/test_migrations_0122_drop_retired_goal_tool_names.py
@@ -13,14 +13,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any, cast
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # wf_goal: both retired verbs amid a plain builtin + a custom tool.
 # wf_only: complete_goal + fail_goal alone → collapses to [].
@@ -39,16 +38,6 @@ VALUES
   ('wf_clean', 'acc_root', 'clean', 1, 'S',
    '[{"type":"bash"},{"type":"create_goal"}]'::jsonb);
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _fetch_tools(db_url: str, wf_id: str) -> list[dict[str, Any]]:
@@ -71,15 +60,15 @@ async def _execute(db_url: str, sql: str) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_retired_goal_tool_names_dropped(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_retired_goal_tool_names_dropped(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
     # Seed AFTER 0121 (the pre-0122 head) so the retired rows are pristine.
-    up = _run_alembic(["upgrade", "0121"], db_url)
+    up = run_alembic(["upgrade", "0121"], db_url)
     assert up.returncode == 0, f"upgrade to 0121 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0122"], db_url)
+    up = run_alembic(["upgrade", "0122"], db_url)
     assert up.returncode == 0, f"upgrade to 0122 failed:\n{up.stderr}\n{up.stdout}"
 
     # Both retired verbs removed; bash + custom untouched, original order preserved.

--- a/tests/integration/test_migrations_0124_tools_vocab_epoch.py
+++ b/tests/integration/test_migrations_0124_tools_vocab_epoch.py
@@ -17,14 +17,13 @@ the migration against a real Postgres:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 from typing import Any
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # The seven surface tables and their backfill horizon (must match migration 0124).
 _SURFACE_TABLES = (
@@ -45,16 +44,6 @@ VALUES ('acc_root', NULL, TRUE, 'root');
 INSERT INTO workflows (id, account_id, name, version, script, tools)
 VALUES ('wf_old', 'acc_root', 'old', 1, 'S', '[{"type":"bash"}]'::jsonb);
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _fetchval(db_url: str, sql: str, *args: Any) -> Any:
@@ -83,15 +72,15 @@ async def _execute(db_url: str, sql: str) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_epoch_column_and_index_added_to_all_seven_surfaces(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_epoch_column_and_index_added_to_all_seven_surfaces(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
     # Seed an "old DB" row BEFORE 0124 so it has no epoch stamp.
-    up = _run_alembic(["upgrade", "0123"], db_url)
+    up = run_alembic(["upgrade", "0123"], db_url)
     assert up.returncode == 0, f"upgrade to 0123 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0124"], db_url)
+    up = run_alembic(["upgrade", "0124"], db_url)
     assert up.returncode == 0, f"upgrade to 0124 failed:\n{up.stderr}\n{up.stdout}"
 
     for table in _SURFACE_TABLES:
@@ -141,11 +130,11 @@ def test_epoch_column_and_index_added_to_all_seven_surfaces(postgres: object) ->
 
 @needs_docker
 @pytest.mark.integration
-def test_default_retained_so_omitting_column_yields_stale_row(postgres: object) -> None:
+def test_default_retained_so_omitting_column_yields_stale_row(migration_db_url: str) -> None:
     # A direct INSERT that does NOT name tools_vocab_epoch (a raw restore, a write
     # path that forgets it) must land at 0 — stale, never silently current.
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0124"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0124"], db_url)
     assert up.returncode == 0, f"upgrade to 0124 failed:\n{up.stderr}\n{up.stdout}"
 
     asyncio.run(
@@ -167,11 +156,11 @@ def test_default_retained_so_omitting_column_yields_stale_row(postgres: object) 
 
 @needs_docker
 @pytest.mark.integration
-def test_partial_index_powers_fast_boot_scan(postgres: object) -> None:
+def test_partial_index_powers_fast_boot_scan(migration_db_url: str) -> None:
     # The boot residue scan fast-paths a table to "clean" when MIN(epoch) >= horizon
     # (the partial stale index is empty); a stale row keeps the table in the scan.
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0124"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0124"], db_url)
     assert up.returncode == 0, f"upgrade to 0124 failed:\n{up.stderr}\n{up.stdout}"
 
     asyncio.run(

--- a/tests/integration/test_migrations_0128_inbound_budget_index.py
+++ b/tests/integration/test_migrations_0128_inbound_budget_index.py
@@ -13,7 +13,7 @@ plan whose scan node over ``events`` is an index scan on the new index rather
 than a ``Seq Scan``. On master (no index) the EXPLAIN assertion fails with a
 ``Seq Scan`` — this is the master-failing pin.
 
-Mirrors the testcontainer-Postgres shape of
+Mirrors the migration-test shape of
 ``test_migrations_0097_unique_tool_result.py`` and the ``EXPLAIN (FORMAT
 JSON)`` plan-shape assertion style of ``tests/e2e/test_sweep_perf.py``.
 """
@@ -22,14 +22,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # A minimal account/agent/env/session chain so admitted-inbound ``role=user``
 # events (and a wake-bearing lifecycle) have a session to hang off. The two
@@ -91,17 +90,6 @@ WHERE account_id = $1
 _INDEX_NAME = "events_inbound_budget_idx"
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -128,10 +116,10 @@ def _collect_nodes(plan_node: dict[str, Any]) -> list[dict[str, Any]]:
 
 @needs_docker
 @pytest.mark.integration
-def test_clean_database_creates_inbound_budget_index(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_clean_database_creates_inbound_budget_index(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
 
     indexdef = asyncio.run(
@@ -152,14 +140,14 @@ def test_clean_database_creates_inbound_budget_index(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_count_query_uses_index_not_seq_scan(postgres: object) -> None:
+def test_count_query_uses_index_not_seq_scan(migration_db_url: str) -> None:
     """The master-failing pin: EXPLAIN of the exact ``_count_recent_inbounds``
     query must seek the new index over ``events``, never a ``Seq Scan``. On
     master (no index) the only ``events`` scan is a ``Seq Scan`` and this
     assertion fails."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL + _EVENTS_SQL))
 

--- a/tests/integration/test_migrations_0129_drop_networking_allow_mcp_servers.py
+++ b/tests/integration/test_migrations_0129_drop_networking_allow_mcp_servers.py
@@ -20,14 +20,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any, cast
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # acc → three environments:
 #   env_mcp   — limited networking still carrying the dropped allow_mcp_servers key.
@@ -51,16 +50,6 @@ VALUES
 """
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _fetch_config(db_url: str, env_id: str) -> dict[str, Any]:
     conn = await asyncpg.connect(db_url)
     try:
@@ -81,15 +70,15 @@ async def _execute(db_url: str, sql: str) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_allow_mcp_servers_key_stripped(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_allow_mcp_servers_key_stripped(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
     # Seed AFTER 0128 (the pre-0129 head) so the offending row is pristine.
-    up = _run_alembic(["upgrade", "0128"], db_url)
+    up = run_alembic(["upgrade", "0128"], db_url)
     assert up.returncode == 0, f"upgrade to 0128 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0129"], db_url)
+    up = run_alembic(["upgrade", "0129"], db_url)
     assert up.returncode == 0, f"upgrade to 0129 failed:\n{up.stderr}\n{up.stdout}"
 
     # The key is gone; every sibling field is preserved verbatim.

--- a/tests/integration/test_migrations_0130_triggers_schedulable_armed.py
+++ b/tests/integration/test_migrations_0130_triggers_schedulable_armed.py
@@ -9,20 +9,19 @@ with a real zombie in the table does not abort; and that the arm is scoped to
 schedulable sources only — an enabled run_completion row keeps NULL
 ``next_fire`` under both the 0108 reactive arm and this schedulable arm.
 
-Each test mutates ``alembic_version``, so the container is function-scoped.
+Each test mutates ``alembic_version``, so each test gets its own database.
 Modeled on tests/integration/test_migrations_0108_triggers_external_event.py.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # FK chain for seeding a trigger row at head (NOT-NULL-without-default columns).
 _CHAIN_SQL = """
@@ -100,17 +99,6 @@ VALUES
 """
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -142,27 +130,27 @@ async def _fetchval(db_url: str, sql: str) -> object:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_and_clean_downgrade_round_trip(postgres: object) -> None:
+def test_upgrade_and_clean_downgrade_round_trip(migration_db_url: str) -> None:
     """With zero violator rows, 0130 upgrades and downgrades cleanly."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0130"], db_url)
+    up = run_alembic(["upgrade", "0130"], db_url)
     assert up.returncode == 0, f"upgrade to 0130 failed:\n{up.stderr}\n{up.stdout}"
 
-    down = _run_alembic(["downgrade", "0129"], db_url)
+    down = run_alembic(["downgrade", "0129"], db_url)
     assert down.returncode == 0, f"downgrade to 0129 failed:\n{down.stderr}\n{down.stdout}"
 
 
 @needs_docker
 @pytest.mark.integration
-def test_zombie_cron_rejected_under_new_check_accepted_under_old(postgres: object) -> None:
+def test_zombie_cron_rejected_under_new_check_accepted_under_old(migration_db_url: str) -> None:
     """An enabled cron row with NULL next_fire (the #925 zombie) is rejected at
     head (0130) and admitted at the prior revision (0129) — the CHECK is what
     makes the state unrepresentable."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
     # Under 0129 (prior head) the zombie is representable (the schema admits it).
-    up129 = _run_alembic(["upgrade", "0129"], db_url)
+    up129 = run_alembic(["upgrade", "0129"], db_url)
     assert up129.returncode == 0, f"upgrade to 0129 failed:\n{up129.stderr}\n{up129.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _ZOMBIE_CRON_ROW_SQL))
@@ -172,7 +160,7 @@ def test_zombie_cron_rejected_under_new_check_accepted_under_old(postgres: objec
     asyncio.run(_execute(db_url, "DELETE FROM triggers WHERE id = 'trig_zombie'"))
 
     # Under 0130 the same row is rejected.
-    up130 = _run_alembic(["upgrade", "0130"], db_url)
+    up130 = run_alembic(["upgrade", "0130"], db_url)
     assert up130.returncode == 0, f"upgrade to 0130 failed:\n{up130.stderr}\n{up130.stdout}"
     assert asyncio.run(_insert_raises(db_url, _ZOMBIE_CRON_ROW_SQL)), (
         "enabled cron with NULL next_fire must be rejected under 0130"
@@ -181,11 +169,11 @@ def test_zombie_cron_rejected_under_new_check_accepted_under_old(postgres: objec
 
 @needs_docker
 @pytest.mark.integration
-def test_zombie_one_shot_rejected_under_new_check(postgres: object) -> None:
+def test_zombie_one_shot_rejected_under_new_check(migration_db_url: str) -> None:
     """Settled fork 1: the schedulable arm covers one_shot too — an enabled
     one-shot with NULL next_fire is rejected under 0130."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0130"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0130"], db_url)
     assert up.returncode == 0, f"upgrade to 0130 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     assert asyncio.run(_insert_raises(db_url, _ZOMBIE_ONE_SHOT_ROW_SQL)), (
@@ -195,12 +183,12 @@ def test_zombie_one_shot_rejected_under_new_check(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_legitimate_rows_still_insert(postgres: object) -> None:
+def test_legitimate_rows_still_insert(migration_db_url: str) -> None:
     """The CHECK admits every legitimate shape: an armed enabled cron, a
     disabled cron with NULL next_fire, and an enabled reactive (run_completion)
     row with NULL next_fire (excluded from the schedulable arm)."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0130"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0130"], db_url)
     assert up.returncode == 0, f"upgrade to 0130 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
 
@@ -212,15 +200,15 @@ def test_legitimate_rows_still_insert(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_auto_disables_preexisting_violators(postgres: object) -> None:
+def test_upgrade_auto_disables_preexisting_violators(migration_db_url: str) -> None:
     """The 0066 lesson: pre-existing violator rows are DISABLED before the
     validating ADD CONSTRAINT, so the migrate succeeds on a table that already
     holds a #925 zombie — and the auto-disable is behaviorally a no-op (the row
     never fired), leaving the row present but ``enabled = false``."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
     # Seed zombies (cron + one_shot) at the prior revision, then migrate.
-    up129 = _run_alembic(["upgrade", "0129"], db_url)
+    up129 = run_alembic(["upgrade", "0129"], db_url)
     assert up129.returncode == 0, f"upgrade to 0129 failed:\n{up129.stderr}\n{up129.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
     asyncio.run(_execute(db_url, _ZOMBIE_CRON_ROW_SQL))
@@ -228,7 +216,7 @@ def test_upgrade_auto_disables_preexisting_violators(postgres: object) -> None:
     # A legitimately armed row must survive untouched.
     asyncio.run(_execute(db_url, _ARMED_CRON_ROW_SQL))
 
-    up130 = _run_alembic(["upgrade", "0130"], db_url)
+    up130 = run_alembic(["upgrade", "0130"], db_url)
     assert up130.returncode == 0, (
         f"upgrade to 0130 must not abort on pre-existing zombies:\n{up130.stderr}\n{up130.stdout}"
     )

--- a/tests/integration/test_migrations_0133_sessions_channels_array.py
+++ b/tests/integration/test_migrations_0133_sessions_channels_array.py
@@ -3,35 +3,22 @@
 Migration 0133 adds ``sessions.channels text[] NOT NULL DEFAULT '{}'`` and
 backfills existing rows from the event log's DISTINCT channel set
 (issue #1742). These tests seed sessions + events directly via SQL (the
-pre-migration schema shape), run the real alembic CLI up to head, and
+pre-migration schema shape), run the real alembic chain up to head, and
 assert the backfilled array matches the DISTINCT-channel set the old
 ``list_session_channels`` query would have returned — including the
 zero-channel case, which must land as ``'{}'`` rather than NULL.
 
-Mirrors the testcontainer-Postgres/real-alembic-CLI pattern of
+Mirrors the migration-test pattern of
 ``test_migrations_workspace_path_backfill.py``.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 
 async def _seed(db_url: str) -> None:
@@ -129,17 +116,17 @@ async def _channels(db_url: str) -> dict[str, list[str]]:
 
 @needs_docker
 @pytest.mark.integration
-def test_backfill_matches_distinct_channel_sets(postgres: object) -> None:
+def test_backfill_matches_distinct_channel_sets(migration_db_url: str) -> None:
     import asyncio
 
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "0131"], db_url)
+    result = run_alembic(["upgrade", "0131"], db_url)
     assert result.returncode == 0, result.stderr
 
     asyncio.run(_seed(db_url))
 
-    result = _run_alembic(["upgrade", "0133"], db_url)
+    result = run_alembic(["upgrade", "0133"], db_url)
     assert result.returncode == 0, result.stderr
 
     channels = asyncio.run(_channels(db_url))
@@ -150,15 +137,15 @@ def test_backfill_matches_distinct_channel_sets(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_drops_column(postgres: object) -> None:
+def test_downgrade_drops_column(migration_db_url: str) -> None:
     import asyncio
 
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, result.stderr
 
-    result = _run_alembic(["downgrade", "0131"], db_url)
+    result = run_alembic(["downgrade", "0131"], db_url)
     assert result.returncode == 0, result.stderr
 
     async def _has_column() -> bool:

--- a/tests/integration/test_migrations_0134_confirmed_allow_recent_index.py
+++ b/tests/integration/test_migrations_0134_confirmed_allow_recent_index.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any
 
 import asyncpg
@@ -44,8 +43,8 @@ import pytest
 
 from aios.db.queries.events import confirmed_unresolved_predicate
 from aios.harness.sweep import CONFIRMED_ROWS_SQL
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 _INDEX_NAME = "events_tool_confirmed_allow_recent_idx"
 
@@ -106,17 +105,6 @@ FROM generate_series(1, {_NOISE_ROW_COUNT}) AS i;
 _CONFIRMED_ROWS_SQL_TEXT = CONFIRMED_ROWS_SQL.format(scope_clause="", age_param="$1")
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -143,10 +131,10 @@ def _collect_nodes(plan_node: dict[str, Any]) -> list[dict[str, Any]]:
 
 @needs_docker
 @pytest.mark.integration
-def test_clean_database_creates_confirmed_allow_recent_index(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_clean_database_creates_confirmed_allow_recent_index(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
 
     indexdef = asyncio.run(
@@ -179,14 +167,14 @@ def test_clean_database_creates_confirmed_allow_recent_index(postgres: object) -
 
 @needs_docker
 @pytest.mark.integration
-def test_confirmed_rows_sql_uses_index_not_seq_scan(postgres: object) -> None:
+def test_confirmed_rows_sql_uses_index_not_seq_scan(migration_db_url: str) -> None:
     """The master-failing pin: EXPLAIN of the exact ``CONFIRMED_ROWS_SQL`` text
     must prune at the new index (``Index Cond`` on ``created_at``), never a
     ``Seq Scan`` over ``events`` for the ``lc`` node. On master (no index) the
     only access path is a ``Seq Scan`` and this assertion fails."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL + _EVENTS_SQL + _NOISE_SQL))
     asyncio.run(_execute(db_url, "ANALYZE"))

--- a/tests/integration/test_migrations_0135_lifecycle_seq_idx.py
+++ b/tests/integration/test_migrations_0135_lifecycle_seq_idx.py
@@ -29,7 +29,7 @@ is exactly the property #1741 is about and the shape a real heavy session has.
 Mirrors the sibling ``test_migrations_0134_confirmed_allow_recent_index.py`` /
 e2e ``TestLifecycleArmPlanShapeGate`` production-shaped-fixture approach.
 
-Mirrors ``test_migrations_0128_inbound_budget_index.py``'s testcontainer +
+Mirrors ``test_migrations_0128_inbound_budget_index.py``'s fresh-database +
 ``EXPLAIN (FORMAT JSON)`` plan-shape style.
 """
 
@@ -37,14 +37,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 from typing import Any
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 _INDEX_NAME = "events_session_lifecycle_seq_idx"
 
@@ -116,17 +115,6 @@ ORDER BY seq ASC
 """
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -153,10 +141,10 @@ def _collect_nodes(plan_node: dict[str, Any]) -> list[dict[str, Any]]:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_creates_lifecycle_index(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_upgrade_creates_lifecycle_index(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
 
     indexdef = asyncio.run(
@@ -176,17 +164,17 @@ def test_upgrade_creates_lifecycle_index(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_downgrade_roundtrip(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_upgrade_downgrade_roundtrip(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
 
     # Target this migration's own down_revision explicitly rather than the
     # relative "-1" — head has since grown a sibling migration (0136,
     # renumbered from 0132/0134 per #1746) chained after this one, so "-1"
     # from head would only undo 0136 and leave this index in place.
-    down = _run_alembic(["downgrade", "0134"], db_url)
+    down = run_alembic(["downgrade", "0134"], db_url)
     assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
 
     indexdef = asyncio.run(
@@ -198,7 +186,7 @@ def test_upgrade_downgrade_roundtrip(postgres: object) -> None:
     )
     assert indexdef is None, f"{_INDEX_NAME} still present after downgrade"
 
-    up_again = _run_alembic(["upgrade", "head"], db_url)
+    up_again = run_alembic(["upgrade", "head"], db_url)
     assert up_again.returncode == 0, (
         f"re-upgrade after downgrade failed:\n{up_again.stderr}\n{up_again.stdout}"
     )
@@ -206,7 +194,7 @@ def test_upgrade_downgrade_roundtrip(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_lifecycle_arm_uses_index_not_seq_scan(postgres: object) -> None:
+def test_lifecycle_arm_uses_index_not_seq_scan(migration_db_url: str) -> None:
     """The master-failing pin: EXPLAIN of the exact lifecycle arm must not
     heap-filter ``kind = 'lifecycle'`` over a whole-session scan. On master
     (no partial index) the ``events`` scan carries a residual
@@ -217,9 +205,9 @@ def test_lifecycle_arm_uses_index_not_seq_scan(postgres: object) -> None:
     production-shaped (messages dominate) so this is a genuine cost decision:
     on an all-lifecycle table the partial index has no selectivity edge and
     the planner picks ``created_at`` within cost noise (see module docstring)."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL + _EVENTS_SQL))
 

--- a/tests/integration/test_migrations_0144_search_views.py
+++ b/tests/integration/test_migrations_0144_search_views.py
@@ -44,15 +44,15 @@ import asyncio
 import hashlib
 import importlib
 import json
-from collections.abc import Iterator
+from collections.abc import Callable
 from typing import Any
 
 import asyncpg
 import pytest
 
 from aios.tools.search_events import _ALLOWED_RELATIONS
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # ---------------------------------------------------------------------------
 # Seed: two tenants, two sessions. Session X carries the full menagerie —
@@ -580,19 +580,14 @@ def test_lifecycle_redaction_vocabulary_alignment() -> None:
 
 
 @pytest.fixture(scope="module")
-def db_url() -> Iterator[str]:
-    """One container + one ``upgrade head`` + one seed for the whole module —
+def db_url(migration_db_factory: Callable[[], str]) -> str:
+    """One database + one ``upgrade head`` + one seed for the whole module —
     every test below is read-only (the EXPLAIN test's DDL is rolled back)."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        url = _alembic_url(pg)
-        result = _run_alembic(["upgrade", "head"], url)
-        assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
-        asyncio.run(_seed(url))
-        yield url
+    url = migration_db_factory()
+    result = run_alembic(["upgrade", "head"], url)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+    asyncio.run(_seed(url))
+    return url
 
 
 async def _seed(db_url: str) -> None:

--- a/tests/integration/test_migrations_0154_rehome_fleet.py
+++ b/tests/integration/test_migrations_0154_rehome_fleet.py
@@ -11,9 +11,7 @@ import asyncio
 import base64
 import importlib.util
 import os
-import shutil
 import subprocess
-from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -22,8 +20,8 @@ import asyncpg
 import pytest
 from nacl.secret import SecretBox
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import PROJECT_ROOT, _alembic_url
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 pytestmark = pytest.mark.integration
 
@@ -111,33 +109,9 @@ def test_revision_and_transactional_upgrade_downgrade_contract() -> None:
     assert migration.upgrade.__module__ == migration.downgrade.__module__
 
 
-@pytest.fixture
-def postgres() -> Iterator[Any]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 def _run_alembic(args: list[str], db_url: str, key: bytes) -> subprocess.CompletedProcess[str]:
-    uv = shutil.which("uv")
-    if uv is None:
-        raise FileNotFoundError("uv not found on PATH")
-    return subprocess.run(
-        [uv, "run", "alembic", *args],
-        cwd=PROJECT_ROOT,
-        env={
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin:/usr/local/bin"),
-            "HOME": str(Path.home()),
-            "AIOS_DB_URL": db_url,
-            "AIOS_VAULT_KEY": base64.b64encode(key).decode(),
-        },
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    """``run_alembic`` with the vault key threaded — 0154 re-encrypts vault rows."""
+    return run_alembic(args, db_url, extra_env={"AIOS_VAULT_KEY": base64.b64encode(key).decode()})
 
 
 async def _composite_fks(db_url: str) -> set[tuple[str, str]]:
@@ -411,9 +385,9 @@ async def _assert_restored(
 
 
 @needs_docker
-def test_downgrade_handles_nested_eumemic_name(postgres: Any) -> None:
+def test_downgrade_handles_nested_eumemic_name(migration_db_url: str) -> None:
     """A post-cutover Eumemic child must survive downgrade beneath root."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     key = os.urandom(SecretBox.KEY_SIZE)
     assert _run_alembic(["upgrade", "0152"], db_url, key).returncode == 0
 
@@ -481,8 +455,8 @@ def test_downgrade_handles_nested_eumemic_name(postgres: Any) -> None:
 
 
 @needs_docker
-def test_real_postgres_upgrade_and_downgrade_round_trip(postgres: Any) -> None:
-    db_url = _alembic_url(postgres)
+def test_real_postgres_upgrade_and_downgrade_round_trip(migration_db_url: str) -> None:
+    db_url = migration_db_url
     key = os.urandom(SecretBox.KEY_SIZE)
     migration = _migration()
     master = migration._Box(key)

--- a/tests/integration/test_migrations_0165_reparent_stranded.py
+++ b/tests/integration/test_migrations_0165_reparent_stranded.py
@@ -26,33 +26,26 @@ import os
 import re
 import shutil
 import subprocess
-from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 
 import asyncpg
 import pytest
 from nacl.secret import SecretBox
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import PROJECT_ROOT, _alembic_url
+from tests.conftest import PROJECT_ROOT, needs_docker
 
 pytestmark = pytest.mark.integration
 
 _MIGRATION_0154 = PROJECT_ROOT / "migrations" / "versions" / "0154_rehome_fleet_to_eumemic_child.py"
 
 
-@pytest.fixture
-def postgres() -> Iterator[Any]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 def _run_alembic(args: list[str], db_url: str, key: bytes) -> subprocess.CompletedProcess[str]:
+    """Subprocess on purpose — do NOT switch to the in-process runner.
+
+    ``_PreFix0154`` rewrites ``migrations/versions/0154_*.py`` on disk between
+    invocations; a fresh interpreter guarantees alembic loads the rewritten
+    file rather than anything a previous in-process run left cached.
+    """
     uv = shutil.which("uv")
     if uv is None:
         raise FileNotFoundError("uv not found on PATH")
@@ -189,9 +182,9 @@ async def _account_tree(db_url: str) -> list[tuple[str, str | None, str]]:
 
 
 @needs_docker
-def test_0165_repairs_a_database_the_original_0154_stranded(postgres: Any) -> None:
+def test_0165_repairs_a_database_the_original_0154_stranded(migration_db_url: str) -> None:
     """RED then GREEN on the state production is actually in."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     key = os.urandom(SecretBox.KEY_SIZE)
 
     assert _run_alembic(["upgrade", "0152"], db_url, key).returncode == 0
@@ -274,9 +267,9 @@ def test_0165_repairs_a_database_the_original_0154_stranded(postgres: Any) -> No
 
 
 @needs_docker
-def test_0165_is_idempotent(postgres: Any) -> None:
+def test_0165_is_idempotent(migration_db_url: str) -> None:
     """Re-running the forward migration changes nothing."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     key = os.urandom(SecretBox.KEY_SIZE)
 
     assert _run_alembic(["upgrade", "0152"], db_url, key).returncode == 0
@@ -298,9 +291,9 @@ def test_0165_is_idempotent(postgres: Any) -> None:
 
 
 @needs_docker
-def test_0165_leaves_a_never_defective_database_untouched(postgres: Any) -> None:
+def test_0165_leaves_a_never_defective_database_untouched(migration_db_url: str) -> None:
     """Positive control: a fresh DB migrated by the corrected 0154."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     key = os.urandom(SecretBox.KEY_SIZE)
 
     assert _run_alembic(["upgrade", "0152"], db_url, key).returncode == 0
@@ -319,9 +312,9 @@ def test_0165_leaves_a_never_defective_database_untouched(postgres: Any) -> None
 
 
 @needs_docker
-def test_0165_noops_without_a_migration_owned_eumemic_child(postgres: Any) -> None:
+def test_0165_noops_without_a_migration_owned_eumemic_child(migration_db_url: str) -> None:
     """An operator-created account merely named Eumemic is not the marker."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     key = os.urandom(SecretBox.KEY_SIZE)
 
     assert _run_alembic(["upgrade", "0159"], db_url, key).returncode == 0

--- a/tests/integration/test_migrations_0169_creation_edge_usage.py
+++ b/tests/integration/test_migrations_0169_creation_edge_usage.py
@@ -9,7 +9,6 @@ target's historical or future subtree spend to that caller.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import cast
 
@@ -17,8 +16,8 @@ import asyncpg
 import psycopg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 _SEED_SQL = r"""
 INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
@@ -54,16 +53,6 @@ VALUES
      '"caller":{"kind":"session","id":"ses_caller_0169","awaited":true}}'::jsonb,
      'acc_0169');
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _execute(db_url: str, sql: str) -> None:
@@ -155,14 +144,14 @@ async def _workflow_spend_watermark(db_url: str) -> tuple[int, int, int]:
 
 @needs_docker
 @pytest.mark.integration
-def test_backfill_does_not_infer_creation_from_archive_when_idle(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_backfill_does_not_infer_creation_from_archive_when_idle(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "0166"], db_url)
+    up = run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _SEED_SQL))
 
-    up = _run_alembic(["upgrade", "0169"], db_url)
+    up = run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
 
     # The invocation-only edge remains unowned even though the target opted
@@ -178,10 +167,10 @@ def test_backfill_does_not_infer_creation_from_archive_when_idle(postgres: objec
     [(0, 0), (100, 100), (50, 50)],
 )
 def test_historical_workflow_spend_is_reconciled_exactly_once(
-    postgres: object, *, spent_microusd: int, accounted_microusd: int
+    migration_db_url: str, *, spent_microusd: int, accounted_microusd: int
 ) -> None:
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0166"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(
         _seed_workflow_spend(
@@ -190,11 +179,11 @@ def test_historical_workflow_spend_is_reconciled_exactly_once(
             run_cost_microusd=100,
         )
     )
-    up = _run_alembic(["upgrade", "0168"], db_url)
+    up = run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend_watermark(db_url, accounted_microusd))
 
-    up = _run_alembic(["upgrade", "0169"], db_url)
+    up = run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
     assert asyncio.run(_account_spend(db_url)) == 100
     assert asyncio.run(_workflow_spend_watermark(db_url)) == (
@@ -218,12 +207,12 @@ def test_historical_workflow_spend_is_reconciled_exactly_once(
 
 @needs_docker
 @pytest.mark.integration
-def test_old_writer_commit_across_migration_snapshot_is_not_lost(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0166"], db_url)
+def test_old_writer_commit_across_migration_snapshot_is_not_lost(migration_db_url: str) -> None:
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=0, run_cost_microusd=100))
-    up = _run_alembic(["upgrade", "0168"], db_url)
+    up = run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
 
@@ -234,7 +223,7 @@ def test_old_writer_commit_across_migration_snapshot_is_not_lost(postgres: objec
             "UPDATE wf_runs SET call_llm_cost_microusd = "
             "call_llm_cost_microusd + 40 WHERE id = 'run_spend_0169'"
         )
-        future = executor.submit(_run_alembic, ["upgrade", "0169"], db_url)
+        future = executor.submit(run_alembic, ["upgrade", "0169"], db_url)
         assert not future.done()
         writer.commit()
         up = future.result(timeout=30)
@@ -246,15 +235,15 @@ def test_old_writer_commit_across_migration_snapshot_is_not_lost(postgres: objec
 
 @needs_docker
 @pytest.mark.integration
-def test_missing_workflow_spend_watermark_fails_closed(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0166"], db_url)
+def test_missing_workflow_spend_watermark_fails_closed(migration_db_url: str) -> None:
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=50, run_cost_microusd=100))
-    up = _run_alembic(["upgrade", "0168"], db_url)
+    up = run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
 
-    up = _run_alembic(["upgrade", "0169"], db_url)
+    up = run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode != 0
     assert "missing workflow spend accounting watermark" in up.stderr
     assert asyncio.run(_account_spend(db_url)) == 50
@@ -262,16 +251,16 @@ def test_missing_workflow_spend_watermark_fails_closed(postgres: object) -> None
 
 @needs_docker
 @pytest.mark.integration
-def test_workflow_spend_watermark_above_retained_cost_fails_closed(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0166"], db_url)
+def test_workflow_spend_watermark_above_retained_cost_fails_closed(migration_db_url: str) -> None:
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=101, run_cost_microusd=100))
-    up = _run_alembic(["upgrade", "0168"], db_url)
+    up = run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend_watermark(db_url, 101))
 
-    up = _run_alembic(["upgrade", "0169"], db_url)
+    up = run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode != 0
     assert "workflow spend accounting watermark exceeds retained run cost" in up.stderr
     assert asyncio.run(_account_spend(db_url)) == 101
@@ -279,18 +268,18 @@ def test_workflow_spend_watermark_above_retained_cost_fails_closed(postgres: obj
 
 @needs_docker
 @pytest.mark.integration
-def test_coincidental_aggregate_equality_does_not_fake_provenance(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0166"], db_url)
+def test_coincidental_aggregate_equality_does_not_fake_provenance(migration_db_url: str) -> None:
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     # The existing 100 is unrelated spend. Its equality with the retained run
     # meter proves nothing about whether that run was charged.
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=100, run_cost_microusd=100))
-    up = _run_alembic(["upgrade", "0168"], db_url)
+    up = run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
 
-    up = _run_alembic(["upgrade", "0169"], db_url)
+    up = run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
     assert asyncio.run(_account_spend(db_url)) == 200
     assert asyncio.run(_workflow_spend_watermark(db_url)) == (100, 100, 100)
@@ -299,10 +288,10 @@ def test_coincidental_aggregate_equality_does_not_fake_provenance(postgres: obje
 @needs_docker
 @pytest.mark.integration
 def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
-    postgres: object,
+    migration_db_url: str,
 ) -> None:
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "0166"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "0166"], db_url)
     assert up.returncode == 0, f"upgrade to 0166 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend(db_url, spent_microusd=0, run_cost_microusd=100))
     asyncio.run(
@@ -315,10 +304,10 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
             ' \'{"result":{"usage":{"input_tokens":"17"}}}\'::jsonb)',
         )
     )
-    up = _run_alembic(["upgrade", "0168"], db_url)
+    up = run_alembic(["upgrade", "0168"], db_url)
     assert up.returncode == 0, f"upgrade to 0168 failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_seed_workflow_spend_watermark(db_url, 0))
-    up = _run_alembic(["upgrade", "0169"], db_url)
+    up = run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode == 0, f"upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
 
     async def _usage_state() -> tuple[tuple[int, int, bool], int, object]:
@@ -364,7 +353,7 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
     before_downgrade = asyncio.run(_usage_state())
     assert before_downgrade[:2] == ((17, 9, False), 23)
 
-    down = _run_alembic(["downgrade", "0166"], db_url)
+    down = run_alembic(["downgrade", "0166"], db_url)
     assert down.returncode == 0, f"downgrade to 0166 failed:\n{down.stderr}\n{down.stdout}"
 
     async def _archived_state() -> tuple[tuple[int, int, bool], int, int, int]:
@@ -404,7 +393,7 @@ def test_historical_tokens_are_incomplete_and_downgrade_is_lossless(
 
     assert asyncio.run(_archived_state()) == ((17, 9, False), 23, 100, 100)
 
-    up = _run_alembic(["upgrade", "0169"], db_url)
+    up = run_alembic(["upgrade", "0169"], db_url)
     assert up.returncode == 0, f"re-upgrade to 0169 failed:\n{up.stderr}\n{up.stdout}"
     restored = asyncio.run(_usage_state())
     assert restored[:2] == ((17, 9, False), 23)

--- a/tests/integration/test_migrations_environment_variable.py
+++ b/tests/integration/test_migrations_environment_variable.py
@@ -7,19 +7,18 @@ Pins two behaviors of the round-trip against a real Postgres:
     dropped, so the migration aborts (preserving ``secret_name``/
     ``allowed_hosts``) rather than silently destroying the data.
 
-Each test mutates ``alembic_version``, so the container is function-scoped.
+Each test mutates ``alembic_version``, so each test gets its own database.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 _ACCOUNT_SQL = """
 INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
@@ -43,17 +42,6 @@ VALUES (
     '\x00'::bytea, '\x00'::bytea, '{}'::jsonb
 )
 """
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _vault_credentials_columns(db_url: str) -> set[str]:
@@ -86,33 +74,33 @@ async def _row_exists(db_url: str, cred_id: str) -> bool:
 
 @needs_docker
 @pytest.mark.integration
-def test_clean_round_trip(postgres: object) -> None:
+def test_clean_round_trip(migration_db_url: str) -> None:
     """Upgrade adds the columns; downgrade (no env-var rows) removes them; re-upgrade restores."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
     cols = asyncio.run(_vault_credentials_columns(db_url))
     assert {"secret_name", "allowed_hosts"} <= cols
 
-    down = _run_alembic(["downgrade", "0080"], db_url)
+    down = run_alembic(["downgrade", "0080"], db_url)
     assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
     cols = asyncio.run(_vault_credentials_columns(db_url))
     assert "secret_name" not in cols
     assert "allowed_hosts" not in cols
 
-    reup = _run_alembic(["upgrade", "head"], db_url)
+    reup = run_alembic(["upgrade", "head"], db_url)
     assert reup.returncode == 0, f"re-upgrade failed:\n{reup.stderr}\n{reup.stdout}"
 
 
 @needs_docker
 @pytest.mark.integration
-def test_env_var_row_accepted_and_blocks_downgrade(postgres: object) -> None:
+def test_env_var_row_accepted_and_blocks_downgrade(migration_db_url: str) -> None:
     """An env-var row passes the widened CHECKs; the downgrade then fails loud,
     preserving the row rather than dropping its columns."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    up = _run_alembic(["upgrade", "head"], db_url)
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
 
     # The widened auth_type CHECK + shape CHECK + secret_name uniq index all
@@ -123,7 +111,7 @@ def test_env_var_row_accepted_and_blocks_downgrade(postgres: object) -> None:
 
     # Downgrade must abort: the narrowed auth_type CHECK is re-added before the
     # columns are dropped, so the env-var row blocks it fail-loud.
-    down = _run_alembic(["downgrade", "0080"], db_url)
+    down = run_alembic(["downgrade", "0080"], db_url)
     assert down.returncode != 0, f"downgrade should have failed loud:\n{down.stdout}"
 
     # The row (and its secret_name/allowed_hosts columns) survived intact.

--- a/tests/integration/test_migrations_reparent.py
+++ b/tests/integration/test_migrations_reparent.py
@@ -8,7 +8,7 @@ from globally exclusive to per-account:
   ``(account_id, connector, external_account_id) WHERE archived_at IS NULL``.
 * downgrade: drops the per-account index, restores the global one.
 
-These tests exercise the real alembic CLI against a fresh Postgres so
+These tests run the real alembic chain against a fresh database so
 each scenario gets an isolated ``alembic_version`` and ``connections``
 catalog state.
 """
@@ -16,24 +16,12 @@ catalog state.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 
 async def _connections_indexes(db_url: str) -> set[str]:
@@ -59,11 +47,11 @@ async def _version_num(db_url: str) -> str:
 
 @needs_docker
 @pytest.mark.integration
-def test_upgrade_to_0060_swaps_index_to_per_account(postgres: object) -> None:
+def test_upgrade_to_0060_swaps_index_to_per_account(migration_db_url: str) -> None:
     """After upgrade to 0060: per-account index present, global index gone."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "0060"], db_url)
+    result = run_alembic(["upgrade", "0060"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
 
     indexes = asyncio.run(_connections_indexes(db_url))
@@ -74,14 +62,14 @@ def test_upgrade_to_0060_swaps_index_to_per_account(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_to_0059_restores_global_index(postgres: object) -> None:
+def test_downgrade_to_0059_restores_global_index(migration_db_url: str) -> None:
     """Downgrade 0060 -> 0059 restores the pre-migration global index."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "0060"], db_url)
+    result = run_alembic(["upgrade", "0060"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
 
-    result = _run_alembic(["downgrade", "0059"], db_url)
+    result = run_alembic(["downgrade", "0059"], db_url)
     assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
 
     indexes = asyncio.run(_connections_indexes(db_url))
@@ -92,7 +80,7 @@ def test_downgrade_to_0059_restores_global_index(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_up_down_up_is_idempotent(postgres: object) -> None:
+def test_up_down_up_is_idempotent(migration_db_url: str) -> None:
     """``upgrade -> downgrade -> upgrade`` lands on the same per-account index.
 
     Idempotency here means "the migration is reversible and re-applicable" —
@@ -101,13 +89,13 @@ def test_up_down_up_is_idempotent(postgres: object) -> None:
     re-application safe even when the previous step leaves the catalog in
     an unexpected state.
     """
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "0060"], db_url)
+    result = run_alembic(["upgrade", "0060"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
-    result = _run_alembic(["downgrade", "0059"], db_url)
+    result = run_alembic(["downgrade", "0059"], db_url)
     assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
-    result = _run_alembic(["upgrade", "0060"], db_url)
+    result = run_alembic(["upgrade", "0060"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
 
     indexes = asyncio.run(_connections_indexes(db_url))

--- a/tests/integration/test_migrations_session_frozen_litellm_extra.py
+++ b/tests/integration/test_migrations_session_frozen_litellm_extra.py
@@ -16,26 +16,14 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 pytestmark = pytest.mark.integration
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _seed_at_0103(db_url: str) -> None:
@@ -120,15 +108,15 @@ async def _seed_at_0103(db_url: str) -> None:
 
 
 @needs_docker
-def test_backfill_freezes_in_flight_children_model_identity(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_backfill_freezes_in_flight_children_model_identity(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "0103"], db_url)
+    result = run_alembic(["upgrade", "0103"], db_url)
     assert result.returncode == 0, f"upgrade 0103 failed:\n{result.stderr}\n{result.stdout}"
 
     asyncio.run(_seed_at_0103(db_url))
 
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, (
         f"upgrade head (0104 backfill) failed:\n{result.stderr}\n{result.stdout}"
     )

--- a/tests/integration/test_migrations_session_frozen_surface.py
+++ b/tests/integration/test_migrations_session_frozen_surface.py
@@ -16,26 +16,14 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 pytestmark = pytest.mark.integration
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 async def _seed_at_0078(db_url: str) -> None:
@@ -104,15 +92,15 @@ async def _seed_at_0078(db_url: str) -> None:
 
 
 @needs_docker
-def test_backfill_freezes_in_flight_children(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
+def test_backfill_freezes_in_flight_children(migration_db_url: str) -> None:
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "0078"], db_url)
+    result = run_alembic(["upgrade", "0078"], db_url)
     assert result.returncode == 0, f"upgrade 0078 failed:\n{result.stderr}\n{result.stdout}"
 
     asyncio.run(_seed_at_0078(db_url))
 
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, (
         f"upgrade head (0079 backfill) failed:\n{result.stderr}\n{result.stdout}"
     )

--- a/tests/integration/test_migrations_session_status_backfill.py
+++ b/tests/integration/test_migrations_session_status_backfill.py
@@ -33,7 +33,7 @@ These tests:
   completes well under the wall-clock budget a correlated form would blow.
 
 Mirrors ``test_migrations_workspace_path_backfill.py`` (seed-at-N then
-upgrade-to-head against a fresh per-test Postgres).
+upgrade-to-head against a fresh per-test database).
 """
 
 from __future__ import annotations
@@ -41,31 +41,15 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import Iterator
 from typing import Any
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import (
-    PROJECT_ROOT,
-    _alembic_url,
-    _run_alembic,
-)
+from tests.conftest import PROJECT_ROOT, needs_docker
+from tests.helpers.alembic import run_alembic
 
 pytestmark = pytest.mark.integration
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
 
 
 # ─── direct-SQL seeding (bypasses the service layer) ─────────────────────────
@@ -249,20 +233,20 @@ async def _seed_rich(db_url: str) -> None:
 
 
 @needs_docker
-def test_backfill_computes_every_scalar(postgres: object) -> None:
+def test_backfill_computes_every_scalar(migration_db_url: str) -> None:
     """After ``upgrade head`` runs 0066's backfill, each scalar on each seeded
     session equals its independently-computed expected value."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
     # Stop at 0065 so the scalar columns don't exist yet and we can seed the
     # legacy (pre-0066) event log directly.
-    result = _run_alembic(["upgrade", "0065"], db_url)
+    result = run_alembic(["upgrade", "0065"], db_url)
     assert result.returncode == 0, f"upgrade 0065 failed:\n{result.stderr}\n{result.stdout}"
 
     asyncio.run(_seed_rich(db_url))
 
     # Run 0066's backfill.
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, (
         "upgrade head (0066 backfill) failed — note the bare correlated form "
         f"ERRORS on the 'tool_calls': null shape:\n{result.stderr}\n{result.stdout}"
@@ -348,7 +332,7 @@ def test_migration_backfill_is_not_correlated() -> None:
 
 
 @needs_docker
-def test_backfill_bounded_on_a_large_session(postgres: object) -> None:
+def test_backfill_bounded_on_a_large_session(migration_db_url: str) -> None:
     """Seed many events for a SINGLE session and assert the backfill stays
     fast. A correlated per-session backfill would re-scan all N events for that
     one session (and again per other session); the set-based form scans the
@@ -356,14 +340,14 @@ def test_backfill_bounded_on_a_large_session(postgres: object) -> None:
     the point — a few thousand events backfill in well under a second
     set-based, whereas the correlated form's cost is visibly super-linear.
 
-    The budget (60s) is deliberately generous: it brackets the WHOLE
-    ``uv run alembic upgrade`` run — process spawn, env bootstrap, and
-    the full migration ladder from 0065 — not just the 0066 statement, so it
-    stays robust on cold CI while still failing a true minutes-long hang.
+    The budget (60s) is deliberately generous: it brackets the whole
+    in-process alembic run — the full migration ladder from 0065, not just
+    the 0066 statement — so it stays robust on cold CI while still failing
+    a true minutes-long hang.
     """
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "0065"], db_url)
+    result = run_alembic(["upgrade", "0065"], db_url)
     assert result.returncode == 0, f"upgrade 0065 failed:\n{result.stderr}\n{result.stdout}"
 
     n_events = 5000
@@ -434,7 +418,7 @@ def test_backfill_bounded_on_a_large_session(postgres: object) -> None:
     asyncio.run(seed())
 
     start = time.monotonic()
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = run_alembic(["upgrade", "head"], db_url)
     elapsed = time.monotonic() - start
     assert result.returncode == 0, f"upgrade head failed:\n{result.stderr}\n{result.stdout}"
 

--- a/tests/integration/test_migrations_stop_hook.py
+++ b/tests/integration/test_migrations_stop_hook.py
@@ -3,33 +3,21 @@
 Production aios DBs are stamped ``alembic_version = 0055`` with a physical
 ``sessions.stop_hook`` column (added by #603, code-reverted by #613/#615).
 Migration ``0055`` was re-added verbatim so the stamp resolves, and ``0056``
-drops the orphaned column. These tests exercise the real alembic CLI against
-a fresh Postgres for each case — each stamps/mutates ``alembic_version``, so
-a shared container would leak state.
+drops the orphaned column. These tests run the real alembic chain against
+a fresh database for each case — each stamps/mutates ``alembic_version``, so
+shared schema state would leak between tests.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 from typing import cast
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 
 async def _sessions_columns(db_url: str) -> set[str]:
@@ -55,11 +43,11 @@ async def _version_num(db_url: str) -> str:
 
 @needs_docker
 @pytest.mark.integration
-def test_full_chain_from_scratch_has_no_stop_hook(postgres: object) -> None:
+def test_full_chain_from_scratch_has_no_stop_hook(migration_db_url: str) -> None:
     """A fresh upgrade-to-head lands past 0056 with no ``stop_hook`` column."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
 
     columns = asyncio.run(_sessions_columns(db_url))
@@ -72,16 +60,16 @@ def test_full_chain_from_scratch_has_no_stop_hook(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_forward_from_stamped_0055_drops_stop_hook(postgres: object) -> None:
+def test_forward_from_stamped_0055_drops_stop_hook(migration_db_url: str) -> None:
     """Reproduce prod (stamped 0055 with the column), then upgrade clears it."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "0055"], db_url)
+    result = run_alembic(["upgrade", "0055"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
     assert "stop_hook" in asyncio.run(_sessions_columns(db_url))
     assert asyncio.run(_version_num(db_url)) == "0055"
 
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
     # Past 0056 — stop_hook is dropped by that revision and stays gone.
     assert asyncio.run(_version_num(db_url)) >= "0056"
@@ -90,19 +78,19 @@ def test_forward_from_stamped_0055_drops_stop_hook(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_head_to_0054_runs_clean(postgres: object) -> None:
+def test_downgrade_head_to_0054_runs_clean(migration_db_url: str) -> None:
     """Downgrading head -> 0055 -> 0054 restores and then drops ``stop_hook``."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
 
-    result = _run_alembic(["upgrade", "head"], db_url)
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
 
-    result = _run_alembic(["downgrade", "0055"], db_url)
+    result = run_alembic(["downgrade", "0055"], db_url)
     assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
     assert asyncio.run(_version_num(db_url)) == "0055"
     assert "stop_hook" in asyncio.run(_sessions_columns(db_url))
 
-    result = _run_alembic(["downgrade", "0054"], db_url)
+    result = run_alembic(["downgrade", "0054"], db_url)
     assert result.returncode == 0, f"alembic downgrade failed:\n{result.stderr}\n{result.stdout}"
     assert asyncio.run(_version_num(db_url)) == "0054"
     assert "stop_hook" not in asyncio.run(_sessions_columns(db_url))

--- a/tests/integration/test_migrations_workspace_path_backfill.py
+++ b/tests/integration/test_migrations_workspace_path_backfill.py
@@ -8,7 +8,7 @@ provision time, lands outside the workspace jail, and surfaces
 ``ForbiddenError`` on every tool call.  Migration 0057 backfills the legacy
 rows to absolute by prepending the operator-supplied ``AIOS_WORKSPACE_ROOT``.
 
-These tests exercise the real alembic CLI against a fresh Postgres for each
+These tests run the real alembic chain against a fresh database for each
 case so each migration run gets an isolated ``alembic_version`` and
 ``sessions`` table.
 """
@@ -16,56 +16,21 @@ case so each migration run gets an isolated ``alembic_version`` and
 from __future__ import annotations
 
 import asyncio
-import os
-import shutil
 import subprocess
-from collections.abc import Iterator
-from pathlib import Path
 
 import asyncpg
 import pytest
 
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import PROJECT_ROOT, _alembic_url
-
-
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 
 def _run_alembic_with_env(
     args: list[str], db_url: str, *, workspace_root: str
 ) -> subprocess.CompletedProcess[str]:
-    """Like ``_run_alembic`` but also threads ``AIOS_WORKSPACE_ROOT`` through.
-
-    The 0057 migration reads ``AIOS_WORKSPACE_ROOT`` to know the prefix it
-    should prepend to legacy relative paths.  ``test_migrations._run_alembic``
-    starts from a clean env (only ``PATH`` / ``AIOS_DB_URL`` / ``HOME``) so we
-    can't reuse it directly.
-    """
-    uv = shutil.which("uv")
-    if uv is None:
-        raise FileNotFoundError("uv not found on PATH")
-    return subprocess.run(
-        [uv, "run", "alembic", *args],
-        cwd=PROJECT_ROOT,
-        env={
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin:/usr/local/bin"),
-            "AIOS_DB_URL": db_url,
-            "AIOS_WORKSPACE_ROOT": workspace_root,
-            "HOME": str(Path.home()),
-        },
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    """``run_alembic`` with ``AIOS_WORKSPACE_ROOT`` threaded through — the
+    0057 migration reads it as the prefix for legacy relative paths."""
+    return run_alembic(args, db_url, extra_env={"AIOS_WORKSPACE_ROOT": workspace_root})
 
 
 async def _list_workspace_paths(db_url: str) -> list[tuple[str, str]]:
@@ -146,10 +111,10 @@ async def _seed_session(db_url: str, *, session_id: str, workspace_volume_path: 
 
 @needs_docker
 @pytest.mark.integration
-def test_relative_path_rewritten_to_absolute(postgres: object) -> None:
+def test_relative_path_rewritten_to_absolute(migration_db_url: str) -> None:
     """A row with ``workspaces/acc/sess`` is rewritten by 0057 to
     ``<AIOS_WORKSPACE_ROOT>/acc/sess`` with no other changes."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     workspace_root = "/var/lib/aios/workspaces"
 
     # Upgrade only as far as 0056 so we can seed the legacy state.
@@ -174,11 +139,11 @@ def test_relative_path_rewritten_to_absolute(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_absolute_paths_untouched(postgres: object) -> None:
+def test_absolute_paths_untouched(migration_db_url: str) -> None:
     """Rows whose ``workspace_volume_path`` is already absolute must be
     left alone.  The migration's ``WHERE`` clause filters on
     ``NOT LIKE '/%'`` so an absolute path never matches."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     workspace_root = "/var/lib/aios/workspaces"
 
     result = _run_alembic_with_env(["upgrade", "0056"], db_url, workspace_root=workspace_root)
@@ -196,7 +161,7 @@ def test_absolute_paths_untouched(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_migration_is_idempotent(postgres: object) -> None:
+def test_migration_is_idempotent(migration_db_url: str) -> None:
     """``upgrade -> downgrade -> upgrade`` converges on the same absolute path.
 
     Idempotency here means "the migration is reversible and re-applicable":
@@ -206,7 +171,7 @@ def test_migration_is_idempotent(postgres: object) -> None:
     protects a hypothetical ``upgrade -> upgrade`` against double-prefixing
     is exercised indirectly: it's what ensures a re-application produces a
     stable result rather than compounding.)"""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     workspace_root = "/var/lib/aios/workspaces"
 
     result = _run_alembic_with_env(["upgrade", "0056"], db_url, workspace_root=workspace_root)
@@ -238,10 +203,10 @@ def test_migration_is_idempotent(postgres: object) -> None:
 
 @needs_docker
 @pytest.mark.integration
-def test_downgrade_reverses_rewrite(postgres: object) -> None:
+def test_downgrade_reverses_rewrite(migration_db_url: str) -> None:
     """``downgrade 0056`` strips the prepended ``AIOS_WORKSPACE_ROOT`` prefix
     so the row returns to its original relative form."""
-    db_url = _alembic_url(postgres)
+    db_url = migration_db_url
     workspace_root = "/var/lib/aios/workspaces"
 
     result = _run_alembic_with_env(["upgrade", "0056"], db_url, workspace_root=workspace_root)

--- a/tests/integration/test_open_request_scan_floor.py
+++ b/tests/integration/test_open_request_scan_floor.py
@@ -30,9 +30,9 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.models.sessions import Ok
-from tests.conftest import _docker_available, needs_docker
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 from tests.integration.conftest import seed_agent_env_session
-from tests.integration.test_migrations import _alembic_url, _run_alembic
 
 pytestmark = pytest.mark.integration
 
@@ -323,16 +323,6 @@ def test_floor_bounded_false_allows_batch_any_sid() -> None:
 # ─── 7. migration plan-shape: partial index exists, valid, and is used ───────
 
 
-@pytest.fixture
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 async def _execute(db_url: str, sql: str, *args: Any) -> None:
     conn = await asyncpg.connect(db_url)
     try:
@@ -358,9 +348,9 @@ def _collect_nodes(plan_node: dict[str, Any]) -> list[dict[str, Any]]:
 
 @needs_docker
 @pytest.mark.integration
-def test_migration_creates_valid_partial_index(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "head"], db_url)
+def test_migration_creates_valid_partial_index(migration_db_url: str) -> None:
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
 
     async def _check() -> tuple[str | None, bool | None]:
@@ -418,12 +408,12 @@ VALUES ('sess_a', 'agent_a', 'env_a', '/tmp/ws-a', 'acc_root', 1000, 990);
 
 @needs_docker
 @pytest.mark.integration
-def test_floor_bounded_query_uses_partial_index_not_full_scan(postgres: object) -> None:
+def test_floor_bounded_query_uses_partial_index_not_full_scan(migration_db_url: str) -> None:
     """The master-failing pin: EXPLAIN of the floor-bounded ``get_open_obligations``
     SQL must seek ``events_request_opened_seq_idx`` with a seq-range condition,
     not scan every ``request_opened`` row."""
-    db_url = _alembic_url(postgres)
-    up = _run_alembic(["upgrade", "head"], db_url)
+    db_url = migration_db_url
+    up = run_alembic(["upgrade", "head"], db_url)
     assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
     asyncio.run(_execute(db_url, _CHAIN_SQL))
 

--- a/tests/integration/test_rekey_column_coverage.py
+++ b/tests/integration/test_rekey_column_coverage.py
@@ -17,14 +17,13 @@ rekey.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 
 import asyncpg
 import pytest
 
 from aios.cli.commands.ops import _REKEY_COLUMNS
-from tests.conftest import _docker_available, needs_docker
-from tests.integration.test_migrations import _alembic_url, _run_alembic
+from tests.conftest import needs_docker
+from tests.helpers.alembic import run_alembic
 
 # ``credentials`` (migration 0001) is the pre-multi-tenancy, pre-vaults
 # credential store, superseded by ``vaults``/``vault_credentials`` (0005) and
@@ -37,21 +36,11 @@ from tests.integration.test_migrations import _alembic_url, _run_alembic
 _LEGACY_UNREKEYABLE = {("credentials", "ciphertext")}
 
 
-@pytest.fixture(scope="module")
-def postgres() -> Iterator[object]:
-    if not _docker_available():
-        pytest.skip("Docker not available")
-    from testcontainers.postgres import PostgresContainer
-
-    with PostgresContainer("postgres:16-alpine") as pg:
-        yield pg
-
-
 @needs_docker
 @pytest.mark.integration
-def test_rekey_covers_every_encrypted_column(postgres: object) -> None:
-    db_url = _alembic_url(postgres)
-    result = _run_alembic(["upgrade", "head"], db_url)
+def test_rekey_covers_every_encrypted_column(migration_db_url: str) -> None:
+    db_url = migration_db_url
+    result = run_alembic(["upgrade", "head"], db_url)
     assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
 
     async def check() -> None:

--- a/tests/integration/test_workspace_reaper_shared_run_lock.py
+++ b/tests/integration/test_workspace_reaper_shared_run_lock.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -301,24 +303,26 @@ async def test_reaper_lock_survives_real_to_thread_delete(
     key = queries.workspace_advisory_lock_key(queries.normalized_workspace_path(path))
     owner = await asyncpg.connect(migrated_db_url)
     contender = await asyncpg.connect(migrated_db_url)
-    thread_entered = asyncio.Event()
-    release_thread = asyncio.Event()
+    # threading.Event, not asyncio.Event: both events are touched from the
+    # worker thread, and asyncio.Event is not thread-safe — a foreign-thread
+    # ``set()`` enqueues the waiter's wakeup without stirring the parked
+    # selector, which stalled this test ~300 s per run until unrelated
+    # socket activity happened to wake the loop.
+    thread_entered = threading.Event()
+    release_thread = threading.Event()
 
     def slow_delete() -> None:
         thread_entered.set()
-        # Prove the event loop remains free while the filesystem operation waits.
-        while not release_thread.is_set():
-            import time
-
-            time.sleep(0.005)
-        import shutil
-
+        # Hold the deletion open until the loop-side assertions have run;
+        # a plain blocking wait here leaves the event loop entirely free.
+        if not release_thread.wait(timeout=30):
+            raise TimeoutError("loop never released the deletion thread")
         shutil.rmtree(target)
 
     try:
         await owner.execute("SELECT pg_advisory_lock($1::bigint)", key)
         delete_task = asyncio.create_task(asyncio.to_thread(slow_delete))
-        await thread_entered.wait()
+        assert await asyncio.to_thread(thread_entered.wait, 30)
         blocked = asyncio.create_task(contender.execute("SELECT pg_advisory_lock($1::bigint)", key))
         await asyncio.sleep(0.05)
         assert not blocked.done(), "separate backend entered during to_thread deletion"


### PR DESCRIPTION
CI's wall clock is the `integration` job — 1153 s of pytest while every other job finishes within 6 minutes in parallel (PR #2235: integration 18m36s, next-longest 5m33s). Profiling broke that 1153 s into three cost centers; this PR removes all three and then lifts the serial-only constraint the removal obsoletes. **Local full `tests/integration`: 187 s serial, 58 s at `-n 4`.** Tests + workflow only — no production behavior changes (one pure refactor in `aios.db.migrations`: the alembic `Config` bootstrap is extracted for sharing, `upgrade_to_head` behavior unchanged).

## 1. A deterministic 300 s stall in one test (26% of the job)

`test_reaper_lock_survives_real_to_thread_delete` coordinated its worker thread through two `asyncio.Event`s — both touched **from the thread**. `asyncio.Event.set()` resolves waiter futures via plain `call_soon`, which appends to the loop's ready queue without writing the self-pipe, so the loop stayed parked in `select()` until unrelated socket activity woke it — measured at 300.15 s / 300.19 s on CI (Linux) and 300.09 s locally (macOS). Every CI run since Jul 24 (#1979) paid it; the faulthandler dump visible in every integration log shows the parked selector plus the thread spinning in its 5 ms poll.

Fix: `threading.Event` for both signals, loop side parks in `asyncio.to_thread(thread_entered.wait, 30)`, thread side blocks in `release_thread.wait(timeout=30)`. Same property proven (contender's `pg_advisory_lock` stays blocked during the `to_thread` deletion; the loop stays free). The file now runs in 3.0 s instead of 304.6 s.

## 2. A Postgres container boot per migration test (~37% of the job)

~110 tests across ~35 `test_migrations_*` files each provisioned their own `PostgresContainer` (1.5–4 s) purely for schema-level isolation, and each `_run_alembic` call shelled out `uv run alembic` (~1 s of uv + interpreter + import cost per call, ~150 call sites, 1–3 per test).

- New `migration_db_factory` (session) / `migration_db_url` (function) fixtures in `tests/integration/conftest.py`: a fresh **database** on the shared session container per test (`CREATE DATABASE` over one persistent admin connection, ~50 ms) instead of a fresh server. Identical isolation — migrations touch only database-local state (verified: no `CREATE ROLE`/`TABLESPACE`/`ALTER SYSTEM` anywhere in `migrations/versions/`; the advisory-lock mentions are comments). The factory shape lets `0144`'s module of read-only tests keep sharing one replayed schema.
- The alembic runner moved to `tests/helpers/alembic.py` (the repo's shared-test-helper home) and drives alembic's command API **in-process**, over a new `aios.db.migrations.alembic_config()` — the single home for "where alembic.ini and `migrations/` live", shared with `upgrade_to_head` so the two cannot drift. The CLI contract the tests assert on is preserved: `returncode` 0/1, `stdout` capture, and a raising migration's traceback as `stderr` (where tests grep for `"cannot downgrade"` etc.). `extra_env` threads 0057's `AIOS_WORKSPACE_ROOT` and 0154's `AIOS_VAULT_KEY`, replacing two files' parallel subprocess runners. `0165`'s local runner **stays a subprocess on purpose** — its `_PreFix0154` rewrites the 0154 migration file on disk and needs a fresh interpreter — and now says so in its docstring.

Measured on the three files baselined before/after: 39.2 s → 14.2 s.

## 3. fsync on a throwaway server (part of the ~35% baseline floor)

The session testcontainer now runs `fsync=off, synchronous_commit=off, full_page_writes=off`. Crash-durability is meaningless for a container whose lifetime is one test session, and CI runner disks made every TRUNCATE-per-test reset and every chain replay pay for it. Commit visibility / NOTIFY semantics are unchanged.

## 4. The serial-only CI constraint is dissolved — run `-n 4`

The workflow's documented reason for running integration serially was that migration tests spawn *additional* containers, exhausting hosted-runner Docker under even two xdist workers. Item 2 removes those containers entirely, so the job now runs `-n 4 --dist=loadfile` like the e2e shards (`loadfile` keeps module-scoped DB fixtures worker-local). Verified locally: 1084 passed at `-n 4`, no xdist-induced failures.

## Numbers

| | before | after |
|---|---|---|
| reaper file (local) | 304.6 s | 3.0 s |
| 0169+0134+0144 migration files (local) | 39.2 s | 14.2 s |
| full `tests/integration` (local, serial) | — | 187.1 s |
| full `tests/integration` (local, `-n 4`) | — | **58.0 s** |
| CI integration job | 1153–1167 s | this PR's run is the measurement |

The job had gained ~420 s in the last month (July master baseline: 745 s; the 300 s test landed Jul 24, plus steady migration-test accretion). Item 2 also flattens the growth curve: each future migration test costs ~0.5 s, not ~4 s.

## Notes

- Net ≈ −390 lines across 43 files. Review pass (4 angles) applied: shared-runner consolidation into `tests/helpers/`, 0154's subprocess runner converted, 0165's kept-and-documented, persistent admin connection, stale docstrings updated.
- Deliberately deferred with data: a revision-keyed **template-database cache** in `migration_db_factory` (155 chain replays span only 40 distinct target revisions — worth ~60–100 s serial, but only ~15 s once `-n 4` absorbs the serial waste; not worth the drop-and-clone machinery today).
- Pre-existing, unrelated: `test_invoke_session::test_call_agent_shares_live_workspace_only_when_explicitly_asked` fails on macOS with `/var` vs `/private/var` (Darwin symlink resolution); verified identical at the pre-change master tip, green on Linux CI. Worth a small follow-up issue.
- Also available if wanted: a hard per-test timeout (pytest-timeout) — it would have turned the silent 300 s stall into a red X on day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
