### PR TITLE
fix(context): tag the trailing-assistant notice ephemeral; correct its false claims

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -1218,11 +1218,57 @@ _PENDING_EXTERNAL = json.dumps(
     }
 )
 
+EPHEMERAL_TAIL_KEY = "_aios_ephemeral_tail"
+"""Out-of-band marker key tagging a per-step-ephemeral tail message.
+
+Set to ``True`` at construction on any per-step-assembled tail message —
+a render-only block appended after ``build_messages`` rather than sourced
+from the event log.  Producers tag their own dicts; nothing enumerates
+them here.  What makes a message ephemeral is that its content OR its
+position varies per step (unread counts mutate; a constant reminder is
+re-appended at the moving tail), so caching a prefix through it can never
+hit.
+
+The cache-breakpoint recognizer in ``completion.py`` reads this marker —
+never the rendered prose — to decide which message must NOT host the
+conversation prefix ``cache_control`` breakpoint.  It is a *property*
+("this message is per-step-ephemeral"), not a discriminated kind, so a
+boolean is the honest shape.
+
+The marker is non-standard (Anthropic rejects unknown message fields) and
+is stripped from every message by ``inject_cache_breakpoints`` before any
+provider call — on every route, including non-Anthropic early returns.
+``_concat_user_messages`` propagates it under OR so a merge of any
+ephemeral message with anything stays ephemeral.
+"""
+
+
 # Synthetic user turn ending a gate-firing build that would otherwise end on
 # an assistant message (see the trailing-assistant guard in build_messages).
+#
 # Generic on purpose: each inline blind-spot injection already opens with a
-# header naming its call, so the tail only needs to redirect attention.
-_TRAILING_STIMULUS_NOTICE = "[New events arrived during your later turns — see above.]"
+# ``[Tool result: … completed]`` header naming its call, so the tail only needs
+# to redirect attention — it must not restate what those headers already say.
+#
+# The wording must be true in BOTH arms the guard serves, which differ in
+# whether the stimulus is actually RENDERED:
+#
+# * inline injection — the result is present earlier in the build;
+# * pruned structural orphan — ``_prune_orphans`` drops the tool result whose
+#   issuing assistant was windowed out, while the watermark still advances, so
+#   the stimulus is present in NO message of this build.
+#
+# So the notice reports only that events arrived; it never asserts they are
+# visible ("see above" would be false in the orphan arm). For literal-minded
+# models a false pointer invites inventing the missed content, so the notice
+# redirects to ``search_events`` instead — the same contract the head-omission
+# marker offers ("Nothing is lost: the full transcript remains queryable").
+_TRAILING_STIMULUS_NOTICE = (
+    "[New events arrived while you were working. Some may not be rendered above. "
+    "Nothing is lost: the full transcript remains queryable with search_events — "
+    "if something is referred to that you cannot see, search for it rather than "
+    "assuming what it was.]"
+)
 
 
 @dataclass(slots=True)
@@ -1621,12 +1667,52 @@ def build_messages(
     # Trailing-assistant guard: the user-deferral window above keeps
     # blind-spot USER messages off the tail (#1120), but a blind-spot TOOL
     # result injected mid-list (horizon-setter ≠ last assistant) — or a
-    # pruned structural orphan — still leaves a gate-firing build ending on
-    # an assistant turn: the same rejected prefill, the same volatile-tail
-    # trade. ``max_stimulus_seq > last_asst_rt`` is the gate's own firing
-    # condition, so reacted (not-sent) builds are never padded.
+    # pruned structural orphan — still leaves a build ending on an assistant
+    # turn: the same rejected prefill, the same volatile-tail trade.
+    #
+    # ``max_stimulus_seq > last_asst_rt`` is NOT the inference gate. The gate
+    # is ``session_active_predicate`` (``db/queries/sessions.py``):
+    #
+    #     ((last_stimulus_seq > last_reacted_seq OR open_tool_call_count > 0)
+    #      AND NOT errored)
+    #
+    # This condition models the FIRST DISJUNCT only, and does so with
+    # window-local operands (the max stimulus seq actually rendered into THIS
+    # build; the last rendered assistant's ``reacting_to``) rather than the
+    # gate's session-wide committed scalars. Two consequences:
+    #
+    # * Over-approximation is impossible in the direction that matters: a
+    #   reacted (not-sent) build has ``max_stimulus_seq <= last_asst_rt``, so
+    #   it is never padded with a spurious notice.
+    # * The SECOND DISJUNCT is uncovered. An open tool call fires the gate
+    #   with no unreacted stimulus, and if such a build ends on an assistant
+    #   turn it is sent WITHOUT a notice — the 400 this guard exists to
+    #   prevent. That residual is believed empty in practice, not by
+    #   construction: the sweep's dispatch-narrowing branch
+    #   (``_filter_incomplete_batches``, #1710) admits only calls actually
+    #   dispatched, and ghost repair converts a dispatched-but-resultless call
+    #   into a synthesized tool result — an unreacted stimulus that re-enters
+    #   the covered first-disjunct arm and lands a ``tool``-role message at
+    #   the tail. "Believed empty" is the honest strength of that claim.
+    #
+    # The divergence is therefore FAIL-OPEN: where the two conditions
+    # disagree, this guard stays silent and the build is emitted exactly as
+    # master would have emitted it. It never fabricates a stimulus, never
+    # rewrites a committed prefix, and never makes an existing build worse —
+    # the uncovered residual is the pre-existing behaviour, not a regression
+    # introduced here.
+    #
+    # The notice is tagged ``EPHEMERAL_TAIL_KEY`` like every other per-step
+    # tail producer (``channels.py``, ``obligations.py``, ``concise.py``): it
+    # is render-only and position-volatile, so the Anthropic cache breakpoint
+    # must skip it and land on the last COMMITTED message. Untagged, on a
+    # build with no other tail — the exact population this guard serves — the
+    # breakpoint would land on the notice itself and the conversation prefix
+    # would be re-cache-created every step (see ``inject_cache_breakpoints``).
     if stripped and stripped[-1].get("role") == "assistant" and max_stimulus_seq > last_asst_rt:
-        stripped.append({"role": "user", "content": _TRAILING_STIMULUS_NOTICE})
+        stripped.append(
+            {"role": "user", "content": _TRAILING_STIMULUS_NOTICE, EPHEMERAL_TAIL_KEY: True}
+        )
 
     return ContextResult(messages=stripped, reacting_to=max_stimulus_seq)
 
@@ -1762,31 +1848,6 @@ def stub_missing_reasoning_content(
         if msg.get("role") == "assistant" and "reasoning_content" not in msg:
             msg["reasoning_content"] = ""
     return messages
-
-
-EPHEMERAL_TAIL_KEY = "_aios_ephemeral_tail"
-"""Out-of-band marker key tagging a per-step-ephemeral tail message.
-
-Set to ``True`` at construction on any per-step-assembled tail message —
-a render-only block appended after ``build_messages`` rather than sourced
-from the event log.  Producers tag their own dicts; nothing enumerates
-them here.  What makes a message ephemeral is that its content OR its
-position varies per step (unread counts mutate; a constant reminder is
-re-appended at the moving tail), so caching a prefix through it can never
-hit.
-
-The cache-breakpoint recognizer in ``completion.py`` reads this marker —
-never the rendered prose — to decide which message must NOT host the
-conversation prefix ``cache_control`` breakpoint.  It is a *property*
-("this message is per-step-ephemeral"), not a discriminated kind, so a
-boolean is the honest shape.
-
-The marker is non-standard (Anthropic rejects unknown message fields) and
-is stripped from every message by ``inject_cache_breakpoints`` before any
-provider call — on every route, including non-Anthropic early returns.
-``_concat_user_messages`` propagates it under OR so a merge of any
-ephemeral message with anything stays ephemeral.
-"""
 
 
 _USER_MESSAGE_SEPARATOR_CONTENT = "."

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -398,7 +398,113 @@ class TestBuildMessages:
         # The orphan itself is pruned from the build...
         assert not any(m.get("role") == "tool" for m in msgs)
         # ...but the gate-firing build still must not end on an assistant.
-        assert msgs[-1] == {"role": "user", "content": _TRAILING_STIMULUS_NOTICE}
+        assert msgs[-1]["role"] == "user"
+        assert msgs[-1]["content"] == _TRAILING_STIMULUS_NOTICE
+        # The notice is a per-step render-only tail, so it MUST carry the
+        # ephemeral marker: the Anthropic cache breakpoint has to skip it and
+        # land on the last COMMITTED message. On this build the notice is the
+        # ONLY tail, so an untagged notice would host the breakpoint itself and
+        # the conversation prefix would be re-cache-created every step.
+        assert msgs[-1][EPHEMERAL_TAIL_KEY] is True
+        # The notice must NOT claim the stimulus is visible: in this arm the
+        # orphan was pruned, so it is rendered in no message of the build.
+        # Pointing at absent content invites a literal-minded model to invent
+        # what it "missed"; the notice redirects to search_events instead.
+        assert "see above" not in msgs[-1]["content"]
+        assert "search_events" in msgs[-1]["content"]
+
+    def test_guard_exposure_boundary_is_the_channel_less_build(self) -> None:
+        """Pin the REAL exposure boundary, which the PR body overstates.
+
+        The 400 is NOT general. ``compose_step_context`` appends the channels
+        tail whenever ``_agent_owes_response`` is False, and an
+        assistant-ending build is exactly that case
+        (``step_context.py`` tail-gate call site). So a CHANNEL-BOUND session
+        already ends on a user turn on master — the tail saves it by
+        accident. The guard's exposure is the channel-less, obligation-less,
+        non-concise session, where no other tail producer runs.
+
+        Two things pinned here:
+
+        (a) the guard fires for the channel-less build (the reachable 400);
+        (b) with the guard, the channels tail is now SUPPRESSED on that step
+            — the notice takes the focal-user arm of ``_agent_owes_response``,
+            which is intended (the missed events ARE the stimulus) but is a
+            live behaviour change for every channel-bound session hitting this
+            shape, and nothing else tests it.
+        """
+        from aios.harness.step_context import _agent_owes_response
+
+        # TWO assistant turns must follow the slow call: the injection anchors
+        # after its horizon-setter, so with only ONE later assistant the
+        # injected result IS the last message and no guard is needed.
+        events = [
+            _evt(1, "user", content="ping the peer"),
+            _evt(2, "assistant", tool_calls=[_tc("slow", "message_bot")]),
+            _evt(3, "user", content="unrelated question one"),
+            _evt(4, "assistant", content="answer one"),
+            _evt(5, "user", content="unrelated question two"),
+            _evt(6, "assistant", content="answer two"),
+            _evt(7, "tool", tool_call_id="slow", content="peer replied: ok"),
+        ]
+        events[1].data["reacting_to"] = 1
+        events[3].data["reacting_to"] = 3
+        events[5].data["reacting_to"] = 5
+
+        # MASTER's shape: what build_messages would have produced without the
+        # guard is an assistant-ending list. Reconstruct that predicate input
+        # by dropping the guard's own tail.
+        ctx = build_messages(events, system_prompt=None)
+        assert ctx.reacting_to == 7
+        without_notice = [m for m in ctx.messages if m.get("content") != _TRAILING_STIMULUS_NOTICE]
+        assert without_notice[-1]["role"] == "assistant", (
+            "precondition: without the guard this build ends on an assistant"
+        )
+
+        # (a) Channel-less: the guard is the ONLY thing keeping this build off
+        # a trailing assistant — this is the reachable 400.
+        assert _agent_owes_response(without_notice) is False, (
+            "an assistant-ending build does not owe a response, so a bound "
+            "channels tail would be appended and would mask the 400"
+        )
+        assert ctx.messages[-1]["role"] == "user"
+        assert ctx.messages[-1]["content"] == _TRAILING_STIMULUS_NOTICE
+
+        # On master the channels tail lands for a channel-bound session, so
+        # that population never saw the 400 — the boundary the PR body misses.
+        tail = build_channels_tail_block(["telegram:1", "telegram:2"], events, "telegram:1")
+        assert tail is not None
+        assert tail["role"] == "user"
+
+        # (b) WITH the guard the notice ends the build, so the tail gate now
+        # SUPPRESSES the channels tail on this step — a live behaviour change
+        # for every channel-bound session hitting this shape.
+        #
+        # NB ``_full_pipeline`` appends the tail UNCONDITIONALLY, so it cannot
+        # show this; mirror the real call site (``step_context.py``:
+        # ``if tail is not None and not _agent_owes_response(ctx.messages)``).
+        assert _agent_owes_response(ctx.messages) is True, (
+            "the notice must classify as a direct stimulus, else the tail "
+            "would be appended after it and become the literal final message"
+        )
+
+        def _gated(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            out = list(messages)
+            if tail is not None and not _agent_owes_response(out):
+                out.append(tail)
+            return out
+
+        # Master (no notice): tail appended -> build ends on a USER turn
+        # already, which is why the channel-bound population never saw the 400.
+        master_final = _gated(without_notice)
+        assert master_final[-1] is tail
+        assert master_final[-1]["role"] == "user"
+
+        # With the guard: tail suppressed, notice is the final message.
+        guarded_final = _gated(ctx.messages)
+        assert guarded_final[-1]["content"] == _TRAILING_STIMULUS_NOTICE
+        assert "━━━ Channels ━━━" not in str(guarded_final[-1]["content"])
+        assert tail not in guarded_final
 
     def test_user_message_after_last_assistant_stays_at_tail(self) -> None:
         """The ordinary case — a user message that genuinely follows the last
@@ -996,8 +1102,11 @@ class TestMonotonicity:
         ctx1 = self._build(l1)
         ctx2 = self._build(l2)
 
-        # Sent build: guard notice at the tail.
-        assert ctx1[-1] == {"role": "user", "content": _TRAILING_STIMULUS_NOTICE}
+        # Sent build: guard notice at the tail, tagged ephemeral so the cache
+        # breakpoint skips it and lands on the last committed message.
+        assert ctx1[-1]["role"] == "user"
+        assert ctx1[-1]["content"] == _TRAILING_STIMULUS_NOTICE
+        assert ctx1[-1][EPHEMERAL_TAIL_KEY] is True
         # Next build: the reply reacted to the result — no notice anywhere.
         assert ctx2[-1]["role"] == "assistant"
         assert not any(m.get("content") == _TRAILING_STIMULUS_NOTICE for m in ctx2)


### PR DESCRIPTION
## Follow-up to [#2261](https://github.com/eumemic/aios/pull/2261), which merged at the pre-fix commit

#2261 landed while an adversarial review was in flight. The review found **two blocking defects**, and they are on master right now. This PR carries the corrections.

## BLOCKING 1 — the notice was not tagged ephemeral, costing a cache entry every step

`completion._last_stable_message_index` walks backward skipping ephemeral tails to place the Anthropic cache breakpoint. Untagged, on a **no-other-tail build — exactly the population this guard serves** — the breakpoint lands on the notice instead of the last committed message.

`completion.py:501-505` documents that case: *"the conversation prefix never gets its own cache entry and has to be re-cache-created every step."*

Every other per-step tail producer already tags (`channels.py:233`, `obligations.py:312`, `concise.py:88`). Executed: untagged → breakpoint index 3 (the notice); tagged → index 2 (last committed). Marker verified stripped before the wire.

`EPHEMERAL_TAIL_KEY` was hoisted above `build_messages` (it was defined below it); module import verified for `context`, `completion`, `channels`, `obligations`, `concise`.

## BLOCKING 2 — the tests pinned the defect

Two exact-dict assertions pinned the *absence* of the marker: applying fix 1 turned both red (`2 failed, 172 passed`). Now assert role + content substring, **plus a positive assertion that the notice carries `EPHEMERAL_TAIL_KEY`** — the marker is a pinned invariant, not an accident.

## The comment was false

`context.py` claimed `max_stimulus_seq > last_asst_rt` is *"the inference gate's own firing condition."* The gate is `session_active_predicate` (`db/queries/sessions.py:131-135`):

```
((last_stimulus_seq > last_reacted_seq OR open_tool_call_count > 0) AND NOT errored)
```

The guard models **the first disjunct only**. Reproduced counter-case: an in-flight tool call fires the gate with no unreacted stimulus → build ends on an assistant → no notice. The comment now states this, notes the operands are window-local vs the gate's session-wide scalars, records that the residual is **believed empty in practice, not by construction**, and that the divergence is **fail-open**.

## "see above" was false in the pruned-orphan case

`_prune_orphans` removes the stimulus while the watermark advances — the PR's own test asserts that case, so the model was told to look at something structurally absent. That invites a literal-minded model to invent what it missed.

New wording is true in both arms — reports arrival, never asserts visibility, redirects to `search_events`, mirroring the head-omission marker's "Nothing is lost" contract.

## The exposure was narrower than #2261 stated

With a channels tail bound, master already ends on a **user** turn (`_agent_owes_response` returns False for an assistant-ending build → tail appended). **The 400 was only ever reachable for channel-less, obligation-less, non-concise sessions** — sub-agent / workflow-child / API.

New test pins that boundary and the live behaviour change it implies: with the guard, `_agent_owes_response` returns True for the notice, so **the channels tail is suppressed on that step** for every channel-bound session hitting this shape. Intended per `step_context.py:531-534`, but nothing tested it.

## Mutation evidence — no weakening

All five re-run after the change; two are **strictly stronger** than the pre-fix baseline:

| mutation | before | after |
|---|---|---|
| guard deleted | 3 red | **4 red** |
| stimulus condition dropped | 8 | 8 |
| empty user message | 2 | **3 red** |
| role check dropped | 26 | 26 |
| `>=` for `>` | 5 | 5 |

Local: `mypy src tests` clean (1010 files), `ruff check` + `ruff format --check` clean, full unit suite **5229 passed / 1 pre-existing skip**, run in 3 non-overlapping chunks (one invocation exceeds the sandbox timeout — stated explicitly rather than claiming an unrun green).

## Provenance

The trace cited in #2261 (`sess_01M0V3590XJRFE175NSBXE0AY4`) **404s to an Eumemic-scoped credential** — it is a jarbot-account session, so no in-repo reviewer can verify it. Noted rather than removed; the mechanism was reproduced from code independently of the trace.
