### PR TITLE
fix(accounting): subtree-driven usage hydration with account-scan fallback (#2246)

### DIFF
--- a/src/aios/db/pool.py
+++ b/src/aios/db/pool.py
@@ -114,6 +114,12 @@ async def create_pool(db_url: str, *, min_size: int = 1, max_size: int = 8) -> a
         server_settings={
             "statement_timeout": "30000",
             "idle_in_transaction_session_timeout": "60000",
+            # Every aios query is OLTP-shaped; the heaviest ones (the
+            # accounting subtree walks, #2246) measured 170ms-8s of pure JIT
+            # compilation per execution against no observable JIT win, because
+            # their recursive-CTE cost estimates clear jit_above_cost while the
+            # actual row counts stay small.
+            "jit": "off",
             **_POOL_TCP_KEEPALIVE_SETTINGS,
         },
     )

--- a/src/aios/db/queries/accounting.py
+++ b/src/aios/db/queries/accounting.py
@@ -68,6 +68,189 @@ def _attributed(row: Any, *, window_seconds: int) -> AttributedUsage:
     )
 
 
+# ``usage_for_nodes`` is bimodal (#2246).  The subtree walk itself is cheap and
+# index-driven, but PostgreSQL cannot estimate recursive-CTE cardinality (it
+# assumes ~10x the seed), so no single statement plans well for both a leaf
+# session and a page of roots whose subtrees span the whole account.  We run
+# the subtree-driven statement first with a lazy ``LIMIT`` cap; iff the walk
+# overflows the cap we discard it and fall back to the account-scan statement,
+# whose hash joins are the right shape at that scale.  Both statements were
+# verified result-identical on production data (issue #2246).
+SUBTREE_PAIR_CAP = 4096
+
+# Per-statement bound for both usage statements, applied via ``SET LOCAL`` in
+# ``usage_for_nodes`` (the peer of ``USAGE_CONSUMERS_STATEMENT_TIMEOUT_MS``).
+# The account-scan fallback measured 4-6s warm on the largest production
+# account, so 5s would fail it chronically; 10s passes warm and converts a
+# cold-cache stall into an explicit error well before the pool's 30s bound.
+USAGE_STATEMENT_TIMEOUT_MS = 10_000
+
+# The subtree-driven statement: the recursive walk carries each node's own
+# counters (the child probe already touches the row, so the extra columns are
+# free), the rolling-window counters come from a per-node probe of the ledger's
+# partial indexes, and ``totals`` reduces the walk directly — ``own_*`` falls
+# out of the same aggregation via ``FILTER`` on the seed row.  There are no
+# CTE-to-CTE joins, so the misestimated tree cardinality cannot flip the plan.
+# ``capped`` bounds the walk lazily: recursion stops once ``$5`` rows exist,
+# and ``pair_count = $5`` tells the caller the result is truncated (and thus
+# wrong — fall back).
+_SUBTREE_USAGE_SQL = r"""
+WITH RECURSIVE
+roots(kind, id) AS (
+    SELECT * FROM unnest($1::text[], $2::text[])
+),
+tree(root_kind, root_id, kind, id, cost_microusd, input_tokens, output_tokens,
+     cache_read_input_tokens, cache_creation_input_tokens, tokens_complete) AS (
+    SELECT r.kind, r.id, r.kind, r.id, n.cost_microusd, n.input_tokens,
+           n.output_tokens, n.cache_read_input_tokens,
+           n.cache_creation_input_tokens, n.tokens_complete
+      FROM roots r
+      JOIN LATERAL (
+           SELECT s.cost_microusd, s.input_tokens, s.output_tokens,
+                  s.cache_read_input_tokens, s.cache_creation_input_tokens,
+                  TRUE AS tokens_complete
+             FROM sessions s
+            WHERE r.kind = 'session' AND s.id = r.id AND s.account_id = $3
+           UNION ALL
+           SELECT w.call_llm_cost_microusd, w.call_llm_input_tokens,
+                  w.call_llm_output_tokens, w.call_llm_cache_read_input_tokens,
+                  w.call_llm_cache_creation_input_tokens, w.call_llm_tokens_complete
+             FROM wf_runs w
+            WHERE r.kind = 'run' AND w.id = r.id AND w.account_id = $3
+      ) n ON TRUE
+    UNION
+    SELECT t.root_kind, t.root_id, child.kind, child.id, child.cost_microusd,
+           child.input_tokens, child.output_tokens, child.cache_read_input_tokens,
+           child.cache_creation_input_tokens, child.tokens_complete
+      FROM tree t
+      JOIN LATERAL (
+           SELECT 'session'::text AS kind, s.id, s.cost_microusd, s.input_tokens,
+                  s.output_tokens, s.cache_read_input_tokens,
+                  s.cache_creation_input_tokens, TRUE AS tokens_complete
+             FROM sessions s
+            WHERE s.account_id = $3
+              AND ((t.kind = 'session' AND s.creator_session_id = t.id)
+                OR (t.kind = 'run' AND s.creator_run_id = t.id))
+           UNION ALL
+           SELECT 'run'::text AS kind, w.id, w.call_llm_cost_microusd,
+                  w.call_llm_input_tokens, w.call_llm_output_tokens,
+                  w.call_llm_cache_read_input_tokens,
+                  w.call_llm_cache_creation_input_tokens, w.call_llm_tokens_complete
+             FROM wf_runs w
+            WHERE w.account_id = $3
+              AND ((t.kind = 'session' AND w.creator_session_id = t.id)
+                OR (t.kind = 'run' AND w.creator_run_id = t.id))
+      ) child ON TRUE
+),
+capped AS (
+    SELECT * FROM tree LIMIT $5
+),
+totals AS (
+    SELECT t.root_kind, t.root_id,
+           SUM(t.cost_microusd)::bigint AS subtree_cost_microusd,
+           SUM(t.input_tokens)::bigint AS subtree_input_tokens,
+           SUM(t.output_tokens)::bigint AS subtree_output_tokens,
+           SUM(t.cache_read_input_tokens)::bigint AS subtree_cache_read_input_tokens,
+           SUM(t.cache_creation_input_tokens)::bigint AS subtree_cache_creation_input_tokens,
+           BOOL_AND(t.tokens_complete) AS subtree_tokens_complete,
+           SUM(COALESCE(wn.cost_microusd, 0))::bigint AS subtree_window_cost_microusd,
+           SUM(COALESCE(wn.input_tokens, 0))::bigint AS subtree_window_input_tokens,
+           SUM(COALESCE(wn.output_tokens, 0))::bigint AS subtree_window_output_tokens,
+           SUM(COALESCE(wn.cache_read_input_tokens, 0))::bigint
+               AS subtree_window_cache_read_input_tokens,
+           SUM(COALESCE(wn.cache_creation_input_tokens, 0))::bigint
+               AS subtree_window_cache_creation_input_tokens,
+           MIN(t.cost_microusd) FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+               AS own_cost_microusd,
+           MIN(t.input_tokens) FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+               AS own_input_tokens,
+           MIN(t.output_tokens) FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+               AS own_output_tokens,
+           MIN(t.cache_read_input_tokens)
+               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+               AS own_cache_read_input_tokens,
+           MIN(t.cache_creation_input_tokens)
+               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+               AS own_cache_creation_input_tokens,
+           BOOL_AND(t.tokens_complete)
+               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+               AS own_tokens_complete,
+           SUM(COALESCE(wn.cost_microusd, 0))
+               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+               AS own_window_cost_microusd,
+           SUM(COALESCE(wn.input_tokens, 0))
+               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+               AS own_window_input_tokens,
+           SUM(COALESCE(wn.output_tokens, 0))
+               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+               AS own_window_output_tokens,
+           SUM(COALESCE(wn.cache_read_input_tokens, 0))
+               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+               AS own_window_cache_read_input_tokens,
+           SUM(COALESCE(wn.cache_creation_input_tokens, 0))
+               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+               AS own_window_cache_creation_input_tokens
+      FROM capped t
+      LEFT JOIN LATERAL (
+           SELECT SUM(l.cost_microusd) AS cost_microusd,
+                  SUM(l.input_tokens) AS input_tokens,
+                  SUM(l.output_tokens) AS output_tokens,
+                  SUM(l.cache_read_input_tokens) AS cache_read_input_tokens,
+                  SUM(l.cache_creation_input_tokens) AS cache_creation_input_tokens
+             FROM inference_usage_ledger l
+            WHERE l.account_id = $3
+              AND ((t.kind = 'session' AND l.session_id = t.id)
+                OR (t.kind = 'run' AND l.run_id = t.id))
+              AND l.occurred_at >= now() - ($4 * interval '1 second')
+      ) wn ON TRUE
+     GROUP BY t.root_kind, t.root_id
+),
+coverage AS (
+    SELECT usage_ledger_started_at AS coverage_started_at,
+           LEAST(
+               $4,
+               GREATEST(
+                   1,
+                   FLOOR(EXTRACT(EPOCH FROM (now() - usage_ledger_started_at)))::integer
+               )
+           ) AS observed_seconds
+      FROM accounts WHERE id = $3
+)
+SELECT r.kind AS root_kind, r.id AS root_id,
+       total.own_cost_microusd,
+       total.own_input_tokens,
+       total.own_output_tokens,
+       total.own_cache_read_input_tokens,
+       total.own_cache_creation_input_tokens,
+       total.own_tokens_complete,
+       total.subtree_cost_microusd,
+       total.subtree_input_tokens,
+       total.subtree_output_tokens,
+       total.subtree_cache_read_input_tokens,
+       total.subtree_cache_creation_input_tokens,
+       total.subtree_tokens_complete,
+       total.own_window_cost_microusd,
+       total.own_window_input_tokens,
+       total.own_window_output_tokens,
+       total.own_window_cache_read_input_tokens,
+       total.own_window_cache_creation_input_tokens,
+       total.subtree_window_cost_microusd,
+       total.subtree_window_input_tokens,
+       total.subtree_window_output_tokens,
+       total.subtree_window_cache_read_input_tokens,
+       total.subtree_window_cache_creation_input_tokens,
+       coverage.coverage_started_at, coverage.observed_seconds,
+       (SELECT COUNT(*) FROM capped) AS pair_count
+  FROM roots r
+  JOIN totals total ON total.root_kind = r.kind AND total.root_id = r.id
+  CROSS JOIN coverage
+"""
+
+
+# The account-scan statement: materializes every node of the account once and
+# reduces it with hash joins.  At whole-account subtree scale (the fallback's
+# only caller) this is the best known plan shape; for small root sets it is
+# pathological, which is why ``_SUBTREE_USAGE_SQL`` runs first.
 _BATCH_USAGE_SQL = r"""
 WITH RECURSIVE
 roots(kind, id) AS (
@@ -193,16 +376,28 @@ async def usage_for_nodes(
     account_id: str,
     window_seconds: int,
 ) -> dict[tuple[str, str], AttributedUsage]:
-    """Return coherent own/subtree usage for many roots in one SQL statement."""
+    """Return coherent own/subtree usage for many roots.
+
+    Runs the subtree-driven statement first and falls back to the account-scan
+    statement iff the walk overflows ``SUBTREE_PAIR_CAP`` (see the constant's
+    comment).  The transaction wrap exists to scope ``SET LOCAL``: ``jit = off``
+    (JIT compilation costs more than either statement's typical execution) and
+    the statement timeout.  When the caller already holds a transaction this is
+    a savepoint and the settings persist until that transaction ends — every
+    current caller hydrates usage as its final read.
+    """
     if not roots:
         return {}
-    rows = await conn.fetch(
-        _BATCH_USAGE_SQL,
-        [root.kind for root in roots],
-        [root.id for root in roots],
-        account_id,
-        window_seconds,
-    )
+    kinds = [root.kind for root in roots]
+    ids = [root.id for root in roots]
+    async with conn.transaction():
+        await conn.execute(f"SET LOCAL statement_timeout = '{USAGE_STATEMENT_TIMEOUT_MS}ms'")
+        await conn.execute("SET LOCAL jit = off")
+        rows = await conn.fetch(
+            _SUBTREE_USAGE_SQL, kinds, ids, account_id, window_seconds, SUBTREE_PAIR_CAP + 1
+        )
+        if rows and int(rows[0]["pair_count"]) > SUBTREE_PAIR_CAP:
+            rows = await conn.fetch(_BATCH_USAGE_SQL, kinds, ids, account_id, window_seconds)
     return {
         (str(row["root_kind"]), str(row["root_id"])): _attributed(
             row, window_seconds=window_seconds

--- a/src/aios/db/queries/accounting.py
+++ b/src/aios/db/queries/accounting.py
@@ -381,7 +381,10 @@ async def usage_for_nodes(
     statement iff the walk overflows ``SUBTREE_PAIR_CAP`` (see the constant's
     comment).  Each statement is bounded client-side (asyncpg cancels the
     server query on expiry) — statement-scoped by construction, unlike a
-    ``SET LOCAL`` inside a caller's transaction.
+    ``SET LOCAL`` inside a caller's transaction.  The bound is per statement
+    (an overflowing page pays the probe, measured ~190ms, plus the fallback),
+    and a timeout deliberately does NOT try the other statement: overflow is a
+    plan-shape decision, timeout is a failure, and failures surface raw.
     """
     if not roots:
         return {}

--- a/src/aios/db/queries/accounting.py
+++ b/src/aios/db/queries/accounting.py
@@ -78,12 +78,34 @@ def _attributed(row: Any, *, window_seconds: int) -> AttributedUsage:
 # verified result-identical on production data (issue #2246).
 SUBTREE_PAIR_CAP = 4096
 
-# Per-statement bound for both usage statements, applied via ``SET LOCAL`` in
-# ``usage_for_nodes`` (the peer of ``USAGE_CONSUMERS_STATEMENT_TIMEOUT_MS``).
-# The account-scan fallback measured 4-6s warm on the largest production
-# account, so 5s would fail it chronically; 10s passes warm and converts a
-# cold-cache stall into an explicit error well before the pool's 30s bound.
+# One bound for every account-scale usage statement: the two hydration
+# statements here (per-fetch asyncpg timeout in ``usage_for_nodes``) and the
+# ranked-consumers view (``SET LOCAL`` in its service, which owns its own
+# transaction).  Both account-scale shapes measured 4-6s warm on the largest
+# production account with JIT off, so 5s would fail them chronically; 10s
+# passes warm and converts a cold-cache stall into an explicit error well
+# before the pool's 30s ``statement_timeout``.
 USAGE_STATEMENT_TIMEOUT_MS = 10_000
+
+
+def _coverage_cte(account_param: str, window_param: str) -> str:
+    """The per-account rate-coverage CTE body, shared by all three statements.
+
+    ``observed_seconds`` is the behavior-bearing clamp every ``_rate()`` divides
+    by; composing it keeps the three statements from drifting.
+    """
+    return f"""
+    SELECT usage_ledger_started_at AS coverage_started_at,
+           LEAST(
+               {window_param},
+               GREATEST(
+                   1,
+                   FLOOR(EXTRACT(EPOCH FROM (now() - usage_ledger_started_at)))::integer
+               )
+           ) AS observed_seconds
+      FROM accounts WHERE id = {account_param}
+"""
+
 
 # The subtree-driven statement: the recursive walk carries each node's own
 # counters (the child probe already touches the row, so the extra columns are
@@ -93,8 +115,10 @@ USAGE_STATEMENT_TIMEOUT_MS = 10_000
 # CTE-to-CTE joins, so the misestimated tree cardinality cannot flip the plan.
 # ``capped`` bounds the walk lazily: recursion stops once ``$5`` rows exist,
 # and ``pair_count = $5`` tells the caller the result is truncated (and thus
-# wrong — fall back).
-_SUBTREE_USAGE_SQL = r"""
+# wrong — fall back).  ``is_root`` is projected in ``capped``, not carried
+# through the recursion, where it would break the ``UNION`` dedup on a
+# malformed cycle re-entering its own root.
+_SUBTREE_USAGE_SQL = rf"""
 WITH RECURSIVE
 roots(kind, id) AS (
     SELECT * FROM unnest($1::text[], $2::text[])
@@ -143,7 +167,8 @@ tree(root_kind, root_id, kind, id, cost_microusd, input_tokens, output_tokens,
       ) child ON TRUE
 ),
 capped AS (
-    SELECT * FROM tree LIMIT $5
+    SELECT tree.*, kind = root_kind AND id = root_id AS is_root
+      FROM tree LIMIT $5
 ),
 totals AS (
     SELECT t.root_kind, t.root_id,
@@ -160,35 +185,29 @@ totals AS (
                AS subtree_window_cache_read_input_tokens,
            SUM(COALESCE(wn.cache_creation_input_tokens, 0))::bigint
                AS subtree_window_cache_creation_input_tokens,
-           MIN(t.cost_microusd) FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+           MIN(t.cost_microusd) FILTER (WHERE t.is_root)
                AS own_cost_microusd,
-           MIN(t.input_tokens) FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+           MIN(t.input_tokens) FILTER (WHERE t.is_root)
                AS own_input_tokens,
-           MIN(t.output_tokens) FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+           MIN(t.output_tokens) FILTER (WHERE t.is_root)
                AS own_output_tokens,
-           MIN(t.cache_read_input_tokens)
-               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+           MIN(t.cache_read_input_tokens) FILTER (WHERE t.is_root)
                AS own_cache_read_input_tokens,
-           MIN(t.cache_creation_input_tokens)
-               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+           MIN(t.cache_creation_input_tokens) FILTER (WHERE t.is_root)
                AS own_cache_creation_input_tokens,
-           BOOL_AND(t.tokens_complete)
-               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)
+           BOOL_AND(t.tokens_complete) FILTER (WHERE t.is_root)
                AS own_tokens_complete,
-           SUM(COALESCE(wn.cost_microusd, 0))
-               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+           SUM(COALESCE(wn.cost_microusd, 0)) FILTER (WHERE t.is_root)::bigint
                AS own_window_cost_microusd,
-           SUM(COALESCE(wn.input_tokens, 0))
-               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+           SUM(COALESCE(wn.input_tokens, 0)) FILTER (WHERE t.is_root)::bigint
                AS own_window_input_tokens,
-           SUM(COALESCE(wn.output_tokens, 0))
-               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+           SUM(COALESCE(wn.output_tokens, 0)) FILTER (WHERE t.is_root)::bigint
                AS own_window_output_tokens,
            SUM(COALESCE(wn.cache_read_input_tokens, 0))
-               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+               FILTER (WHERE t.is_root)::bigint
                AS own_window_cache_read_input_tokens,
            SUM(COALESCE(wn.cache_creation_input_tokens, 0))
-               FILTER (WHERE t.kind = t.root_kind AND t.id = t.root_id)::bigint
+               FILTER (WHERE t.is_root)::bigint
                AS own_window_cache_creation_input_tokens
       FROM capped t
       LEFT JOIN LATERAL (
@@ -198,25 +217,16 @@ totals AS (
                   SUM(l.cache_read_input_tokens) AS cache_read_input_tokens,
                   SUM(l.cache_creation_input_tokens) AS cache_creation_input_tokens
              FROM inference_usage_ledger l
-            WHERE l.account_id = $3
+            WHERE (SELECT COUNT(*) FROM capped) < $5
+              AND l.account_id = $3
               AND ((t.kind = 'session' AND l.session_id = t.id)
                 OR (t.kind = 'run' AND l.run_id = t.id))
               AND l.occurred_at >= now() - ($4 * interval '1 second')
       ) wn ON TRUE
      GROUP BY t.root_kind, t.root_id
 ),
-coverage AS (
-    SELECT usage_ledger_started_at AS coverage_started_at,
-           LEAST(
-               $4,
-               GREATEST(
-                   1,
-                   FLOOR(EXTRACT(EPOCH FROM (now() - usage_ledger_started_at)))::integer
-               )
-           ) AS observed_seconds
-      FROM accounts WHERE id = $3
-)
-SELECT r.kind AS root_kind, r.id AS root_id,
+coverage AS ({_coverage_cte("$3", "$4")})
+SELECT total.root_kind, total.root_id,
        total.own_cost_microusd,
        total.own_input_tokens,
        total.own_output_tokens,
@@ -241,8 +251,7 @@ SELECT r.kind AS root_kind, r.id AS root_id,
        total.subtree_window_cache_creation_input_tokens,
        coverage.coverage_started_at, coverage.observed_seconds,
        (SELECT COUNT(*) FROM capped) AS pair_count
-  FROM roots r
-  JOIN totals total ON total.root_kind = r.kind AND total.root_id = r.id
+  FROM totals total
   CROSS JOIN coverage
 """
 
@@ -251,7 +260,7 @@ SELECT r.kind AS root_kind, r.id AS root_id,
 # reduces it with hash joins.  At whole-account subtree scale (the fallback's
 # only caller) this is the best known plan shape; for small root sets it is
 # pathological, which is why ``_SUBTREE_USAGE_SQL`` runs first.
-_BATCH_USAGE_SQL = r"""
+_BATCH_USAGE_SQL = rf"""
 WITH RECURSIVE
 roots(kind, id) AS (
     SELECT * FROM unnest($1::text[], $2::text[])
@@ -324,17 +333,7 @@ totals AS (
       LEFT JOIN window_node wn ON wn.kind = t.kind AND wn.id = t.id
      GROUP BY t.root_kind, t.root_id
 ),
-coverage AS (
-    SELECT usage_ledger_started_at AS coverage_started_at,
-           LEAST(
-               $4,
-               GREATEST(
-                   1,
-                   FLOOR(EXTRACT(EPOCH FROM (now() - usage_ledger_started_at)))::integer
-               )
-           ) AS observed_seconds
-      FROM accounts WHERE id = $3
-)
+coverage AS ({_coverage_cte("$3", "$4")})
 SELECT r.kind AS root_kind, r.id AS root_id,
        own.cost_microusd AS own_cost_microusd,
        own.input_tokens AS own_input_tokens,
@@ -380,24 +379,28 @@ async def usage_for_nodes(
 
     Runs the subtree-driven statement first and falls back to the account-scan
     statement iff the walk overflows ``SUBTREE_PAIR_CAP`` (see the constant's
-    comment).  The transaction wrap exists to scope ``SET LOCAL``: ``jit = off``
-    (JIT compilation costs more than either statement's typical execution) and
-    the statement timeout.  When the caller already holds a transaction this is
-    a savepoint and the settings persist until that transaction ends — every
-    current caller hydrates usage as its final read.
+    comment).  Each statement is bounded client-side (asyncpg cancels the
+    server query on expiry) — statement-scoped by construction, unlike a
+    ``SET LOCAL`` inside a caller's transaction.
     """
     if not roots:
         return {}
     kinds = [root.kind for root in roots]
     ids = [root.id for root in roots]
-    async with conn.transaction():
-        await conn.execute(f"SET LOCAL statement_timeout = '{USAGE_STATEMENT_TIMEOUT_MS}ms'")
-        await conn.execute("SET LOCAL jit = off")
+    timeout = USAGE_STATEMENT_TIMEOUT_MS / 1000
+    rows = await conn.fetch(
+        _SUBTREE_USAGE_SQL,
+        kinds,
+        ids,
+        account_id,
+        window_seconds,
+        SUBTREE_PAIR_CAP + 1,
+        timeout=timeout,
+    )
+    if rows and int(rows[0]["pair_count"]) > SUBTREE_PAIR_CAP:
         rows = await conn.fetch(
-            _SUBTREE_USAGE_SQL, kinds, ids, account_id, window_seconds, SUBTREE_PAIR_CAP + 1
+            _BATCH_USAGE_SQL, kinds, ids, account_id, window_seconds, timeout=timeout
         )
-        if rows and int(rows[0]["pair_count"]) > SUBTREE_PAIR_CAP:
-            rows = await conn.fetch(_BATCH_USAGE_SQL, kinds, ids, account_id, window_seconds)
     return {
         (str(row["root_kind"]), str(row["root_id"])): _attributed(
             row, window_seconds=window_seconds
@@ -523,17 +526,7 @@ rollup AS (
         ON wn.kind = t.kind AND wn.id = t.id
      GROUP BY t.root_kind, t.root_id
 ),
-coverage AS (
-    SELECT usage_ledger_started_at AS coverage_started_at,
-           LEAST(
-               $2,
-               GREATEST(
-                   1,
-                   FLOOR(EXTRACT(EPOCH FROM (now() - usage_ledger_started_at)))::integer
-               )
-           ) AS observed_seconds
-      FROM accounts WHERE id = $1
-),
+coverage AS ({_coverage_cte("$1", "$2")}),
 rankable AS (
     SELECT n.*, r.*,
            n.cost_microusd AS own_cost_microusd,

--- a/src/aios/services/accounting.py
+++ b/src/aios/services/accounting.py
@@ -7,9 +7,8 @@ from typing import Any
 import asyncpg
 
 from aios.db.queries import accounting as accounting_queries
+from aios.db.queries.accounting import USAGE_STATEMENT_TIMEOUT_MS
 from aios.models.accounting import UsageConsumersResponse, UsageMetric
-
-USAGE_CONSUMERS_STATEMENT_TIMEOUT_MS = 5_000
 
 
 async def ranked_consumers(
@@ -21,10 +20,11 @@ async def ranked_consumers(
     limit: int,
 ) -> UsageConsumersResponse:
     """Return additive account roots ranked by live subtree rate."""
+    # One shared bound for every account-scale usage statement (#2246): the
+    # previous 5s bound chronically failed the largest production account
+    # (measured 11.6s with JIT, 4-4.3s with the pool's jit=off).
     async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
-        await conn.execute(
-            f"SET LOCAL statement_timeout = '{USAGE_CONSUMERS_STATEMENT_TIMEOUT_MS}ms'"
-        )
+        await conn.execute(f"SET LOCAL statement_timeout = '{USAGE_STATEMENT_TIMEOUT_MS}ms'")
         coverage_started_at, total_rate, items = await accounting_queries.ranked_consumers(
             conn,
             account_id=account_id,

--- a/tests/integration/test_creation_edge_accounting.py
+++ b/tests/integration/test_creation_edge_accounting.py
@@ -437,7 +437,7 @@ async def test_ranked_timeout_rolls_back_and_releases_pool_connection(
         await conn.execute("SELECT pg_sleep(0.05)")
         raise AssertionError("statement timeout did not fire")
 
-    monkeypatch.setattr(accounting_service, "USAGE_CONSUMERS_STATEMENT_TIMEOUT_MS", 1)
+    monkeypatch.setattr(accounting_service, "USAGE_STATEMENT_TIMEOUT_MS", 1)
     monkeypatch.setattr(accounting_queries, "ranked_consumers", _slow_query)
     with pytest.raises(asyncpg.QueryCanceledError):
         await accounting_service.ranked_consumers(

--- a/tests/integration/test_creation_edge_accounting.py
+++ b/tests/integration/test_creation_edge_accounting.py
@@ -293,7 +293,9 @@ async def test_account_scan_fallback_is_result_identical_to_subtree_path(
         UsageNodeRef(kind="run", id="wfr_does_not_exist"),
     ]
 
-    async with accounting_pool.acquire() as conn:
+    # One transaction pins now() (transaction_timestamp) across both paths, so
+    # observed_seconds — and thus every rate — cannot drift between the calls.
+    async with accounting_pool.acquire() as conn, conn.transaction():
         subtree_conn = _FetchCountingConn(conn)
         via_subtree = await accounting_queries.usage_for_nodes(
             subtree_conn,

--- a/tests/integration/test_creation_edge_accounting.py
+++ b/tests/integration/test_creation_edge_accounting.py
@@ -256,6 +256,71 @@ async def test_descendant_mutation_moves_root_by_exact_amount_and_peer_invocatio
         )
 
 
+class _FetchCountingConn:
+    """Delegating proxy that counts ``fetch`` calls to observe path selection."""
+
+    def __init__(self, conn: asyncpg.Connection[Any]) -> None:
+        self._conn = conn
+        self.fetch_calls = 0
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._conn, name)
+
+    async def fetch(self, *args: Any, **kwargs: Any) -> Any:
+        self.fetch_calls += 1
+        return await self._conn.fetch(*args, **kwargs)
+
+
+async def test_account_scan_fallback_is_result_identical_to_subtree_path(
+    accounting_pool: asyncpg.Pool[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The two ``usage_for_nodes`` statements must agree exactly (#2246).
+
+    The subtree walk overflowing ``SUBTREE_PAIR_CAP`` switches to the
+    account-scan statement; a divergence there would silently misattribute
+    usage only on large accounts, so pin equality on a mixed
+    session -> run -> session chain with rolling-window ledger rows on both
+    node kinds.
+    """
+    root_id, run_id, child_id, _agent_id, _environment_id = await _seed_agent_workflow_agent_chain(
+        accounting_pool
+    )
+    await _charge_known_chain(accounting_pool, root_id, run_id, child_id)
+    roots = [
+        UsageNodeRef(kind="session", id=root_id),
+        UsageNodeRef(kind="run", id=run_id),
+        UsageNodeRef(kind="session", id=child_id),
+        UsageNodeRef(kind="run", id="wfr_does_not_exist"),
+    ]
+
+    async with accounting_pool.acquire() as conn:
+        subtree_conn = _FetchCountingConn(conn)
+        via_subtree = await accounting_queries.usage_for_nodes(
+            subtree_conn,
+            roots,
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+        assert subtree_conn.fetch_calls == 1
+
+        # A 3-node chain overflows a cap of 1, forcing the account-scan path.
+        monkeypatch.setattr(accounting_queries, "SUBTREE_PAIR_CAP", 1)
+        fallback_conn = _FetchCountingConn(conn)
+        via_account_scan = await accounting_queries.usage_for_nodes(
+            fallback_conn,
+            roots,
+            account_id=ACCOUNT,
+            window_seconds=86_400,
+        )
+        assert fallback_conn.fetch_calls == 2
+
+    assert set(via_subtree) == {("session", root_id), ("run", run_id), ("session", child_id)}
+    assert via_subtree[("session", root_id)].subtree.cost_microusd == 600
+    root_rate = via_subtree[("session", root_id)].subtree_rate
+    assert root_rate is not None and root_rate.cost_microusd_per_hour > 0
+    assert via_account_scan == via_subtree
+
+
 async def test_cycle_is_bounded_and_each_node_counts_once(
     accounting_pool: asyncpg.Pool[Any],
 ) -> None:

--- a/tests/unit/test_db_pool.py
+++ b/tests/unit/test_db_pool.py
@@ -67,6 +67,7 @@ async def test_pool_sets_timeouts_and_keepalive() -> None:
         ss = kwargs["server_settings"]
         assert ss["statement_timeout"] == "30000"
         assert ss["idle_in_transaction_session_timeout"] == "60000"
+        assert ss["jit"] == "off"
         assert ss["tcp_keepalives_idle"] == "60"
         assert ss["tcp_keepalives_interval"] == "10"
         assert ss["tcp_keepalives_count"] == "5"


### PR DESCRIPTION
Closes #2246.

## Root cause — verified with EXPLAIN ANALYZE on prod

`usage_for_nodes` (called on every fat session/run read: `get_session`, `list_sessions`, `get_run`, `archive_run`, `list_runs`) ran one statement whose `node_usage`/`window_node` CTEs materialized **every session and run of the account** before joining the requested subtrees: 104,731 rows, disk spill, ~380MB of buffer reads for a single leaf root. On top of that, JIT compilation added 170ms–8.4s per execution (cost estimates clear `jit_above_cost`; actual row counts stay small), and cold-vs-warm cache on the 380MB working set produced the 0.5s→30s+ variance the issue observed — including the apparent "control flip" on `/v1/runs`, which runs the same scans and was never a valid control.

The issue comment's proposed patch (`JOIN members` into those CTEs) was tested on prod and **refuted**: on the real top-100 page the 100 sessions' subtrees cover 103,725 of the account's 104,731 nodes, and PostgreSQL's recursive-CTE misestimate (~200 guessed vs ~103k actual) flips the CTE-to-CTE joins to nested loops — 55.1s vs 5.8s for the current shape.

## Fix — adaptive at the query sink

No single statement plans well for both a leaf and a whole-account page, so `usage_for_nodes` now:

1. Runs `_SUBTREE_USAGE_SQL`: the recursive walk carries each node's counters, `totals` reduces the walk directly (`own_*` via `FILTER` on the seed row), and the rolling window comes from per-node probes of the ledger's partial indexes — no CTE-to-CTE joins, so the misestimate cannot flip the plan. A lazy `LIMIT` caps the walk at `SUBTREE_PAIR_CAP` (4096 pairs) and a `pair_count` sentinel reports overflow.
2. On overflow, discards the probe (~190ms on the pathological page) and falls back to the unchanged account-scan statement — the right shape at that scale.
3. Bounds each statement with a per-fetch asyncpg timeout (`USAGE_STATEMENT_TIMEOUT_MS = 10s`) — statement-scoped by construction, unlike `SET LOCAL` inside the callers' snapshot transactions, which would leak.
4. Turns **JIT off pool-wide** (`db/pool.py` server_settings) — measured pure loss on aios's OLTP shapes.
5. Unifies the account-scale bound: `/v1/usage/consumers` now shares the 10s constant. Its old 5s bound was already chronically exceeded on the largest prod account (11.6s measured with JIT; 4.0–4.3s with jit off).

## Measured on prod (shipping SQL)

| | before | after |
|---|---|---|
| point read (`limit=1` shape) | 2,972ms cold / 507ms warm | **5.6ms** |
| whole-account top-100 page | 5.8s + JIT, unbounded jitter to 30s+ | 190ms probe + 4.2–5.8s fallback, bounded 10s |
| `/v1/usage/consumers` | 11.6s against a 5s bound | 4.0–4.3s against 10s |

## Correctness

- Old and new statements verified **result-identical on prod data**: single-snapshot `EXCEPT` in both directions returned 0 rows over a 10k-node mixed subtree, a run root with children, leaves, nonexistent roots, and nested ancestor/descendant roots.
- New integration test forces **both** paths over a session→run→session chain with rolling-window ledger rows on both node kinds and asserts identical results (`test_account_scan_fallback_is_result_identical_to_subtree_path`); the full `test_creation_edge_accounting.py` suite (7 tests, the #2228 discriminator) passes under Docker.
- `is_root` is projected in `capped`, not carried through the recursion, where it would break `UNION` dedup on a malformed cycle re-entering its own root (the existing cycle test covers this).

## Acceptance (from #2246)

- [x] `/v1/sessions?limit=100` returns within a stated bound or fails explicitly at it (10s per statement, under the pool's 30s)
- [x] `/v1/sessions?limit=1` comparable to `/v1/runs?limit=5` — the account-sized fixed cost is gone (ms-scale)
- [x] Discrimination: deep-subtree attribution intact — prod result-equality + the forced-both-paths integration test

## Residuals

- The whole-account full-view page costs ~5s irreducibly under per-root subtree attribution (Σ|subtree| ≈ N). The cure at that scale is the issue's step 2 (lazy hydration param / precomputed rollup) — future work.
- The substrate-health check should switch to `view=lite` (skips usage hydration entirely); seat-side change.
- Checks: mypy ✓ ruff ✓ unit 5,222 ✓ integration 1,087 ✓ (one pre-existing macOS-only failure in `test_invoke_session.py` — `/var` vs `/private/var` realpath, untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
