### PR TITLE
perf(sessions): bound the awaiting scan by open_tool_call_floor_seq (#2254)

### DIFF
--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -1886,10 +1886,9 @@ async def _unresolved_tool_calls(
     if not session_ids:
         return {}
     # ``data ? 'tool_calls'`` is the partial-index predicate on
-    # ``events_assistant_tool_calls_idx``; the ``jsonb_array_length > 0``
-    # post-filter narrows to non-empty arrays (the index admits
-    # ``null`` / ``[]`` too).  Without the ``?`` conjunct the planner
-    # falls back to the wider btree backing the ``events``
+    # ``events_assistant_tool_calls_idx``; empty/``null`` arrays the index
+    # admits simply explode to zero LATERAL rows.  Without the ``?`` conjunct
+    # the planner falls back to the wider btree backing the ``events``
     # ``UNIQUE (session_id, seq)`` constraint.
     #
     # ``$3`` carries the optional age bound (seconds); NULL disables it so
@@ -1897,72 +1896,76 @@ async def _unresolved_tool_calls(
     # the connector backfill (#744) passes a positive value to drop stale
     # sends.  ``make_interval`` keeps the bound parameterized rather than
     # string-interpolated into the SQL.
-    asst_rows = await conn.fetch(
+    #
+    # ``a.seq >= s.open_tool_call_floor_seq`` (#2254) is the sweep-maintained
+    # ghost-scan floor (migration 0136): a proven lower bound on the oldest
+    # still-open call's seq, advanced GREATEST-only by the ghost sweep.  It
+    # turns the O(session lifetime) history scan into O(open window).  The
+    # column defaults to 0 (unbounded), so behaviour is unchanged until a
+    # sweep advances it.  Do NOT short-circuit on ``open_tool_call_count``
+    # instead — the counter can undercount (see 0136's migration body); the
+    # floor-seq bound is the sanctioned form.
+    #
+    # The result-pairing check is a per-element ``NOT EXISTS`` probe on the
+    # UNIQUE ``events_tool_result_idx (session_id, data->>'tool_call_id')``
+    # (0097) — O(1) per tool_call — replacing the former second whole-history
+    # scan of every tool-role row plus an in-Python set diff.  Projecting the
+    # exploded ``tool_calls`` element (never the full assistant ``data``
+    # JSONB) keeps multi-KB turn payloads out of the wire/decode path.
+    #
+    # Join order is load-bearing: ``sessions`` drives, so the floor lands in
+    # the ``events_assistant_tool_calls_idx (session_id, seq)`` INDEX COND
+    # (verified by EXPLAIN in prod: 1274ms → 32ms on a 518k-event session).
+    # Written events-first, the planner scanned every assistant turn and
+    # applied the floor as a post-join filter — the bound bought nothing.
+    rows = await conn.fetch(
         """
-        SELECT session_id, data, created_at
-          FROM events
-         WHERE session_id = ANY($1::text[])
-           AND account_id = $2
-           AND kind = 'message'
-           AND role = 'assistant'
-           AND data ? 'tool_calls'
-           AND jsonb_array_length(
-                 COALESCE(NULLIF(data->'tool_calls','null'::jsonb), '[]'::jsonb)
-               ) > 0
+        SELECT a.session_id,
+               tc.item AS tool_call,
+               a.created_at
+          FROM sessions s
+          JOIN events a
+            ON a.session_id = s.id
+           AND a.account_id = $2
+           AND a.kind = 'message'
+           AND a.role = 'assistant'
+           AND a.data ? 'tool_calls'
+           AND a.seq >= s.open_tool_call_floor_seq
+         CROSS JOIN LATERAL jsonb_array_elements(
+               COALESCE(NULLIF(a.data->'tool_calls','null'::jsonb), '[]'::jsonb)
+             ) WITH ORDINALITY AS tc(item, ord)
+         WHERE s.id = ANY($1::text[])
+           AND s.account_id = $2
            AND (
                  $3::bigint IS NULL
-                 OR created_at >= now() - make_interval(secs => $3::bigint)
+                 OR a.created_at >= now() - make_interval(secs => $3::bigint)
                )
-         ORDER BY session_id, seq ASC
+           AND COALESCE(tc.item->>'id', '') <> ''
+           AND NOT EXISTS (
+                 SELECT 1
+                   FROM events r
+                  WHERE r.session_id = a.session_id
+                    AND r.account_id = $2
+                    AND r.kind = 'message'
+                    AND r.role = 'tool'
+                    AND r.data->>'tool_call_id' = tc.item->>'id'
+               )
+         ORDER BY a.session_id, a.seq ASC, tc.ord ASC
         """,
         session_ids,
         account_id,
         max_age_seconds,
     )
-    if not asst_rows:
-        return {}
-    results_by_sid = await _tool_result_ids_by_session(conn, session_ids, account_id=account_id)
     out: dict[str, list[dict[str, Any]]] = {}
-    for row in asst_rows:
-        sid: str = row["session_id"]
-        data = row["data"]
-        completed: set[str] = results_by_sid.get(sid, set())
-        for tc in data.get("tool_calls") or []:
-            if tc.get("id") and tc["id"] not in completed:
-                # Shallow copy so the read-model carries the parent
-                # assistant turn's created_at without mutating the parsed
-                # source dict (the jsonb codec may return a shared reference).
-                # Connector-SSE consumers
-                # build their own explicit output dicts, so this extra key
-                # never leaks into their payloads.
-                out.setdefault(sid, []).append({**tc, "_pending_since": row["created_at"]})
-    return out
-
-
-async def _tool_result_ids_by_session(
-    conn: asyncpg.Connection[Any],
-    session_ids: list[str],
-    *,
-    account_id: str,
-) -> dict[str, set[str]]:
-    """Map ``session_id → {tool_call_id}`` for every tool-role event."""
-    rows = await conn.fetch(
-        """
-        SELECT session_id, data->>'tool_call_id' AS tool_call_id
-          FROM events
-         WHERE session_id = ANY($1::text[])
-           AND account_id = $2
-           AND kind = 'message'
-           AND role = 'tool'
-        """,
-        session_ids,
-        account_id,
-    )
-    out: dict[str, set[str]] = {}
-    for r in rows:
-        tcid = r["tool_call_id"]
-        if tcid:
-            out.setdefault(r["session_id"], set()).add(tcid)
+    for row in rows:
+        # Shallow copy so the read-model carries the parent assistant turn's
+        # created_at without mutating the parsed source dict (the jsonb codec
+        # may return a shared reference).  Connector-SSE consumers build their
+        # own explicit output dicts, so this extra key never leaks into their
+        # payloads.
+        out.setdefault(row["session_id"], []).append(
+            {**row["tool_call"], "_pending_since": row["created_at"]}
+        )
     return out
 
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1110,6 +1110,13 @@ def _classify_awaiting(
     return None
 
 
+# One bound for the awaiting read-model's statements (#2254), sibling of
+# ``USAGE_STATEMENT_TIMEOUT_MS`` (#2249): the floor-bounded scan is
+# milliseconds in steady state; seconds here means a floor-less whale
+# session, and the listing should fail fast rather than hold its slot.
+AWAITING_STATEMENT_TIMEOUT_MS = 10_000
+
+
 async def compute_awaiting(
     pool: asyncpg.Pool[Any], sessions: list[Session], *, account_id: str
 ) -> dict[str, list[AwaitingToolCall]]:
@@ -1121,7 +1128,12 @@ async def compute_awaiting(
     """
     if not sessions:
         return {}
-    async with pool.acquire() as conn:
+    # Bounded like the usage CTEs (#2249) and ``/v1/usage/consumers``: a read
+    # model should degrade (raise at the bound), not hang to the pool's 30s
+    # default while holding a listing request open (#2254).  ``SET LOCAL`` is
+    # transaction-scoped, hence the explicit read-only transaction.
+    async with pool.acquire() as conn, conn.transaction(readonly=True):
+        await conn.execute(f"SET LOCAL statement_timeout = '{AWAITING_STATEMENT_TIMEOUT_MS}ms'")
         unresolved_by_sid = await queries.list_unresolved_tool_calls_batch(
             conn, [s.id for s in sessions], account_id=account_id
         )

--- a/tests/integration/test_awaiting_floor_seq_bound.py
+++ b/tests/integration/test_awaiting_floor_seq_bound.py
@@ -1,0 +1,194 @@
+"""Integration tests for #2254: the awaiting read-model's history scan is
+bounded by ``sessions.open_tool_call_floor_seq`` (migration 0136), and the
+former two-scan + in-Python diff is a single SQL anti-join.
+
+Discrimination proof, both directions (a guard only ever seen to permit is
+indistinguishable from one that permits everything):
+
+* ``test_bound_is_applied`` FAILS IF THE BOUND IS REMOVED — with the floor
+  raised above an open call's seq, that call must vanish from the batch.  (A
+  floor the sweep maintains never sits above a genuinely open call — invariant
+  of #1746 — so hiding it here is safe to assert on; the test forges the floor
+  precisely to make the bound observable.)
+* ``test_open_call_at_floor_surfaces`` FAILS IF THE BOUND IS TOO AGGRESSIVE —
+  the bound is ``>=``: an open call whose assistant event sits EXACTLY at the
+  floor must still surface.
+
+Plus behaviour-unchanged (floor 0 = unbounded, the migration default) and
+anti-join parity (resolved calls stay hidden, intra-turn order preserved).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.agents import ToolSpec
+from aios.models.sessions import Session
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+def _assistant(*tool_call_ids: str, name: str = "bash") -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": tcid,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+            for tcid in tool_call_ids
+        ],
+    }
+
+
+async def _set_floor(pool: asyncpg.Pool[Any], session_id: str, floor_seq: int) -> None:
+    """Forge ``open_tool_call_floor_seq`` directly.
+
+    Production writes go through the sweep's single GREATEST-only statement
+    (guarded by ``test_open_tool_call_floor_seq_single_writer``); tests forge
+    the column to place the floor exactly where each discrimination case
+    needs it.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE sessions SET open_tool_call_floor_seq = $1 WHERE id = $2",
+            floor_seq,
+            session_id,
+        )
+
+
+@pytest.fixture
+async def two_open_turns(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, Session, int, int]]:
+    """Yield ``(pool, account_id, session, a1_seq, a2_seq)`` for a log of
+    A1(tc_old) → user → A2(tc_new), with NO tool_result for either."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_awaiting_floor_bound"
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, $2)",
+                account_id,
+                "awaiting-floor-bound-test",
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool,
+            account_id=account_id,
+            prefix="awaiting-floor-bound",
+            tools=[ToolSpec(type="bash")],
+        )
+        async with pool.acquire() as conn:
+            a1 = await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session.id,
+                kind="message",
+                data=_assistant("tc_old"),
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session.id,
+                kind="message",
+                data={"role": "user", "content": "are you still there?"},
+            )
+            a2 = await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session.id,
+                kind="message",
+                data=_assistant("tc_new"),
+            )
+        yield pool, account_id, session, a1.seq, a2.seq
+    finally:
+        await pool.close()
+
+
+async def _unresolved_ids(
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
+) -> list[str]:
+    async with pool.acquire() as conn:
+        batch = await queries.list_unresolved_tool_calls_batch(
+            conn, [session_id], account_id=account_id
+        )
+    return [e["tool_call_id"] for e in batch.get(session_id, [])]
+
+
+class TestAwaitingFloorSeqBound:
+    async def test_default_floor_is_unbounded(
+        self, two_open_turns: tuple[asyncpg.Pool[Any], str, Session, int, int]
+    ) -> None:
+        """Migration default (floor 0): behaviour unchanged — every open call
+        from the whole history surfaces, #741 span semantics intact."""
+        pool, account_id, session, _a1_seq, _a2_seq = two_open_turns
+        assert await _unresolved_ids(pool, session.id, account_id=account_id) == [
+            "tc_old",
+            "tc_new",
+        ]
+
+    async def test_bound_is_applied(
+        self, two_open_turns: tuple[asyncpg.Pool[Any], str, Session, int, int]
+    ) -> None:
+        """FAILS IF THE BOUND IS REMOVED: floor above A1 hides tc_old."""
+        pool, account_id, session, _a1_seq, a2_seq = two_open_turns
+        await _set_floor(pool, session.id, a2_seq)
+        assert await _unresolved_ids(pool, session.id, account_id=account_id) == ["tc_new"], (
+            "open_tool_call_floor_seq did not bound the awaiting scan — a "
+            "forged floor above tc_old's assistant seq must exclude it (#2254)"
+        )
+
+    async def test_open_call_at_floor_surfaces(
+        self, two_open_turns: tuple[asyncpg.Pool[Any], str, Session, int, int]
+    ) -> None:
+        """FAILS IF THE BOUND IS TOO AGGRESSIVE: the bound is ``>=`` — an open
+        call sitting EXACTLY at the floor (the sweep's normal steady state:
+        the floor IS the oldest open call's seq) must still surface."""
+        pool, account_id, session, a1_seq, _a2_seq = two_open_turns
+        await _set_floor(pool, session.id, a1_seq)
+        assert await _unresolved_ids(pool, session.id, account_id=account_id) == [
+            "tc_old",
+            "tc_new",
+        ], (
+            "an open call at seq == open_tool_call_floor_seq was hidden — the "
+            "bound must be inclusive (>=), or the sweep's own floor placement "
+            "(floor = oldest open call's seq, #1746) would hide real work"
+        )
+
+    async def test_anti_join_parity_and_order(
+        self, two_open_turns: tuple[asyncpg.Pool[Any], str, Session, int, int]
+    ) -> None:
+        """The SQL anti-join matches the old two-scan + set-diff semantics:
+        a resolved call disappears, unresolved intra-turn order is preserved."""
+        pool, account_id, session, _a1_seq, _a2_seq = two_open_turns
+        async with pool.acquire() as conn:
+            # A third assistant turn with TWO calls; resolve only the first.
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session.id,
+                kind="message",
+                data=_assistant("tc_a", "tc_b"),
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session.id,
+                kind="message",
+                data={"role": "tool", "tool_call_id": "tc_a", "content": "done"},
+            )
+        assert await _unresolved_ids(pool, session.id, account_id=account_id) == [
+            "tc_old",
+            "tc_new",
+            "tc_b",
+        ]


### PR DESCRIPTION
Fixes #2254.

## What

`compute_awaiting()` → `_unresolved_tool_calls` ran **two unbounded full-history scans of `events` per session page** (all assistant-with-tool_calls turns + every tool-result row), O(session lifetime) — measured 1.3s for a 518k-event session, paid on every default `/v1/sessions` listing including `view=lite`.

Three changes, exactly the issue's scope:

1. **Floor bound**: `a.seq >= s.open_tool_call_floor_seq` (migration 0136, the sweep-maintained ghost-scan floor, already used by the sweep for its identical scan). `sessions` drives the join so the floor lands in the `events_assistant_tool_calls_idx (session_id, seq)` **index cond** — written events-first the planner applied it as a post-join filter and the bound bought nothing (EXPLAIN-verified both ways in prod). Floor 0 = unbounded → behaviour unchanged until a sweep advances it. No `open_tool_call_count == 0` short-circuit (the 0136 Chesterton's Fence: the counter can undercount).
2. **Single anti-join**: the second whole-history tool-result scan + in-Python set diff becomes a per-element `NOT EXISTS` probe on the UNIQUE `events_tool_result_idx (session_id, data->>'tool_call_id')` — O(1) per call — and the query projects only the exploded `tool_calls` element, never the full assistant `data` JSONB. `_tool_result_ids_by_session` deleted (no other callers).
3. **`statement_timeout` (10s)** on the awaiting read path inside a read-only transaction, matching #2249's usage-CTE bound. Raise-at-bound, no silent degrade — an empty `awaiting` that lies is worse than a failed listing.

No new indexes (per the issue: not a missing-index bug). #741 span-all-assistants semantics and the #744 connector age-bound paths unchanged (`max_age_seconds` still `NULL` for the read model).

## Prod evidence (same session ids, EXPLAIN ANALYZE + \timing, control-style)

| session | before (2 scans) | after |
|---|---|---|
| 518k events, floor maintained (518,357) | ~1,274ms | **32ms** |
| 557k events, floor **0** | ~1,274ms | 950ms |

The floor-0 whale improves only by the result-scan drop: its floor never advances because the sweep's floor writer only visits sessions passing the `open_tool_call_count > 0` gate. **Named residual** (kept out of scope — the floor column is single-writer by design): advancing floors for count-0 sessions would need a sweep-side change, filed as a follow-up note on #2254.

## Tests

`tests/integration/test_awaiting_floor_seq_bound.py` — discrimination proof in both directions, mutation-verified locally:

- bound **removed** (`AND TRUE`) → `test_bound_is_applied` fails ✅
- bound **too aggressive** (`>=` → `>`) → `test_open_call_at_floor_surfaces` fails ✅
- floor 0 default → behaviour unchanged (#741 ordering intact)
- anti-join parity: resolved call hidden, intra-turn `WITH ORDINALITY` order preserved

39 tests green across the affected suites (`awaiting_spans_all_assistants`, `stale_connector_backfill`, `list_sessions_lite`, `classify_awaiting`, `sse_generator_cleanup`, `session_obligations_field`, floor single-writer guard); ruff + mypy clean.

## Acceptance checklist (from #2254)

- [x] Large-history session with maintained floor reads in control time (32ms)
- [x] `awaiting` still correct incl. open call older than any age window (floor-at-call test; `max_age_seconds=None` preserved)
- [x] Discrimination proof both directions (mutation-verified)
- [x] `view=lite` no longer pays the dominant hydration (the awaiting scan is now bounded; lite already skipped the rest)
- [x] Before/after on the same session ids with in-loop control-style comparison
- [x] EXPLAIN-confirmed mechanism (the issue's named gap): assistant scan dominated, 80k buffers → projection change warranted

🤖 Generated with [Claude Code](https://claude.com/claude-code)