### PR TITLE
fix(harness): concise output style no longer mutes channel-attached agents

### DIFF
--- a/src/aios/harness/concise.py
+++ b/src/aios/harness/concise.py
@@ -41,20 +41,49 @@ CONCISE_STYLE_BLOCK = (
     "requested information.\n"
     "- Never trade correctness for brevity: error reports, warnings, and "
     "confirmations for destructive actions keep their full content.\n"
-    "Where these rules conflict with more general style guidance elsewhere "
-    "in your instructions, these rules win."
+    "These rules govern the LENGTH and SHAPE of what you write, and where "
+    "they conflict with more general style guidance elsewhere in your "
+    "instructions, these rules win. They do NOT govern where your output "
+    "goes, which tools you call, or whether a reply is owed: any "
+    "instruction about how your output reaches a person — the channel it "
+    "goes to, the tool that sends it, when you owe a response — outranks "
+    "these rules absolutely. Brevity is about saying less, never about "
+    "saying it to no one."
 )
 """Cache-stable system-prompt rules block. Constant across steps, so the
 prompt prefix stays hot; joined into the prelude's system prompt iff the
 agent is concise."""
 
-CONCISE_NAG_CONTENT = (
-    "<system-reminder>Concise output style is active. Be concise: lead with "
-    "the result, skip preamble and narration, keep only what the recipient "
-    "needs.</system-reminder>"
+CONCISE_NAG_BODY: Final[str] = (
+    "Concise output style is active. Be concise: lead with the result, "
+    "skip preamble and narration, keep only what the recipient needs."
 )
-"""The tail reminder's exact text. Constant — only its position moves (it is
-always re-appended at the tail), which is why the message carries
+"""The steering sentence both nag variants share."""
+
+CONCISE_NAG_DELIVERY_CLAUSE: Final[str] = (
+    " Being concise never means going silent: a reply to a person still "
+    "requires the connector's send tool — bare assistant text is private "
+    "thinking and reaches no one."
+)
+"""Appended for a channel-attached session ONLY.
+
+The mute this guards against (#2262) is a per-step pressure, so its
+counter-pressure has to sit at the same recency: the nag is the final
+message of the payload, landing after the channels tail, which is exactly
+where the "stay terse, don't post" reading was winning. Rendered only when
+the session has bound channels — for a channel-less agent there is no
+connector to send through and the clause would be noise."""
+
+CONCISE_NAG_CONTENT: Final[str] = f"<system-reminder>{CONCISE_NAG_BODY}</system-reminder>"
+"""The tail reminder for a session with no bound channels."""
+
+CONCISE_NAG_CONTENT_CHANNELS: Final[str] = (
+    f"<system-reminder>{CONCISE_NAG_BODY}{CONCISE_NAG_DELIVERY_CLAUSE}</system-reminder>"
+)
+"""The tail reminder for a channel-attached session.
+
+Both variants are constant — only the nag's *position* moves (it is always
+re-appended at the tail), which is why the message carries
 :data:`~aios.harness.context.EPHEMERAL_TAIL_KEY`."""
 
 # Local-token reserve for the nag at windowing time, mirroring
@@ -63,10 +92,15 @@ always re-appended at the tail), which is why the message carries
 # payload past ``window_max``.  Reserved UNCONDITIONALLY — like the omission
 # marker and the tail block, any reserve may not render; the named tradeoff
 # is the same one the omission marker already accepted: a non-concise agent
-# over-reserves ~50 local tokens against a >=50k window floor.  The measured
-# cost of the built message is ~44 local tokens; ``TestConciseNagReserve``
-# pins the real builder output under this bound.
-CONCISE_NAG_UPPER_BOUND_LOCAL: Final[int] = 64
+# over-reserves against a >=50k window floor.  The bound must cover the
+# LONGEST variant — the channel-attached nag, which carries
+# :data:`CONCISE_NAG_DELIVERY_CLAUSE` — because the reserve is computed at
+# windowing time from the agent alone, before the composer knows which
+# variant renders.  ``TestConciseNagReserve`` pins BOTH real builder outputs
+# under this bound, so it is verified rather than guessed: if a future edit
+# lengthens either variant past it, raise the constant — never shorten the
+# clause to fit.
+CONCISE_NAG_UPPER_BOUND_LOCAL: Final[int] = 128
 
 
 def augment_with_concise_style(base_system: str, concise: bool) -> str:
@@ -76,8 +110,12 @@ def augment_with_concise_style(base_system: str, concise: bool) -> str:
     return join_blocks(base_system, CONCISE_STYLE_BLOCK)
 
 
-def build_concise_nag_message() -> dict[str, Any]:
+def build_concise_nag_message(*, has_channels: bool = False) -> dict[str, Any]:
     """The tail-reminder user message, built fresh each step.
+
+    ``has_channels`` selects the variant: a channel-attached session also
+    gets :data:`CONCISE_NAG_DELIVERY_CLAUSE`, so the reminder that steers
+    the model shorter can never be read as licence to stop posting (#2262).
 
     Marked :data:`~aios.harness.context.EPHEMERAL_TAIL_KEY` so the
     cache-breakpoint recognizer never hosts the stable-prefix
@@ -85,4 +123,5 @@ def build_concise_nag_message() -> dict[str, Any]:
     *position* is per-step (always last), so a prefix cached through it
     would never be re-usable.
     """
-    return {"role": "user", "content": CONCISE_NAG_CONTENT, EPHEMERAL_TAIL_KEY: True}
+    content = CONCISE_NAG_CONTENT_CHANNELS if has_channels else CONCISE_NAG_CONTENT
+    return {"role": "user", "content": content, EPHEMERAL_TAIL_KEY: True}

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -763,8 +763,14 @@ async def compose_step_context(
     # standing as its own final user message.  Why a per-step user-content
     # injection at all (exactly-once, max recency, never persisted, survives
     # LiteLLM's provider transforms): see ``aios.harness.concise``.
+    #
+    # ``has_channels`` selects the channel-attached variant (#2262): landing
+    # after the channels tail is what let "be concise" read as licence to stop
+    # posting, so for a bound session the nag carries the delivery clause at
+    # that same maximum recency.  The position is deliberately unchanged —
+    # the counter-pressure has to sit exactly where the pressure was.
     if agent.output_style == "concise":
-        ctx.messages.append(build_concise_nag_message())
+        ctx.messages.append(build_concise_nag_message(has_channels=bool(channels)))
 
     # Merge consecutive user inbounds into one turn (Anthropic requires
     # alternating roles). This replaces the old "." placeholder separator,

--- a/tests/unit/test_concise_style.py
+++ b/tests/unit/test_concise_style.py
@@ -16,6 +16,8 @@ from pydantic import ValidationError
 
 from aios.harness.concise import (
     CONCISE_NAG_CONTENT,
+    CONCISE_NAG_CONTENT_CHANNELS,
+    CONCISE_NAG_DELIVERY_CLAUSE,
     CONCISE_NAG_UPPER_BOUND_LOCAL,
     CONCISE_STYLE_BLOCK,
     build_concise_nag_message,
@@ -123,7 +125,18 @@ def _text(msg: dict[str, Any]) -> str:
 
 
 def _nag_count(messages: list[dict[str, Any]]) -> int:
-    return sum(_text(m).count(CONCISE_NAG_CONTENT) for m in messages)
+    """Occurrences of EITHER nag variant.
+
+    The channel-attached variant (#2262) is not a superstring of the plain one
+    — the delivery clause lands inside the ``<system-reminder>`` element — so
+    counting only ``CONCISE_NAG_CONTENT`` would silently score a channel
+    session as zero nags and turn every exactly-once assertion green-for-the-
+    wrong-reason.
+    """
+    return sum(
+        _text(m).count(CONCISE_NAG_CONTENT) + _text(m).count(CONCISE_NAG_CONTENT_CHANNELS)
+        for m in messages
+    )
 
 
 # ── the nag in the composed payload ──────────────────────────────────────────
@@ -165,8 +178,37 @@ class TestConciseNag:
         assert last["role"] == "user"
         text = _text(last)
         assert "━━━ Channels ━━━" in text
-        assert text.endswith(CONCISE_NAG_CONTENT)
+        assert text.endswith(CONCISE_NAG_CONTENT_CHANNELS)
         assert _nag_count(messages) == 1
+
+    async def test_nag_carries_delivery_clause_when_channels_bound(self) -> None:
+        """#2262: for a channel-attached session the nag must also say that
+        being brief is not licence to stop posting.
+
+        The mute this guards against was a per-step pressure that survived an
+        explicit in-band correction from the user, so the counter-pressure has
+        to ride the nag — the one injection rebuilt at maximum recency every
+        step — rather than the system prompt alone.
+        """
+        events = [_evt(1, role="user"), _evt(2, role="assistant", content="done")]
+        messages = await _compose(
+            _agent(output_style="concise"), events, channels=["telegram/8622/chat-a"]
+        )
+        text = _text(messages[-1])
+        assert CONCISE_NAG_DELIVERY_CLAUSE.strip() in text
+        # The clause lands INSIDE the reminder element, after the steering
+        # sentence — not as a second stray <system-reminder>.
+        assert text.count("<system-reminder>") == 1
+        assert _nag_count(messages) == 1
+
+    async def test_nag_omits_delivery_clause_without_channels(self) -> None:
+        """No bound channels -> no connector to send through, so the clause
+        would be noise; the plain variant renders verbatim."""
+        events = [_evt(1, role="user"), _evt(2, role="assistant", content="done")]
+        messages = await _compose(_agent(output_style="concise"), events, channels=[])
+        text = _text(messages[-1])
+        assert text == CONCISE_NAG_CONTENT
+        assert CONCISE_NAG_DELIVERY_CLAUSE.strip() not in text
 
     async def test_nag_carries_ephemeral_tail_marker(self) -> None:
         """The nag (and any merge containing it) must never host the
@@ -209,6 +251,25 @@ class TestConciseSystemPrompt:
         prelude = await self._prelude_for(_agent(output_style="default"))
         assert CONCISE_STYLE_BLOCK not in prelude.system_prompt
 
+    async def test_override_clause_carves_out_delivery(self) -> None:
+        """#2262: the precedence clause must claim STYLE only.
+
+        ``augment_with_concise_style`` appends this block directly on top of
+        ``build_focal_paradigm_block``, whose contract ("bare assistant text is
+        NOT delivered to any channel") reads like style guidance but is the
+        rule that makes the agent audible. An unscoped "these rules win"
+        outranked it and muted a live channel-attached agent, so the carve-out
+        is load-bearing, not decorative — this asserts it cannot be quietly
+        re-broadened by a later edit.
+        """
+        assert "outranks these rules absolutely" in CONCISE_STYLE_BLOCK
+        assert "LENGTH and SHAPE" in CONCISE_STYLE_BLOCK
+        # The old unscoped sentence must not come back verbatim.
+        assert (
+            "Where these rules conflict with more general style guidance "
+            "elsewhere in your instructions, these rules win."
+        ) not in CONCISE_STYLE_BLOCK
+
 
 # ── the windowing reserve ────────────────────────────────────────────────────
 
@@ -216,8 +277,19 @@ class TestConciseSystemPrompt:
 class TestConciseNagReserve:
     def test_upper_bound_covers_real_builder_output(self) -> None:
         """The hardcoded reserve must cover the message the builder actually
-        emits -- costed on the REAL builder output, not a re-rolled inline dict."""
-        assert approx_tokens([build_concise_nag_message()]) <= CONCISE_NAG_UPPER_BOUND_LOCAL
+        emits -- costed on the REAL builder output, not a re-rolled inline dict.
+
+        BOTH variants: the reserve is computed at windowing time from the agent
+        alone, before the composer knows whether the session has channels, so
+        the bound has to hold for the longer channel-attached nag (#2262).
+        """
+        for has_channels in (False, True):
+            cost = approx_tokens([build_concise_nag_message(has_channels=has_channels)])
+            assert cost <= CONCISE_NAG_UPPER_BOUND_LOCAL, (
+                f"nag variant has_channels={has_channels} costs {cost} local tokens, "
+                f"over the {CONCISE_NAG_UPPER_BOUND_LOCAL} reserve -- raise the "
+                f"constant rather than shortening the clause"
+            )
 
     def test_reserve_summed_unconditionally(self) -> None:
         """Reserved for every agent (the omission-marker idiom) -- the prelude


### PR DESCRIPTION
Fixes #2262.

## What was wrong

`output_style: "concise"` (#2247) suppressed **channel delivery**. The agent stayed fully healthy —
stepping, tool-calling, ending turns with `is_error: false` — but stopped calling the connector send
tool and wrote its user-facing replies as `INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER` instead. The human
saw silence; every health check saw green.

Observed live on an `anthropic/claude-opus-5` agent bound to a Telegram DM: 98 minutes and zero
sends across two PR merges and two issue filings, a direct `hello?` answered into the void, and — the
diagnostic detail — a relapse to monologue **one minute** after the user explicitly said "use
telegram_send". The pressure re-applies every step, so the fix has to as well.

Not the fable-5 last-message-anchoring residual named in #2247; that one is untouched and still open.

## The two causes

**1. An unscoped override clause landing on top of the delivery contract.**

`compute_step_prelude` appends the concise block directly after `augment_with_focal_paradigm`:

```python
system_prompt = augment_with_focal_paradigm(system_prompt, channels)
system_prompt = augment_with_concise_style(system_prompt, agent.output_style == "concise")
```

`CONCISE_STYLE_BLOCK` closed with *"Where these rules conflict with more general style guidance
elsewhere in your instructions, these rules win."* The block immediately above holds *"Bare assistant
text is NOT delivered to any channel"* — not style guidance, but the rule that makes the agent
audible. It reads like style guidance, and the clause claimed precedence over it in so many words.

Now the clause governs **length and shape only**, and explicitly cedes to anything about where output
goes, which tool sends it, or whether a reply is owed.

**2. The nag displacing channel state from the recency slot.**

The nag lands after the channels + obligations tails, so the last thing read each step was "be
concise" — while `build_focal_paradigm_block` documents a sanctioned terse path (*"the right move is
to NOT post… say so in one line prefixed INTERNAL_MONOLOGUE"*) that, under "keep only what the
recipient needs," is the *more* concise-compliant branch. Concise didn't merely permit the monologue
path; it selected for it.

`build_concise_nag_message(*, has_channels: bool)` now appends a delivery clause for channel-attached
sessions. The nag's **position is deliberately unchanged** — the counter-pressure belongs exactly
where the pressure was winning.

## Scope decisions

- **`build_focal_paradigm_block` untouched.** It is shared by every channel-attached agent, concise
  or not. Editing its "don't post" path would put regression risk on all of them to fix a
  concise-only defect.
- **Block ordering unchanged.** Reordering was considered and rejected: "elsewhere in your
  instructions" is direction-agnostic, so it weakens the conflict without removing it. Fixing the
  clause text fixes it at the source.
- **Reserve 64 → 128**, still summed unconditionally. Measured cost is 44 local tokens plain / 75
  channel; the composer does not know at windowing time which variant will render, so the bound must
  cover the longer one. Same over-reserve tradeoff the omission marker already accepts.

## Tests

The reason this shipped broken is that every existing concise test asserts the *shape of the
payload* and none asserts the *behaviour it produces* — `test_nag_lands_after_channels_tail_block`
even pins the exact adjacency that caused the mute, as intended behaviour. So each new test was
verified to actually catch its defect rather than assumed to:

| injected defect | caught by |
|---|---|
| override clause re-broadened to the old sentence | `test_override_clause_carves_out_delivery` |
| `build_concise_nag_message` ignores `has_channels` | `test_nag_carries_delivery_clause_when_channels_bound`, `test_nag_lands_after_channels_tail_block` |
| call site drops the `has_channels` argument | same two |
| reserve left at the stale 64 | `test_upper_bound_covers_real_builder_output` |

Added: the two nag-variant tests, the override-clause regression guard, both-variant reserve
coverage, and `_nag_count` updated to count either variant (the channel variant is not a superstring
— the clause lands inside the `<system-reminder>` element — so counting only the plain one would have
scored a channel session as zero nags and turned every exactly-once assertion green for the wrong
reason).

`5263 passed`, ruff check + format clean, mypy clean on both changed modules. No migration, no SDK
regeneration, no openapi change — this is prompt text and one keyword argument.

## Residual risks

- **These tests are structural, not behavioural.** They prove the payload carries the
  counter-pressure; they cannot prove the model acts on it. A real behavioural assertion needs a
  model in the loop, and `evals/` currently holds only the bespoke `wam_fusion` harness — building
  that framework is well outside this fix. **Recommend a live smoke on one channel-attached agent
  before turning concise back on broadly.**
- **The silence class itself remains undetectable.** An agent that receives a direct inbound on its
  focal channel and ends its turn with no send is still indistinguishable from one that correctly
  chose not to post. That observability gap is what let this run 98 minutes before a human noticed;
  it is a detector rather than a fix and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
