### PR TITLE
chore(agents): declare ceo-front window at the live 200k/400k clamp

### DIFF
--- a/infra/agents/ceo-front.json
+++ b/infra/agents/ceo-front.json
@@ -946,7 +946,7 @@
   "description": "Full-capability CEO seat of the zero-human company (chairman-directed 2026-07-13). Acts: bash/write/edit, GitHub write + merge within policy, workflows, subagents, triggers, skills, read-write brain. Chairman reaches it on Telegram (@EumemicBot). The prior 'Phase-1 conversational / read-only' self-model is RETIRED.",
   "metadata": {},
   "litellm_extra": {},
-  "window_min": 600000,
-  "window_max": 700000,
+  "window_min": 200000,
+  "window_max": 400000,
   "preempt_policy": "preempt"
 }


### PR DESCRIPTION
## What

Declare `ceo-front`'s context window at the values that have been live since agent v82.

```
window_min: 600000 -> 200000
window_max: 700000 -> 400000
```

Two lines; nothing else in the manifest is touched.

## Why the LIVE side is authoritative here

The clamp was **deliberate** — a chairman-directed latency experiment applied 2026-08-25 (and it also corrected a real bug: `window_max` was not being enforced, so the seat had been running unbounded at ~940k, filed as [#2252](https://github.com/eumemic/aios/issues/2252)).

So this is not "live drifted from declared." It is **declared went stale after an intentional change**, and the manifest is the side that needs to catch up.

## Why bother, rather than muting the alarm

The drift check deliberately **refuses to adjudicate** — it reports declared-vs-live and states that the ambiguity itself is the finding ([eumemic-ops#379](https://github.com/eumemic/eumemic-ops/issues/379)). That is the right design: with no reconciler there is no adjudicator, and a check that guessed would sometimes guess wrong.

But a refusal to adjudicate is only cheap if someone closes the cases where the answer *is* known. Left alone this fires daily, forever, saying something true and unactionable — which is how a real drift, when it comes, gets skimmed past.

**A drift whose answer someone actually knows should be closed by writing the answer down.**

## Note on the route

The contents API refused this with `409: 6 of 6 required status checks are expected` — branch protection working correctly. Went through a branch and PR instead, which is what protection is asking for.
