### PR TITLE
Journal-prune drain hardening: pruned-run trace fallback, feeder index, autovacuum tuning (#2245)

### DIFF
--- a/migrations/versions/0172_journal_prune_drain_support.py
+++ b/migrations/versions/0172_journal_prune_drain_support.py
@@ -1,0 +1,102 @@
+"""Journal-prune drain support: feeder backlog index + journal-table autovacuum tuning.
+
+Revision ID: 0172
+Revises: 0169
+(Numbered 0172 because 0170/0171 are claimed by in-flight PRs #2202/#2247;
+renumber at rebase if they land first — see #2212 for the fork-detection gap.)
+
+Two schema-only changes for the #2245 drain (the 97 GB of terminal-run
+journals that becomes prune-eligible as runs age past the retention window):
+
+1. ``wf_runs_archival_backlog_idx`` — ``reconcile_terminal_archival_batch``
+   (db/queries/prune.py) runs hourly forever, and its WHERE has no usable
+   index: ``wf_runs_active_idx`` covers only NON-terminal rows (the exact
+   complement), so every sweep seq-scans wf_runs. The predicate here is
+   deliberately ``(archived_at IS NULL OR terminal_summary IS NULL)`` — BOTH
+   arms of the feeder's OR must logically imply the index predicate or the
+   planner cannot use it at all (verified empirically: the narrower
+   ``archived_at IS NULL``-only form plans as a seq scan even with
+   enable_seqscan=off; the widened form gives an ordered index scan matching
+   the query's ``ORDER BY updated_at, id`` with no Sort node). Rows leave the
+   index once the feeder stamps archived_at + terminal_summary, so it is
+   near-empty in steady state.
+
+   The ``DROP INDEX CONCURRENTLY IF EXISTS`` before the create is the retry
+   path, not decoration: a failed CONCURRENTLY build (statement cancel,
+   deadlock, dropped connection) leaves an INVALID index behind, and a bare
+   ``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` retry then reports "already
+   exists, skipping" while the corpse is maintained on every write and never
+   used by the planner. Dropping first makes the retry actually rebuild.
+
+2. Autovacuum tuning on the two journal tables. The drain deletes tens of
+   GB of rows whose bytes live almost entirely in TOAST; at the default
+   ``autovacuum_vacuum_scale_factor = 0.2`` a 54 GB table accrues ~20% dead
+   tuples before the first vacuum fires, so reclaimed space would lag the
+   drain by weeks. 0.01 + no cost delay keeps vacuum roughly in step with
+   the pruner. Per-table only; no global settings are touched. NOTE:
+   deletion + vacuum makes space REUSABLE — returning it to the OS is a
+   separate supervised pg_repack ceremony (eumemic-ops).
+
+   The ALTERs take SHARE UPDATE EXCLUSIVE, which is online-safe but queues
+   behind any running (anti-wraparound) autovacuum on the same table — and
+   everything behind the ALTER then queues on it. ``lock_timeout`` +
+   bounded retries make that a fail-fast loop instead of a wedged deploy.
+"""
+
+import time
+
+from alembic import op
+
+revision = "0172"
+down_revision = "0169"
+branch_labels = None
+depends_on = None
+
+_INDEX = "wf_runs_archival_backlog_idx"
+
+_RELOPTS = "(autovacuum_vacuum_scale_factor = 0.01, autovacuum_vacuum_cost_delay = 0)"
+_TABLES = ("wf_run_events", "wf_run_signals")
+
+
+def _alter_with_lock_timeout(sql: str, *, attempts: int = 5) -> None:
+    """Run one ALTER with a 5s lock_timeout, retrying a few times.
+
+    A plain ALTER here can sit behind an anti-wraparound autovacuum for
+    hours while blocking every query behind it in the lock queue. Failing
+    fast and retrying lets concurrent traffic interleave between attempts;
+    if all attempts lose the race the migration fails loudly and is safe to
+    re-run.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            op.execute("SET lock_timeout = '5s'")
+            op.execute(sql)
+            op.execute("SET lock_timeout = DEFAULT")
+            return
+        except Exception:
+            if attempt == attempts:
+                raise
+            time.sleep(2 * attempt)
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX}")
+        op.execute(
+            f"CREATE INDEX CONCURRENTLY {_INDEX} "
+            "ON wf_runs (updated_at, id) "
+            "WHERE status IN ('completed','errored','cancelled') "
+            "AND (archived_at IS NULL OR terminal_summary IS NULL)"
+        )
+        for table in _TABLES:
+            _alter_with_lock_timeout(f"ALTER TABLE {table} SET {_RELOPTS}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX}")
+        for table in _TABLES:
+            _alter_with_lock_timeout(
+                f"ALTER TABLE {table} RESET "
+                "(autovacuum_vacuum_scale_factor, autovacuum_vacuum_cost_delay)"
+            )

--- a/migrations/versions/0172_journal_prune_drain_support.py
+++ b/migrations/versions/0172_journal_prune_drain_support.py
@@ -1,7 +1,7 @@
 """Journal-prune drain support: feeder backlog index + journal-table autovacuum tuning.
 
 Revision ID: 0172
-Revises: 0169
+Revises: 0171
 
 Two schema-only changes for the #2245 drain (the 97 GB of terminal-run
 journals that becomes prune-eligible as runs age past the retention window):
@@ -51,7 +51,7 @@ import sqlalchemy.exc
 from alembic import op
 
 revision = "0172"
-down_revision = "0169"
+down_revision = "0171"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/0172_journal_prune_drain_support.py
+++ b/migrations/versions/0172_journal_prune_drain_support.py
@@ -2,8 +2,6 @@
 
 Revision ID: 0172
 Revises: 0169
-(Numbered 0172 because 0170/0171 are claimed by in-flight PRs #2202/#2247;
-renumber at rebase if they land first — see #2212 for the fork-detection gap.)
 
 Two schema-only changes for the #2245 drain (the 97 GB of terminal-run
 journals that becomes prune-eligible as runs age past the retention window):
@@ -37,14 +35,19 @@ journals that becomes prune-eligible as runs age past the retention window):
    deletion + vacuum makes space REUSABLE — returning it to the OS is a
    separate supervised pg_repack ceremony (eumemic-ops).
 
-   The ALTERs take SHARE UPDATE EXCLUSIVE, which is online-safe but queues
-   behind any running (anti-wraparound) autovacuum on the same table — and
-   everything behind the ALTER then queues on it. ``lock_timeout`` +
-   bounded retries make that a fail-fast loop instead of a wedged deploy.
+   The ALTERs take SHARE UPDATE EXCLUSIVE — application DML and reads do
+   NOT conflict with it (verified: INSERT/UPDATE/DELETE/SELECT flow freely
+   while the ALTER waits), so the risk is not app traffic. The risk is the
+   DEPLOY hanging for hours behind an anti-wraparound autovacuum on the same
+   table, with other maintenance DDL/autovacuum queueing behind the request.
+   ``lock_timeout`` + bounded retries make that a fail-fast loop instead of
+   a wedged deploy.
 """
 
 import time
 
+import psycopg.errors
+import sqlalchemy.exc
 from alembic import op
 
 revision = "0172"
@@ -59,13 +62,11 @@ _TABLES = ("wf_run_events", "wf_run_signals")
 
 
 def _alter_with_lock_timeout(sql: str, *, attempts: int = 5) -> None:
-    """Run one ALTER with a 5s lock_timeout, retrying a few times.
-
-    A plain ALTER here can sit behind an anti-wraparound autovacuum for
-    hours while blocking every query behind it in the lock queue. Failing
-    fast and retrying lets concurrent traffic interleave between attempts;
-    if all attempts lose the race the migration fails loudly and is safe to
-    re-run.
+    """Fail-fast ALTER under a 5s lock_timeout with bounded retries — see the
+    module docstring for why. Retries ONLY the lock timeout (55P03): any other
+    failure re-raises immediately on first occurrence, so a broken statement
+    is not retried five times and an earlier, different error is never masked
+    by a later one.
     """
     for attempt in range(1, attempts + 1):
         try:
@@ -73,7 +74,9 @@ def _alter_with_lock_timeout(sql: str, *, attempts: int = 5) -> None:
             op.execute(sql)
             op.execute("SET lock_timeout = DEFAULT")
             return
-        except Exception:
+        except sqlalchemy.exc.OperationalError as exc:
+            if not isinstance(getattr(exc, "orig", None), psycopg.errors.LockNotAvailable):
+                raise
             if attempt == attempts:
                 raise
             time.sleep(2 * attempt)

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -674,8 +674,9 @@ class Settings(BaseSettings):
     reclaimable_prune_enabled: bool = Field(
         default=True,
         description="Kill-switch for the age-based prune of RECLAIMABLE instance "
-        "ephemera (T6): terminal+archived ``wf_runs`` (and their ``WfRunEvent`` "
-        "journals, which cascade) plus archived agent/skill/workflow definitions "
+        "ephemera (T6): the journals (``wf_run_events`` + ``wf_run_signals``) of "
+        "terminal+archived ``wf_runs`` — the run row itself is kept forever as "
+        "the durable summary — plus archived agent/skill/workflow definitions "
         "no live session/run still pins. When False the maintenance sweep prunes "
         "nothing (set ``AIOS_RECLAIMABLE_PRUNE_ENABLED=false``). NEVER touches the "
         "sacred set: memory content, referenced session history, any version a "
@@ -685,11 +686,13 @@ class Settings(BaseSettings):
     wf_runs_retention_days: int = Field(
         default=30,
         ge=1,
-        description="Days a TERMINAL+ARCHIVED workflow run (``wf_runs`` with "
-        "``archived_at`` set by ``archive_run``) is retained before the prune "
-        "sweep deletes it — dropping its ``wf_run_events`` journal (the unbounded-"
-        "growth driver) via ``ON DELETE CASCADE`` in the same statement. Modeled "
-        "on ``trigger_runs_retention_days``; age-keyed on ``archived_at``. "
+        description="Days a TERMINAL+ARCHIVED workflow run's journal detail "
+        "(``wf_run_events`` + ``wf_run_signals``, the unbounded-growth drivers) "
+        "is retained before the prune sweep deletes it. The ``wf_runs`` row "
+        "itself is never pruned — it survives as the durable summary "
+        "(``terminal_summary``, output, cost), with ``journal_pruned_at`` "
+        "stamped when the journal empties. Modeled on "
+        "``trigger_runs_retention_days``; age-keyed on ``archived_at``. "
         "Time-based by design — a count-cap is explicitly rejected (#1461).",
     )
     reclaimable_prune_batch_rows: int = Field(

--- a/src/aios/db/queries/prune.py
+++ b/src/aios/db/queries/prune.py
@@ -21,12 +21,16 @@ Modeled on the two prunes that already exist in aios:
 
 Prune candidates (reclaimable):
 
-- **terminal + archived runs** past ``wf_runs_retention_days`` — deleting the
-  ``wf_runs`` row drops its ``WfRunEvent`` journal (the unbounded-growth driver)
-  via the ``wf_run_events.run_id ... ON DELETE CASCADE`` FK (migration 0064). A
-  run is only a candidate once ``archive_run`` (aios#9) has stamped
-  ``archived_at`` AND its status is terminal — so a live/suspended run is never
-  reached.
+- **terminal + archived runs** past ``wf_runs_retention_days`` — the
+  ``wf_runs`` row is KEPT FOREVER as the durable summary (status, output,
+  ``terminal_summary``, cost columns); what gets deleted is the child detail:
+  the ``wf_run_events`` journal and ``wf_run_signals`` (the unbounded-growth
+  drivers), with ``journal_pruned_at`` stamped once the journal is empty.
+  (The original design deleted the row and let ``ON DELETE CASCADE`` drop the
+  journal; #2076 inverted it — parents resolve child results from the run row
+  at any later time, so the row is institutional memory, not ephemera.) A run
+  is only a candidate once ``archive_run`` (aios#9) has stamped ``archived_at``
+  AND its status is terminal — so a live/suspended run is never reached.
 - **archived definitions** (agents / skills / workflows) past
   ``archived_definition_retention_days`` with **NO live session pinning** them —
   replay-stability requires the pinned version survive, so a definition any live

--- a/src/aios/db/queries/trace.py
+++ b/src/aios/db/queries/trace.py
@@ -426,22 +426,33 @@ async def read_run_meta_batched(
 
     ``{status, workflow_id, caller, request_id, created_at}`` plus the
     ``run_completed`` payload (``{is_error, error}``) so a root run's terminal
-    state and ``error_kind`` resolve from the journal without a per-node fetch.
-    Account-scoped.
+    state and ``error_kind`` resolve without a per-node fetch. Account-scoped.
+
+    ``terminal_summary`` is preferred over the journal's ``run_completed``
+    event, exactly as ``derive_run_response`` and ``resolve_run_error`` do:
+    once the reclaimable-prune sweep empties a terminal run's journal
+    (``journal_pruned_at``), the summary on the run row is the only surviving
+    record of ``is_error``/``error`` — without this fallback a pruned run's
+    trace silently lost its terminal state. The journal read is the legacy arm
+    for rows that predate summary projection.
     """
     if not run_ids:
         return {}
     rows = await conn.fetch(
         "SELECT r.id, r.status, r.workflow_id, r.caller, r.request_id, r.created_at, "
+        "  r.terminal_summary, "
+        "  CASE WHEN r.terminal_summary IS NULL THEN "
         "  (SELECT e.payload FROM wf_run_events e "
-        "   WHERE e.run_id = r.id AND e.type = 'run_completed' LIMIT 1) AS completed "
+        "   WHERE e.run_id = r.id AND e.type = 'run_completed' "
+        "   ORDER BY e.seq DESC LIMIT 1) END AS legacy_completed "
         "FROM wf_runs r WHERE r.id = ANY($1) AND r.account_id = $2",
         run_ids,
         account_id,
     )
     out: dict[str, dict[str, Any]] = {}
     for r in rows:
-        completed = r["completed"] if r["completed"] is not None else None
+        summary = r["terminal_summary"]
+        completed = summary if summary is not None else r["legacy_completed"]
         out[r["id"]] = {
             "status": r["status"],
             "workflow_id": r["workflow_id"],

--- a/src/aios/harness/reclaimable_prune.py
+++ b/src/aios/harness/reclaimable_prune.py
@@ -9,8 +9,9 @@ and the ``trigger_runner`` maintenance pair.
 What it reclaims (all time-based, per the ``trigger_runs`` doctrine — never a
 count-cap):
 
-- terminal+archived ``wf_runs`` past ``wf_runs_retention_days`` (dropping their
-  ``WfRunEvent`` journals via ``ON DELETE CASCADE``),
+- the journal detail (``wf_run_events`` + ``wf_run_signals``) of
+  terminal+archived ``wf_runs`` past ``wf_runs_retention_days`` — the run row
+  is kept forever as the durable summary,
 - archived agent/skill/workflow definitions past
   ``archived_definition_retention_days`` that NO live session/run still pins.
 

--- a/tests/integration/test_reclaimable_prune.py
+++ b/tests/integration/test_reclaimable_prune.py
@@ -155,6 +155,17 @@ async def _insert_session(
     )
 
 
+async def _set_journal_completed_divergent(conn: asyncpg.Connection[Any], run_id: str) -> None:
+    """Point the journal's run_completed at a payload that DISAGREES with
+    terminal_summary — the discriminator the trace-preference tests rely on."""
+    await conn.execute(
+        'UPDATE wf_run_events SET payload = \'{"is_error": true, '
+        '"error": {"kind": "from_journal"}}\'::jsonb '
+        "WHERE run_id = $1 AND type = 'run_completed'",
+        run_id,
+    )
+
+
 async def _count(conn: asyncpg.Connection[Any], table: str, _id_col: str, _id: str) -> int:
     count = await conn.fetchval(f"SELECT count(*) FROM {table} WHERE {_id_col} = $1", _id)
     return int(count)
@@ -350,12 +361,7 @@ async def test_trace_meta_prefers_terminal_summary_when_both_exist(
     preference — or one that keeps reading only the journal — fails here.
     """
     run_id = await _make_archived_run(conn, archived_age_days=1)
-    await conn.execute(
-        'UPDATE wf_run_events SET payload = \'{"is_error": true, '
-        '"error": {"kind": "from_journal"}}\'::jsonb '
-        "WHERE run_id = $1 AND type = 'run_completed'",
-        run_id,
-    )
+    await _set_journal_completed_divergent(conn, run_id)
 
     meta = await trace_queries.read_run_meta_batched(conn, [run_id], account_id="acc_root")
     completed = meta[run_id]["run_completed"]
@@ -371,13 +377,19 @@ async def test_trace_meta_survives_journal_prune(
     the fallback, silently dropping is_error/error from a pruned run's trace.
     """
     run_id = await _make_archived_run(conn, archived_age_days=60)
+    await conn.execute(
+        'UPDATE wf_runs SET terminal_summary = \'{"is_error": true, '
+        '"error": {"kind": "from_summary"}}\'::jsonb WHERE id = $1',
+        run_id,
+    )
     assert await prune_archived_runs(conn, retention_days=30) == 2
     assert await _count(conn, "wf_run_events", "run_id", run_id) == 0
 
     meta = await trace_queries.read_run_meta_batched(conn, [run_id], account_id="acc_root")
     completed = meta[run_id]["run_completed"]
     assert completed is not None
-    assert completed["is_error"] is False
+    assert completed["is_error"] is True
+    assert completed["error"]["kind"] == "from_summary"
 
 
 async def test_trace_meta_falls_back_to_journal_for_legacy_rows(
@@ -387,12 +399,7 @@ async def test_trace_meta_falls_back_to_journal_for_legacy_rows(
     journal — the legacy arm must not go dead when the summary arm is added."""
     run_id = await _make_archived_run(conn, archived_age_days=1)
     await conn.execute("UPDATE wf_runs SET terminal_summary = NULL WHERE id = $1", run_id)
-    await conn.execute(
-        'UPDATE wf_run_events SET payload = \'{"is_error": true, '
-        '"error": {"kind": "from_journal"}}\'::jsonb '
-        "WHERE run_id = $1 AND type = 'run_completed'",
-        run_id,
-    )
+    await _set_journal_completed_divergent(conn, run_id)
 
     meta = await trace_queries.read_run_meta_batched(conn, [run_id], account_id="acc_root")
     completed = meta[run_id]["run_completed"]

--- a/tests/integration/test_reclaimable_prune.py
+++ b/tests/integration/test_reclaimable_prune.py
@@ -23,6 +23,7 @@ import pytest
 
 from aios.config import get_settings
 from aios.db.pool import create_pool, register_jsonb_codec
+from aios.db.queries import trace as trace_queries
 from aios.db.queries import workflows as wf_queries
 from aios.db.queries.prune import (
     prune_archived_runs,
@@ -78,7 +79,8 @@ async def _make_archived_run(
         depth=10,
     )
     if seq_journal:
-        # A couple of journal rows to prove the cascade drops them.
+        # A couple of journal rows to prove the prune deletes the child
+        # detail directly (the run row survives; nothing cascades).
         await conn.execute(
             "INSERT INTO wf_run_events (id, run_id, seq, type, payload) "
             "VALUES ($1, $2, 0, 'run_started', '{}'::jsonb)",
@@ -333,6 +335,70 @@ async def test_archived_legacy_run_is_backfilled_before_detail_prune(
     assert row["terminal_summary"] is not None
     assert await prune_archived_runs(conn, retention_days=30) == 2
     assert await _count(conn, "wf_run_events", "run_id", run_id) == 0
+
+
+# ─── trace metadata survives journal pruning (#2245) ────────────────────────
+
+
+async def test_trace_meta_prefers_terminal_summary_when_both_exist(
+    conn: asyncpg.Connection[Any],
+) -> None:
+    """Summary wins over a divergent journal payload.
+
+    The journal's ``run_completed`` deliberately DISAGREES with
+    ``terminal_summary`` (is_error True vs False) so a mutant that swaps the
+    preference — or one that keeps reading only the journal — fails here.
+    """
+    run_id = await _make_archived_run(conn, archived_age_days=1)
+    await conn.execute(
+        'UPDATE wf_run_events SET payload = \'{"is_error": true, '
+        '"error": {"kind": "from_journal"}}\'::jsonb '
+        "WHERE run_id = $1 AND type = 'run_completed'",
+        run_id,
+    )
+
+    meta = await trace_queries.read_run_meta_batched(conn, [run_id], account_id="acc_root")
+    completed = meta[run_id]["run_completed"]
+    assert completed is not None
+    assert completed["is_error"] is False  # from summary, not the journal
+
+
+async def test_trace_meta_survives_journal_prune(
+    conn: asyncpg.Connection[Any],
+) -> None:
+    """After the prune empties the journal, the trace still resolves terminal
+    state from ``terminal_summary`` — the #2245 gap: this returned None before
+    the fallback, silently dropping is_error/error from a pruned run's trace.
+    """
+    run_id = await _make_archived_run(conn, archived_age_days=60)
+    assert await prune_archived_runs(conn, retention_days=30) == 2
+    assert await _count(conn, "wf_run_events", "run_id", run_id) == 0
+
+    meta = await trace_queries.read_run_meta_batched(conn, [run_id], account_id="acc_root")
+    completed = meta[run_id]["run_completed"]
+    assert completed is not None
+    assert completed["is_error"] is False
+
+
+async def test_trace_meta_falls_back_to_journal_for_legacy_rows(
+    conn: asyncpg.Connection[Any],
+) -> None:
+    """A pre-summary row (terminal_summary NULL) still resolves from the
+    journal — the legacy arm must not go dead when the summary arm is added."""
+    run_id = await _make_archived_run(conn, archived_age_days=1)
+    await conn.execute("UPDATE wf_runs SET terminal_summary = NULL WHERE id = $1", run_id)
+    await conn.execute(
+        'UPDATE wf_run_events SET payload = \'{"is_error": true, '
+        '"error": {"kind": "from_journal"}}\'::jsonb '
+        "WHERE run_id = $1 AND type = 'run_completed'",
+        run_id,
+    )
+
+    meta = await trace_queries.read_run_meta_batched(conn, [run_id], account_id="acc_root")
+    completed = meta[run_id]["run_completed"]
+    assert completed is not None
+    assert completed["is_error"] is True
+    assert completed["error"]["kind"] == "from_journal"
 
 
 # ─── archived definitions: agents ───────────────────────────────────────────

--- a/tests/unit/test_check_migration_heads.py
+++ b/tests/unit/test_check_migration_heads.py
@@ -63,5 +63,7 @@ def test_known_good_repository_has_expected_revision_count_and_one_head() -> Non
     versions = Path(__file__).resolve().parents[2] / "migrations" / "versions"
     revisions = load_revisions(versions)
 
-    assert len(revisions) == 158
+    # Bump this when adding a migration — the count pins accidental
+    # deletions/duplications, not a maximum.
+    assert len(revisions) == 159
     assert check_history(revisions) in revisions


### PR DESCRIPTION
Closes the code half of #2245. The investigation overturned the issue's premise: the journal pruner + feeder are shipped, enabled, and correct — the 97 GB exists because every terminal run was archived only Aug 17–24 (#2076/#2220), so nothing has aged past the retention window yet. The retention **policy** decision (14 days, chairman 2026-08-25) is applied as `AIOS_WF_RUNS_RETENTION_DAYS=14` on the deployed worker (recorded in eumemic-ops spec); the drain begins ~Aug 31. This PR hardens what the drain exposes.

## Changes

**`read_run_meta_batched` keeps a pruned run's terminal state.** It was the one journal reader without the `terminal_summary`-first fallback its siblings (`derive_run_response`, `resolve_run_error`) already have — after pruning, a run's trace silently lost `is_error`/`error`. Same CASE-guarded shape as `derive_run_response`; the legacy journal arm now has a deterministic `ORDER BY e.seq DESC`.

**Migration 0172** (schema-only, hot-table safe):
- `wf_runs_archival_backlog_idx` — the archival feeder seq-scans `wf_runs` hourly forever (`wf_runs_active_idx` covers exactly the complement). The predicate is deliberately `(archived_at IS NULL OR terminal_summary IS NULL)`: the red-team **proved empirically** that the "obvious" `archived_at IS NULL`-only form can never be used by the feeder's OR-query (seq scan even with `enable_seqscan=off`), while this form gives an ordered index scan, no Sort node, near-empty steady state.
- `DROP INDEX CONCURRENTLY IF EXISTS` precedes the create: a failed CONCURRENTLY build leaves an INVALID index that a bare `IF NOT EXISTS` retry silently keeps forever (0163 carries this latent flaw; not replicated).
- Journal-table autovacuum tightened (`scale_factor 0.01`, `cost_delay 0`) so TOAST reclaim keeps pace with the drain; ALTERs run under a 5s `lock_timeout` retrying **only** 55P03 — DML doesn't conflict with SUE (verified live), the risk is the deploy wedging behind anti-wraparound autovacuum.

**Docstring truth (5 sites).** The prune module, both config field descriptions, the sweep header, and a test comment still described the pre-#2076 design (delete the row, CASCADE the journal). The shipped code inverts that: the row survives forever as the durable summary; only child detail is deleted.

## Review provenance

Adversarial pipeline: plan red-teamed **before code** (3 lenses, 12/12 findings confirmed incl. one critical — the unusable index predicate — and the 0170/0171 migration-number collisions with #2202/#2247); implementation reviewed by 3 finder angles + empirical verification (6/6 minor findings confirmed and folded). Preference tests are mutation-verified: the journal-wins mutant fails the both-exist test (applied and observed failing); a Python-layer-only mutant was found vacuous (the SQL CASE carries the preference) and the test set was strengthened accordingly.

## Residuals (accepted, named for sign-off)

- **Migration number**: `0172`/`Revises: 0169` assumes #2202 (0170) and #2247 (0171) are unmerged; whoever lands later renumbers (the #2212 gap).
- Sweep still has no advisory lock, no dry-run, coupled batch limits — real gaps, harmless at current volumes (single worker; 12k runs/day prune ceiling vs ~1.2k/day eligibility). Not built to keep this PR tight.
- `prune.py`'s legacy-summary backfill can produce a content-free `{"cancelled": false}` summary for a journal-less legacy run (pre-existing, documented).
- Row deletion returns **no** disk to the OS — the pg_repack ceremony is an eumemic-ops runbook item, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
