### PR TITLE
fix(obligations): abridge oversized task in reminder instead of ordering a refusal (#2221)

### DIFF
--- a/src/aios/harness/obligations.py
+++ b/src/aios/harness/obligations.py
@@ -59,11 +59,46 @@ MAX_RENDERED_OBLIGATIONS = 10
 _TASK_MAX = 8192
 _TASK_TRUNCATED = "[TASK TRUNCATED — return an error; do not act on or infer the missing task]"
 
+# The genuinely-unavailable marker: NO content was ever persisted on the frame
+# (pre-#1413), so there is nothing to abridge and nothing to point at. Shared by
+# BOTH renderers — the tail block and the reminder surfaces — because #2080's
+# fail-loud property is correct on every surface: an absent task cannot be
+# recovered from anywhere, so improvising one is the exact hazard. Hoisted to a
+# module constant so the two paths can never drift on this wording.
+_TASK_UNAVAILABLE = "[TASK CONTENT UNAVAILABLE — return an error; do not infer the task]"
+
 # Chars of an oversized-but-present task echoed as a bounded preview beside the
 # pointer. Strictly smaller than :data:`_TASK_MAX`, so the abridged render is
 # never fatter than the at-cap VERBATIM render the reserved budget already
 # permits — the fence stays where #2080/#2071 put it.
 _TASK_PREVIEW = 2048
+
+# What an oversized task renders as on a surface that CANNOT establish whether the
+# original ask is still reachable (#2221 round 2): the quiescence nudge and the
+# ``list_obligations`` projection. Both are REMINDERS about a request that is, by
+# construction, still open — so ordering a refusal there is never justified:
+#
+# * the surface cannot prove the original is GONE, and
+# * a refusal order on the nudge path is strictly WORSE than the tail-block bug
+#   this issue opened for. The tail block is ephemeral and rebuilt each step; the
+#   nudge is written to the event log as a DURABLE user message (up to
+#   ``REQUEST_NUDGE_BUDGET`` times) and then sits in the window permanently. #2080's
+#   own evidence is that a model obeys a trailing refuse-order, so emitting one here
+#   re-parks exactly the oversized-payload sessions #2221 exists to unpark.
+#
+# Deliberately carries NO content prefix. On the tail block a preview is safe
+# because presence is ESTABLISHED — the full task is intact earlier in the same
+# prompt, so the preview is redundant signal, not a substitute. Here presence is
+# unknown, and a plausible-looking prefix of an unrecoverable task is precisely
+# #2080's improvisation hazard (a sub-agent read a prefix and invented the rest).
+# A bare char-count pointer refuses BOTH failure modes: it never orders a refusal,
+# and it offers nothing to improvise from. It also keeps the durable nudge event
+# small regardless of task size.
+_REMINDER_ABRIDGED = (
+    "[TASK ABRIDGED IN THIS REMINDER — {chars} characters, over this reminder's "
+    "{cap}-character budget. This is a reminder, not the task: the original request "
+    "message carries it in full. Do not refuse on account of this line.]"
+)
 
 # Max chars of a rendered ``output_schema`` contract (#1522). Kept narrower
 # than the task budget because a schema is a structural contract and usually
@@ -133,7 +168,7 @@ def _request_content(summary: str | None, *, original_present: bool = False) -> 
     opt into the softer render.
     """
     if summary is None:
-        return "[TASK CONTENT UNAVAILABLE — return an error; do not infer the task]"
+        return _TASK_UNAVAILABLE
     if len(summary) > _TASK_MAX:
         if not original_present:
             return f"{_TASK_TRUNCATED} (received {len(summary)} characters; limit {_TASK_MAX})"
@@ -143,6 +178,41 @@ def _request_content(summary: str | None, *, original_present: bool = False) -> 
             f"budget {_TASK_MAX}. Do not refuse; read the original message above.]\n"
             f"{summary[:_TASK_PREVIEW]}"
         )
+    return summary
+
+
+def _reminder_content(summary: str | None) -> str:
+    """Render a task for a **reminder surface that cannot establish presence**.
+
+    The sibling of :func:`_request_content` for the two consumers of
+    :func:`render_owed_entry` — the quiescence-attempt nudge and the
+    ``list_obligations`` tool. Neither holds a post-windowing slate, so neither can
+    answer "is the original ask still in the context?" the way
+    :func:`~aios.harness.step_context.compose_step_context` can.
+
+    This is a DISTINCT function rather than a presence flag on
+    :func:`_request_content` on purpose. A boolean threaded through these callers
+    could only ever be a *guess* at presence, and a guess that says "present" is the
+    false-reassurance hazard #2080 exists to prevent. The surface class is a static
+    fact about the caller, not a runtime claim about the window, so it is encoded
+    in WHICH renderer the caller picks.
+
+    * ``summary is None`` -> the loud unavailable marker, unchanged. Nothing was
+      ever persisted on the frame, so there is no task to point AT; #2080's
+      fail-loud property is correct here and is preserved verbatim.
+    * within :data:`_TASK_MAX` -> verbatim, byte-for-byte (identical to the tail).
+    * oversized -> a NEUTRAL bounded pointer (:data:`_REMINDER_ABRIDGED`) with no
+      refusal imperative and no content prefix.
+
+    The invariant: **a surface that cannot establish the original is GONE must not
+    order a refusal.** These surfaces are reminders about a still-open request, so
+    the honest render is "this line is abridged; the request message has the whole
+    thing" — never "return an error".
+    """
+    if summary is None:
+        return _TASK_UNAVAILABLE
+    if len(summary) > _TASK_MAX:
+        return _REMINDER_ABRIDGED.format(chars=len(summary), cap=_TASK_MAX)
     return summary
 
 
@@ -256,17 +326,33 @@ def render_owed_entry(obligation: Obligation, *, session_id: str, now: datetime)
 
     Each entry carries ``request_id``, ``caller_kind`` (the trusted frame kind),
     ``origin`` (``api``/``session``/``run`` plus ``self`` for a #1414 self-goal),
-    the verbatim task in ``summary`` (or a loud truncation marker), a terse
-    ``age``, and the **bounded**
+    the task in ``summary``, a terse ``age``, and the **bounded**
     ``output_schema`` contract (elided to :data:`_SCHEMA_MAX`; ``None`` when the
     request demands no schema). The schema bound is what lets the surfacing render
     stay within :func:`max_obligations_block_local`'s upper bound.
+
+    ``summary`` renders through :func:`_reminder_content`, NOT
+    :func:`_request_content` (#2221 round 2). Both consumers above are REMINDER
+    surfaces: they run without a post-windowing slate, so neither can establish
+    that the original ask has been evicted — and the nudge consumer persists its
+    render as a durable user event. An oversized task therefore renders as a
+    neutral bounded pointer with no refusal imperative; only a genuinely absent
+    ``summary`` (nothing on the frame) still fails loud. The tail block keeps
+    :func:`_request_content`, which CAN prove presence and so can safely show a
+    preview.
     """
     return {
         "request_id": obligation.request_id,
         "caller_kind": obligation.caller_kind or "",
         "origin": _origin_label(obligation, session_id=session_id),
-        "summary": _request_content(obligation.summary),
+        # #2221 round 2: the REMINDER renderer, not ``_request_content``. Both
+        # consumers of this projection (the quiescence nudge, ``list_obligations``)
+        # are reminders about a STILL-OPEN request on a surface that cannot see the
+        # post-windowing slate, so neither can establish that the original ask is
+        # gone — and the nudge writes its render to the event log DURABLY. Emitting
+        # a refuse-order from here re-parks the very sessions #2221 unparks, through
+        # a more permanent door than the ephemeral tail block ever had.
+        "summary": _reminder_content(obligation.summary),
         "age": _format_age(obligation.opened_at, now),
         "output_schema": _render_schema(obligation.output_schema),
     }

--- a/src/aios/harness/obligations.py
+++ b/src/aios/harness/obligations.py
@@ -40,11 +40,30 @@ if TYPE_CHECKING:
 # complementary per-session open-goal admission cap.
 MAX_RENDERED_OBLIGATIONS = 10
 
-# Requests up to this size remain verbatim in the always-on reminder. Beyond it,
-# render a loud refusal instruction rather than a plausible-looking prefix. This
-# bounds the reserved tail while making instruction loss impossible to miss.
+# Requests up to this size remain verbatim in the always-on reminder. Beyond it
+# the reminder cannot re-render the task in full without blowing the reserved tail
+# budget (see ``max_obligations_block_local``), so it renders one of two things —
+# and WHICH one turns on whether the original ask is still in the context window:
+#
+# * still in the window (#2221) -> a bounded preview + a pointer to the intact
+#   original. The task is NOT lost; it is sitting earlier in this same prompt, so
+#   an instruction to refuse it is simply false. Emitting one made every task over
+#   this cap structurally unbuildable: the child read the whole task, then read a
+#   trailing order to refuse it, and obeyed.
+# * genuinely gone (evicted, or no summary on the frame) -> the loud refuse marker
+#   (#2080). Here the task really is unrecoverable from context, and a
+#   plausible-looking prefix is what let a sub-agent improvise cross-repo writes.
+#
+# The cap itself is load-bearing and unchanged; only the behaviour AT the cap
+# depends on presence.
 _TASK_MAX = 8192
 _TASK_TRUNCATED = "[TASK TRUNCATED — return an error; do not act on or infer the missing task]"
+
+# Chars of an oversized-but-present task echoed as a bounded preview beside the
+# pointer. Strictly smaller than :data:`_TASK_MAX`, so the abridged render is
+# never fatter than the at-cap VERBATIM render the reserved budget already
+# permits — the fence stays where #2080/#2071 put it.
+_TASK_PREVIEW = 2048
 
 # Max chars of a rendered ``output_schema`` contract (#1522). Kept narrower
 # than the task budget because a schema is a structural contract and usually
@@ -91,12 +110,39 @@ def _format_age(opened_at: datetime, now: datetime) -> str:
     return f"{hours // 24}d"
 
 
-def _request_content(summary: str | None) -> str:
-    """Render a verbatim task, or a loud marker when that is impossible."""
+def _request_content(summary: str | None, *, original_present: bool = False) -> str:
+    """Render a verbatim task, an abridged one, or a loud marker.
+
+    ``original_present`` is the caller's answer to "is the ORIGINAL request user
+    message still in the rendered context window?" — knowable only from the
+    post-windowing slate, so it is threaded in rather than guessed here.
+
+    * ``summary is None`` -> the unavailable marker. No content exists on the
+      frame (pre-#1413), so there is nothing to abridge (#2080 fail-loud).
+    * within :data:`_TASK_MAX` -> verbatim, byte-for-byte.
+    * oversized AND the original is still in the window -> a bounded preview plus
+      a pointer to the intact original (#2221). The task is not lost, so a refuse
+      instruction here is FALSE and — being the last user-role content the model
+      reads — gets obeyed over the real task sitting earlier in the same prompt.
+    * oversized AND the original is gone -> the refuse marker (#2080). Now the
+      task really is unrecoverable, and a plausible prefix is the exact failure
+      that let a sub-agent improvise cross-repo writes.
+
+    Defaults to ``False`` so any caller that does NOT know the window state keeps
+    today's conservative fail-loud behaviour; only a caller holding the slate can
+    opt into the softer render.
+    """
     if summary is None:
         return "[TASK CONTENT UNAVAILABLE — return an error; do not infer the task]"
     if len(summary) > _TASK_MAX:
-        return f"{_TASK_TRUNCATED} (received {len(summary)} characters; limit {_TASK_MAX})"
+        if not original_present:
+            return f"{_TASK_TRUNCATED} (received {len(summary)} characters; limit {_TASK_MAX})"
+        return (
+            f"[TASK ABRIDGED IN THIS REMINDER — the full task is intact in the original "
+            f"request message earlier in this context; {len(summary)} characters, reminder "
+            f"budget {_TASK_MAX}. Do not refuse; read the original message above.]\n"
+            f"{summary[:_TASK_PREVIEW]}"
+        )
     return summary
 
 
@@ -121,16 +167,27 @@ def _render_schema(output_schema: dict[str, Any] | None) -> str | None:
     return text
 
 
-def _obligation_line(obligation: Obligation, *, session_id: str, now: datetime) -> str:
+def _obligation_line(
+    obligation: Obligation,
+    *,
+    session_id: str,
+    now: datetime,
+    present_request_ids: frozenset[str] = frozenset(),
+) -> str:
     """One render line for an obligation, oldest-first ordering applied by caller.
 
     The literal ``request_id`` comes first (copy-pasteable; the id the model
-    echoes to ``return``/``error``), followed by origin, age, and the verbatim
-    task. Tasks beyond the render budget are replaced wholesale by a loud marker;
-    no plausible-looking prefix is ever shown.
+    echoes to ``return``/``error``), followed by origin, age, and the task.
+    An oversized task is abridged (preview + pointer) when its original ask is
+    still in the window, and replaced by a loud marker when it is not — see
+    :func:`_request_content`. A plausible prefix is never shown WITHOUT either the
+    pointer or the marker.
     """
     origin = _origin_label(obligation, session_id=session_id)
-    request_content = _request_content(obligation.summary)
+    request_content = _request_content(
+        obligation.summary,
+        original_present=obligation.request_id in present_request_ids,
+    )
     age = _format_age(obligation.opened_at, now)
     return f"• {obligation.request_id} [{origin}] (open {age}) verbatim task: {request_content}"
 
@@ -140,6 +197,7 @@ def build_obligations_tail_block(
     *,
     session_id: str,
     now: datetime | None = None,
+    present_request_ids: frozenset[str] = frozenset(),
 ) -> dict[str, Any] | None:
     """Ephemeral per-step listing of every open awaited obligation (#1413).
 
@@ -151,10 +209,18 @@ def build_obligations_tail_block(
     Header line, then one line per obligation **oldest-first** (the caller already
     fetches them ``ORDER BY req.seq ASC``): the literal ``request_id``, an
     ``[origin]`` label (``api``|``session``|``run``, plus ``self`` for a #1414
-    self-goal), ``(open <age>)``, and the verbatim task (or a loud truncation
-    marker when it exceeds the render budget). The block is
+    self-goal), ``(open <age>)``, and the verbatim task (or, past the render
+    budget, an abridged preview + pointer when the original ask is still in the
+    window, else a loud marker). The block is
     capped at :data:`MAX_RENDERED_OBLIGATIONS` lines + a ``+K more`` marker so the
     reserved tail budget stays bounded regardless of obligation count.
+
+    ``present_request_ids`` is the set of ``request_id``s whose ORIGINAL request
+    user message survived windowing into this step's slate (#2221). The composer
+    computes it from the post-windowing events; it is the ONLY input that can
+    distinguish "oversized but recoverable from context" (abridge + point) from
+    "oversized and genuinely gone" (fail loud). Empty by default, which keeps the
+    conservative #2080 marker for any caller that cannot know.
 
     Returns ``None`` on an empty set (zero tail, zero tokens).
     """
@@ -165,7 +231,11 @@ def build_obligations_tail_block(
     lines = [_HEADER]
     rendered = obligations[:MAX_RENDERED_OBLIGATIONS]
     for ob in rendered:
-        lines.append(_obligation_line(ob, session_id=session_id, now=now))
+        lines.append(
+            _obligation_line(
+                ob, session_id=session_id, now=now, present_request_ids=present_request_ids
+            )
+        )
     remaining = len(obligations) - len(rendered)
     if remaining > 0:
         lines.append(f"…(+{remaining} more)")
@@ -254,10 +324,21 @@ def max_obligations_block_local(obligations: list[Obligation]) -> int:
     set is **already fetched** by ``compute_step_prelude``, so this bounds from the
     REAL obligations — the real count (capped at :data:`MAX_RENDERED_OBLIGATIONS`
     + the ``+K more`` marker line) and each rendered task (verbatim through
-    :data:`_TASK_MAX`, then replaced by a fixed loud marker). Strictly tighter than
-    a synthetic max; the produced tail at
+    :data:`_TASK_MAX`, then either abridged or marker-replaced). Strictly tighter
+    than a synthetic max; the produced tail at
     send time is guaranteed ≤ this bound, so reserving it never overshoots
     ``window_max``.
+
+    **Presence is unknowable here, so the bound assumes the FATTER branch.** This
+    runs at windowing time — BEFORE the slate exists — so it cannot know which
+    oversized tasks will render abridged (#2221: preview + pointer, ~
+    :data:`_TASK_PREVIEW` chars) versus marker-replaced (#2080: a short fixed
+    string). The abridged branch is strictly fatter, so the bound is computed with
+    every request treated as present. Costing the marker branch instead would
+    UNDER-RESERVE — measured 516 reserved against a 3240-token real render for 10
+    oversized obligations — and an under-reserved tail is exactly the
+    ``read_windowed_events`` budget overflow (→ step crash) the cap exists to
+    prevent.
 
     Returns 0 on an empty set (the block is ``None`` and nothing is appended).
     """
@@ -269,9 +350,13 @@ def max_obligations_block_local(obligations: list[Obligation]) -> int:
     # Render with a fixed ``now`` so the age clause has a stable (worst-case-ish)
     # width — ``4d`` etc. are all <= a handful of chars; the count/summary
     # dominate the bound. session_id="" keeps the origin label bare ("self" never
-    # widens the bound vs. the literal caller_kind).
+    # widens the bound vs. the literal caller_kind). Every request is treated as
+    # PRESENT so the bound covers the fatter abridged render (see docstring).
     block = build_obligations_tail_block(
-        obligations, session_id="", now=datetime(1970, 1, 1, tzinfo=UTC)
+        obligations,
+        session_id="",
+        now=datetime(1970, 1, 1, tzinfo=UTC),
+        present_request_ids=frozenset(ob.request_id for ob in obligations),
     )
     if block is None:
         return 0

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -546,6 +546,41 @@ def _agent_owes_response(messages: list[dict[str, Any]]) -> bool:
     return False
 
 
+def _present_request_ids(events: list[Event]) -> frozenset[str]:
+    """``request_id``s whose ORIGINAL request user message survived windowing.
+
+    The obligations tail (#1413) is rebuilt each step from a full-log query, so it
+    lists obligations whose original ask may or may not still be in the window.
+    That distinction decides how an OVERSIZED task renders (#2221):
+
+    * present -> the task is intact earlier in this same prompt, so the reminder
+      abridges it (bounded preview + a pointer to the original). Telling the model
+      to refuse here is false, and — being the last user-role content it reads —
+      gets obeyed over the real task sitting above.
+    * absent -> the task is genuinely unrecoverable from context, so the reminder
+      keeps #2080's loud refuse marker rather than a plausible-looking prefix.
+
+    Reads the same ``metadata.request.request_id`` stamp that
+    :func:`~aios.harness.context.render_user_event` surfaces as the reply marker,
+    off the POST-windowing slate. Defensive about shape throughout: a malformed
+    ``metadata`` blob yields no id rather than raising inside context assembly.
+    """
+    present: set[str] = set()
+    for event in events:
+        if event.kind != "message":
+            continue
+        metadata = event.data.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        request = metadata.get("request")
+        if not isinstance(request, dict):
+            continue
+        request_id = request.get("request_id")
+        if isinstance(request_id, str) and request_id:
+            present.add(request_id)
+    return frozenset(present)
+
+
 def _stub_reasoning_content_for_thinking_target(
     messages: list[dict[str, Any]], model: str
 ) -> list[dict[str, Any]]:
@@ -703,7 +738,18 @@ async def compose_step_context(
     # obligation IS the stimulus to act on, so it renders even after a tool
     # result (where ``build_obligations_tail_block`` returning non-None already
     # encodes "non-empty").
-    obligations_block = build_obligations_tail_block(prelude.obligations, session_id=session.id)
+    #
+    # ``present_request_ids`` (#2221) is computed from the POST-windowing slate:
+    # the request_ids whose ORIGINAL ask survived into this step's context. It is
+    # the only signal that distinguishes an oversized-but-recoverable task (render
+    # an abridged preview + a pointer to the intact original) from one genuinely
+    # gone (keep #2080's loud refuse marker). Computed here because this is the
+    # only layer that holds both the obligations and the windowed events.
+    obligations_block = build_obligations_tail_block(
+        prelude.obligations,
+        session_id=session.id,
+        present_request_ids=_present_request_ids(events),
+    )
     if obligations_block is not None:
         ctx.messages.append(obligations_block)
 

--- a/tests/unit/test_obligations.py
+++ b/tests/unit/test_obligations.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from aios.harness.obligations import (
+    _TASK_MAX,
+    _TASK_PREVIEW,
     MAX_RENDERED_OBLIGATIONS,
     build_obligations_tail_block,
     max_obligations_block_local,
@@ -98,6 +100,8 @@ class TestBuildObligationsTailBlock:
         assert "TRUNCATED" not in content
 
     def test_oversized_task_fails_loud_instead_of_showing_a_silent_prefix(self) -> None:
+        # ORIGINAL EVICTED (no present_request_ids): the task is genuinely
+        # unrecoverable from context, so #2080's loud marker is correct.
         ob = _ob("req_too_long", summary="dangerous instruction " * 1000)
         block = build_obligations_tail_block([ob], session_id="sess_x", now=_NOW)
         assert block is not None
@@ -105,6 +109,107 @@ class TestBuildObligationsTailBlock:
         assert "TASK TRUNCATED" in content
         assert "return an error; do not act on or infer" in content
         assert "dangerous instruction" not in content
+
+    def test_oversized_but_present_abridges_and_points_instead_of_refusing(self) -> None:
+        # THE #2221 DEFECT. The original ask is still in the window, so the task is
+        # NOT lost — it sits earlier in this same prompt. The reminder must abridge
+        # + point, never order a refusal: this block is the LAST user-role content
+        # the model reads, so a refuse-instruction here overrides the real task.
+        task = "BUILD TASK — implement the widget. " * 700
+        assert len(task) > _TASK_MAX
+        ob = _ob("req_present", summary=task)
+        block = build_obligations_tail_block(
+            [ob], session_id="sess_x", now=_NOW, present_request_ids=frozenset({"req_present"})
+        )
+        assert block is not None
+        content = block["content"]
+        assert "TASK ABRIDGED IN THIS REMINDER" in content
+        assert str(len(task)) in content
+        # The refuse-instruction — in every phrasing — must be absent.
+        assert "TASK TRUNCATED" not in content
+        assert "return an error" not in content
+        assert "do not act on or infer" not in content
+        # A real prefix of the task is shown, so the reminder still carries signal.
+        assert task[:200] in content
+
+    def test_abridged_preview_is_bounded_not_merely_shorter(self) -> None:
+        # The preview is a FIXED bound, not a fraction: a 10x larger task yields
+        # the same preview width, so the reserved tail can't be inflated by size.
+        small_over = "z" * (_TASK_MAX + 1)
+        huge_over = "z" * (_TASK_MAX * 40)
+        ids = frozenset({"req_x"})
+        rendered = []
+        for task in (small_over, huge_over):
+            block = build_obligations_tail_block(
+                [_ob("req_x", summary=task)],
+                session_id="sess_x",
+                now=_NOW,
+                present_request_ids=ids,
+            )
+            assert block is not None
+            rendered.append(len(block["content"]))
+        # Both renders are bounded by the preview budget + a fixed pointer line,
+        # and crucially the 40x-larger task does NOT produce a larger render
+        # (only the char-count digits differ).
+        assert abs(rendered[0] - rendered[1]) < 20
+        assert max(rendered) < _TASK_PREVIEW + 500
+        # And the abridged render never exceeds the AT-CAP VERBATIM render the
+        # reserved budget already permits today.
+        at_cap = build_obligations_tail_block(
+            [_ob("req_x", summary="z" * _TASK_MAX)], session_id="sess_x", now=_NOW
+        )
+        assert at_cap is not None
+        assert max(rendered) < len(at_cap["content"])
+
+    def test_summary_exactly_at_cap_renders_verbatim(self) -> None:
+        task = "y" * _TASK_MAX
+        ob = _ob("req_boundary", summary=task)
+        block = build_obligations_tail_block([ob], session_id="sess_x", now=_NOW)
+        assert block is not None
+        content = block["content"]
+        assert "verbatim task: " + task in content
+        assert "TRUNCATED" not in content
+        assert "ABRIDGED" not in content
+
+    def test_under_cap_task_is_verbatim_even_when_original_present(self) -> None:
+        # Presence must not perturb the under-cap path: still byte-for-byte.
+        task = "k" * 5000
+        ob = _ob("req_small", summary=task)
+        block = build_obligations_tail_block(
+            [ob], session_id="sess_x", now=_NOW, present_request_ids=frozenset({"req_small"})
+        )
+        assert block is not None
+        content = block["content"]
+        assert "verbatim task: " + task in content
+        assert "ABRIDGED" not in content
+        assert "TRUNCATED" not in content
+
+    def test_missing_summary_fails_loud_even_when_request_id_is_present(self) -> None:
+        # Presence of the ORIGINAL ask cannot conjure content that was never
+        # persisted on the frame — the unavailable marker must survive.
+        ob = _ob("req_nosum2", summary=None)
+        block = build_obligations_tail_block(
+            [ob], session_id="sess_x", now=_NOW, present_request_ids=frozenset({"req_nosum2"})
+        )
+        assert block is not None
+        content = block["content"]
+        assert "TASK CONTENT UNAVAILABLE" in content
+        assert "do not infer" in content
+
+    def test_presence_is_per_request_not_global(self) -> None:
+        # A present oversized task abridges; an absent one in the SAME block still
+        # fails loud. The signal must not leak across obligations.
+        big = "q" * (_TASK_MAX + 10)
+        obs = [_ob("req_here", summary=big), _ob("req_gone", summary=big)]
+        block = build_obligations_tail_block(
+            obs, session_id="sess_x", now=_NOW, present_request_ids=frozenset({"req_here"})
+        )
+        assert block is not None
+        lines = block["content"].splitlines()
+        here = next(ln for ln in lines if "req_here" in ln)
+        gone = next(ln for ln in lines if "req_gone" in ln)
+        assert "ABRIDGED" in here and "TASK TRUNCATED" not in here
+        assert "TASK TRUNCATED" in gone and "ABRIDGED" not in gone
 
     def test_missing_task_fails_loud(self) -> None:
         ob = _ob("req_nosum", summary=None)
@@ -157,6 +262,49 @@ class TestMaxObligationsBlockLocal:
             assert block is not None
             actual = approx_tokens([block])
             assert bound >= actual, f"under-reserved for n={n}: {bound} < {actual}"
+
+    def test_bound_covers_the_abridged_branch_not_just_the_marker(self) -> None:
+        # THE FENCE (#2221). The bound is computed at WINDOWING time, before the
+        # slate exists, so it cannot know which oversized tasks will render
+        # abridged (fat) versus marker-replaced (thin). It must reserve the FATTER
+        # branch. Costing the marker instead under-reserves — and an under-reserved
+        # tail is exactly the read_windowed_events budget overflow (step crash)
+        # that _TASK_MAX exists to prevent.
+        #
+        # The pre-existing bound test above uses 80-char summaries, so it never
+        # crosses the cap and cannot catch this. This one does.
+        for n in (1, MAX_RENDERED_OBLIGATIONS, MAX_RENDERED_OBLIGATIONS + 5):
+            obs = [_ob(f"req_{i}", summary="w" * 23_631) for i in range(n)]
+            bound = max_obligations_block_local(obs)
+            # The worst case at send time: every original still in the window, so
+            # every oversized task takes the fatter abridged branch.
+            block = build_obligations_tail_block(
+                obs,
+                session_id="sess_x",
+                now=_NOW,
+                present_request_ids=frozenset(o.request_id for o in obs),
+            )
+            assert block is not None
+            actual = approx_tokens([block])
+            assert bound >= actual, f"under-reserved abridged tail n={n}: {bound} < {actual}"
+
+    def test_bound_stays_bounded_for_oversized_tasks(self) -> None:
+        # The abridged render must not scale with task size: a 40x larger task
+        # cannot inflate the reserved tail (the Chesterton's-Fence property —
+        # the cap holds, only the behaviour AT the cap changed).
+        modest = max_obligations_block_local(
+            [
+                _ob(f"req_{i}", summary="w" * (_TASK_MAX + 1))
+                for i in range(MAX_RENDERED_OBLIGATIONS)
+            ]
+        )
+        enormous = max_obligations_block_local(
+            [
+                _ob(f"req_{i}", summary="w" * (_TASK_MAX * 40))
+                for i in range(MAX_RENDERED_OBLIGATIONS)
+            ]
+        )
+        assert enormous - modest < 50
 
     def test_bound_stays_bounded_regardless_of_count(self) -> None:
         # The whole point of the cap: a huge count does not inflate the bound past

--- a/tests/unit/test_owed_read_model_render.py
+++ b/tests/unit/test_owed_read_model_render.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from aios.harness.obligations import (
     _SCHEMA_MAX,
+    _TASK_MAX,
     MAX_RENDERED_OBLIGATIONS,
     build_obligations_tail_block,
     max_obligations_block_local,
@@ -84,6 +85,68 @@ class TestRenderOwedEntry:
         entry = render_owed_entry(_ob("req_n", output_schema=None), session_id="sess_x", now=_NOW)
         assert entry["output_schema"] is None
 
+    def test_oversized_task_does_not_order_a_refusal(self) -> None:
+        # THE #2221-round-2 DEFECT, on the read-model projection. This entry feeds
+        # BOTH the quiescence nudge (persisted as a DURABLE user event, up to
+        # REQUEST_NUDGE_BUDGET times) and the list_obligations tool. Neither surface
+        # can establish that the original ask is gone — the request is open by
+        # construction and its message may well still be in the window — so neither
+        # may order a refusal. A refuse-order here is strictly worse than the tail
+        # -block bug: the tail is ephemeral, this one persists in the event log.
+        task = "BUILD TASK — implement the widget. " * 700
+        assert len(task) > _TASK_MAX
+        entry = render_owed_entry(_ob("req_big_task", summary=task), session_id="s", now=_NOW)
+        summary = entry["summary"]
+        assert isinstance(summary, str)
+        # The refuse-instruction, in every phrasing that appears in the module.
+        assert "TASK TRUNCATED" not in summary
+        assert "return an error" not in summary
+        assert "do not act on or infer" not in summary
+        # Still a useful, honest pointer: the size, and where the real task lives.
+        assert str(len(task)) in summary
+        assert "original request message" in summary
+
+    def test_oversized_task_render_is_bounded_and_leaks_no_prefix(self) -> None:
+        # Two properties at once. (a) BOUNDED: this render is persisted on the nudge
+        # path, so a 40x larger task must not produce a 40x larger durable event.
+        # (b) NO PREFIX: unlike the tail block — which shows a preview only because
+        # it has PROVEN the original is present — this surface cannot prove that, and
+        # a plausible-looking prefix of a possibly-unrecoverable task is exactly
+        # #2080's improvisation hazard. So it points, and shows no content at all.
+        marker = "SECRET-TASK-CONTENT-MARKER"
+        small_over = marker + "z" * (_TASK_MAX + 1)
+        huge_over = marker + "z" * (_TASK_MAX * 40)
+        lengths = []
+        for task in (small_over, huge_over):
+            entry = render_owed_entry(_ob("req_x", summary=task), session_id="s", now=_NOW)
+            summary = entry["summary"]
+            assert isinstance(summary, str)
+            assert marker not in summary, "reminder surface must not echo task content"
+            lengths.append(len(summary))
+        # Only the char-count digits differ between the two renders.
+        assert abs(lengths[0] - lengths[1]) < 20
+        assert max(lengths) < 400
+
+    def test_absent_summary_still_fails_loud(self) -> None:
+        # The OTHER direction — the discrimination that proves the fix above did not
+        # simply delete the guard. ``summary is None`` means nothing was ever
+        # persisted on the frame, so the task is unrecoverable from ANY surface and
+        # there is nothing to point at. #2080's fail-loud property is correct here
+        # and must survive.
+        entry = render_owed_entry(_ob("req_nosum", summary=None), session_id="s", now=_NOW)
+        summary = entry["summary"]
+        assert isinstance(summary, str)
+        assert "TASK CONTENT UNAVAILABLE" in summary
+        assert "return an error" in summary
+        assert "do not infer" in summary
+
+    def test_under_cap_task_is_verbatim(self) -> None:
+        # The third direction: the ordinary case must stay byte-for-byte. A fix that
+        # abridged everything would pass both tests above and still be wrong.
+        task = "k" * (_TASK_MAX - 1)
+        entry = render_owed_entry(_ob("req_small", summary=task), session_id="s", now=_NOW)
+        assert entry["summary"] == task
+
     def test_large_schema_is_elided(self) -> None:
         big = {"type": "object", "properties": {f"k{i}": {"type": "string"} for i in range(500)}}
         entry = render_owed_entry(_ob("req_big", output_schema=big), session_id="sess_x", now=_NOW)
@@ -109,6 +172,63 @@ class TestRenderOwedListing:
         )
         assert "output_schema" in text
         assert "shipped" in text
+
+    def test_oversized_task_does_not_order_a_refusal_in_the_nudge(self) -> None:
+        # The DURABLE surface, end-to-end. This exact string is written to the event
+        # log by services.sessions as a {"role": "user"} message (up to
+        # REQUEST_NUDGE_BUDGET times) when a session tries to quiesce while owing an
+        # obligation — i.e. the ordinary case of "child got the task, worked, ended a
+        # turn without answering". #2080's evidence is that a model obeys a trailing
+        # refuse-order, so this content ordering a refusal permanently re-parks the
+        # oversized-payload sessions #2221 exists to unpark.
+        task = "BUILD TASK — implement the widget. " * 700
+        assert len(task) > _TASK_MAX
+        text = render_owed_listing(
+            [_ob("req_nudge", summary=task)], session_id="s", header="H", now=_NOW
+        )
+        assert "TASK TRUNCATED" not in text
+        assert "return an error" not in text
+        assert "do not act on or infer" not in text
+        # The obligation is still identified and pointed at — a reminder, not silence.
+        assert "req_nudge" in text
+        assert "original request message" in text
+
+    def test_nudge_absent_summary_still_fails_loud(self) -> None:
+        # Other direction on the durable surface: a task that was never persisted is
+        # unrecoverable from anywhere, so the nudge must still fail loud (#2080).
+        text = render_owed_listing(
+            [_ob("req_nosum", summary=None)], session_id="s", header="H", now=_NOW
+        )
+        assert "TASK CONTENT UNAVAILABLE" in text
+        assert "return an error" in text
+
+    def test_nudge_discriminates_per_obligation(self) -> None:
+        # Both branches in ONE render: an oversized task must not drag the absent one
+        # into silence, and the absent one must not drag the oversized one into a
+        # refusal. A fix that keyed off the listing as a whole would fail here.
+        text = render_owed_listing(
+            [
+                _ob("req_over", summary="w" * (_TASK_MAX + 10)),
+                _ob("req_none", summary=None),
+            ],
+            session_id="s",
+            header="H",
+            now=_NOW,
+        )
+        over_line = next(ln for ln in text.splitlines() if "req_over" in ln)
+        none_line = next(ln for ln in text.splitlines() if "req_none" in ln)
+        assert "return an error" not in over_line
+        assert "ABRIDGED" in over_line
+        assert "TASK CONTENT UNAVAILABLE" in none_line
+        assert "return an error" in none_line
+
+    def test_nudge_render_stays_small_regardless_of_task_size(self) -> None:
+        # This render is PERSISTED. An unbounded task must not produce an unbounded
+        # durable event — the property that makes the neutral pointer safe to write
+        # up to REQUEST_NUDGE_BUDGET times.
+        obs = [_ob(f"req_{i}", summary="z" * (_TASK_MAX * 30)) for i in range(3)]
+        text = render_owed_listing(obs, session_id="s", header="H", now=_NOW)
+        assert len(text) < 1500
 
     def test_count_capped_with_more_marker(self) -> None:
         n = MAX_RENDERED_OBLIGATIONS + 4


### PR DESCRIPTION
Fixes #2221.

## The defect

The obligations tail-block is rebuilt each step and appended as the **last user-role content**. When an obligation's task exceeded `_TASK_MAX` (8192), `_request_content` replaced it wholesale with:

```
[TASK TRUNCATED — return an error; do not act on or infer the missing task]
```

**Nothing was actually truncated.** `_obligation_summary` (`services/sessions.py:634`) persists the content verbatim — *"this copy must remain exact"* — and `render_user_event` applies no clipping. The child receives the **complete** task as its first user message, then reads a trailing instruction to refuse the task it can plainly see. It obeys. Every task over 8192 chars was structurally unbuildable.

Verified against live master (`362f0ab8`) before changing anything; the retargeting analysis in [#2221's correction comment](https://github.com/eumemic/aios/issues/2221#issuecomment-5416851967) is confirmed on every load-bearing claim.

## The fix

Stop conflating *"too big to re-render in this reminder"* with *"lost — refuse."*

| case | render |
|---|---|
| within `_TASK_MAX` | verbatim, byte-for-byte (unchanged) |
| oversized, original **still in window** | bounded preview + pointer to the intact original. **No refuse-instruction.** |
| oversized, original **evicted** | #2080's loud refuse marker (unchanged) |
| `summary is None` | unavailable marker (unchanged) |

## One deviation from the dispatched spec — worth a look

The spec asked for the pointer text *"full task in the original request message above"* and, separately, for the refuse-marker to be kept when the original is *"actually evicted from the window."*

**`_request_content` structurally cannot tell those apart** — it receives only a `str | None`, and `build_obligations_tail_block` receives no event slate. A blind pointer would therefore assert *"the full task is above"* in exactly the case #1413's module docstring says the block exists for (windowing erased the ask) — a plausible-looking prefix plus a false reassurance, which is #2080's improvisation hazard reintroduced one layer up.

So presence is **computed where it is knowable** and threaded down: `_present_request_ids(events)` in `compose_step_context` — the only layer holding both the obligations and the post-windowing slate — reads the same `metadata.request.request_id` stamp that `render_user_event` surfaces as the reply marker. Callers that cannot know default to `original_present=False`, i.e. today's conservative fail-loud behaviour.

## Chesterton's Fence — the cap is unchanged, and the bound got *tighter*

`_TASK_MAX` is untouched; only the behaviour **at** the bound changes.

`max_obligations_block_local` runs at **windowing time, before the slate exists**, so it cannot know presence either — and the abridged branch is strictly fatter than the marker. Left as-is it would **under-reserve**: measured **75 reserved vs 1110 actual tokens** for a single oversized obligation. That is precisely the `read_windowed_events` budget overflow → step crash the cap was added to prevent. It now costs the fatter branch by treating every request as present.

The abridged render is a **fixed** bound, not a fraction: a 40× larger task produces the same width (only the digit-count differs), and it stays below the at-cap *verbatim* render the budget already permits.

## Mutation proof — both directions

Not just green tests; each change was reverted and the guarding test observed to fail:

1. **Revert `_request_content`** to master's behaviour →
   `test_oversized_but_present_abridges_and_points_instead_of_refusing` and `test_presence_is_per_request_not_global` **FAIL**, with the refuse-marker visible in the assertion output.
2. **Revert the budget change** (cost the thin marker branch) →
   `test_bound_covers_the_abridged_branch_not_just_the_marker` **FAILS**: `under-reserved abridged tail n=1: 75 < 1110`.

Note the pre-existing bound test uses 80-char summaries, so it never crosses the cap and **could not** have caught defect 2 — hence the new test.

Also covered: 23,631-char → preview+pointer with no refuse-instruction; 5,000-char → verbatim; exactly `_TASK_MAX` → verbatim (boundary); `None` → unavailable marker; presence is per-request and does not leak across obligations in one block.

## CI evidence (run locally, in full)

- `mypy src tests` — **Success: no issues found in 1008 source files**
- `ruff check .` — **All checks passed!**
- `ruff format --check .` — **1332 files already formatted**
- Full unit suite — **4556 passed, 0 failed** (`tests/unit`, run in 4 chunks under `-n 4`; the whole suite in one process exceeds the sandbox wall-clock limit: 1247 + 947 + 1041 + 1321)

Not merging, no label changes.