### PR TITLE
Distinguish dead OAuth refresh token from generic refresh failure (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Distinguish a dead OAuth refresh token (RFC 6749 `invalid_grant` — revoked,
+  expired, or otherwise unrecoverable) from a generic/transient
+  `OAuthRefreshError` via a new `OAuthReauthRequiredError` subclass
+  (`error_type: "oauth_reauth_required"`), so a caller can branch on "this
+  connection needs to be reconnected" instead of retrying. Severity/eviction
+  wiring (status_code 502, non-evicting on the MCP dispatch path, evicting via
+  the `http_request` built-in's oauth2_refresh path) is unchanged (#192).
 - Extend the #1975 diagnostic harness with timeout-scoped slow HTTP and
   streaming call graphs inside open transactions, a pre-saturated 16-slot pool,
   13 queued waiters, and per-storm client/server recovery checks.

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -171,6 +171,30 @@ class OAuthRefreshError(AiosError):
     status_code = 502
 
 
+class OAuthReauthRequiredError(OAuthRefreshError):
+    """Raised when the OAuth token endpoint rejects a refresh as unrecoverable —
+    RFC 6749 ``invalid_grant`` (revoked, expired, or otherwise dead refresh token).
+
+    A subclass of :class:`OAuthRefreshError`, not a sibling: it keeps the same
+    ``status_code`` (502, still an upstream-credential failure, still correctly
+    non-evicting on the MCP dispatch path and still evicting via the
+    ``http_request`` built-in's oauth2_refresh path — #192 deliberately does not
+    touch that severity/eviction wiring). What distinguishes it is ``error_type``
+    and a model-actionable message: a caller (the model, or jarbot's observer
+    polling session events) can branch on ``error_type ==
+    "oauth_reauth_required"`` to mean "stop retrying, this connection needs the
+    human to reconnect it" — as opposed to a generic :class:`OAuthRefreshError`,
+    which may still be transient (network blip, momentary token-endpoint 5xx).
+
+    Every other refresh failure (missing fields, decrypt failure, network error,
+    a non-``invalid_grant`` 4xx, missing ``access_token`` in the response) stays
+    a plain :class:`OAuthRefreshError` — this subclass is raised ONLY when the
+    token endpoint's response body identifies the failure as ``invalid_grant``.
+    """
+
+    error_type = "oauth_reauth_required"
+
+
 class OAuthFlowError(AiosError):
     """Raised when an interactive OAuth "Connect" flow fails.
 

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -51,7 +51,7 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.db.listen import MCP_EVICT_VAULT_CHANNEL
 from aios.db.pool import normalize_dsn
-from aios.errors import NotFoundError, OAuthRefreshError, ValidationError
+from aios.errors import NotFoundError, OAuthReauthRequiredError, OAuthRefreshError, ValidationError
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
 from aios.models.vaults import (
@@ -78,6 +78,32 @@ _OAUTH_REFRESH_LOCKS: dict[tuple[str, str, str], asyncio.Lock] = {}
 _REFRESH_HTTP_TIMEOUT_SECONDS = 30
 
 log = get_logger("aios.services.vaults")
+
+
+def _extract_oauth_error_code(exc: httpx.HTTPError) -> str | None:
+    """Best-effort read of the RFC 6749 §5.2 ``error`` field from a token-endpoint
+    error response, e.g. ``{"error": "invalid_grant", "error_description": "..."}``
+    (the shape Google, and most OAuth providers, return).
+
+    Only ``httpx.HTTPStatusError`` carries a ``.response`` to read; other
+    ``httpx.HTTPError`` subclasses (timeout, connect error) have no body to
+    inspect and return ``None`` here, which keeps them on the generic
+    :class:`OAuthRefreshError` path. A response body that isn't JSON, isn't an
+    object, or has no ``error`` key also returns ``None`` — never raises: this
+    is a classification aid, not a load-bearing parse, so a malformed or
+    non-standard error body degrades to "unclassified" rather than masking the
+    real failure with a parse exception.
+    """
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return None
+    try:
+        body = exc.response.json()
+    except Exception:
+        return None
+    if not isinstance(body, dict):
+        return None
+    code = body.get("error")
+    return code if isinstance(code, str) else None
 
 
 async def _notify_evict_vault(pool: asyncpg.Pool[Any], vault_id: str) -> None:
@@ -341,6 +367,18 @@ async def _refresh_credential_serialized(
             token_endpoint=token_endpoint,
             exc_info=True,
         )
+        oauth_error = _extract_oauth_error_code(exc)
+        if oauth_error == "invalid_grant":
+            # RFC 6749 §5.2: the authorization server rejected the refresh grant
+            # itself (revoked/expired/dead refresh token) — not a transient
+            # transport failure. Distinguishable so a caller (the model, or a
+            # supervisor polling session events) can stop retrying and prompt
+            # for reconnection instead of treating this like a network blip.
+            raise OAuthReauthRequiredError(
+                "refresh token is no longer valid — the connection needs to be "
+                "reconnected (re-authorized) before it can be used again",
+                detail={"credential_id": credential_id, "token_endpoint": token_endpoint},
+            ) from exc
         raise OAuthRefreshError(
             f"OAuth token endpoint request failed: {exc}",
             detail={"credential_id": credential_id, "token_endpoint": token_endpoint},

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -23,6 +23,7 @@ from aios.errors import (
     CryptoDecryptError,
     ForbiddenError,
     NotFoundError,
+    OAuthReauthRequiredError,
     RateLimitedError,
     ValidationError,
 )
@@ -140,6 +141,18 @@ class TestClassifyToolError:
             (ConflictError("stale version"), False, "stale version", {}),
             (RateLimitedError("slow down"), False, "slow down", {}),
             (ValidationError("bad field"), False, "bad field", {}),
+            # #192: OAuthReauthRequiredError is a 502 (server-class) AiosError like its
+            # OAuthRefreshError parent — deliberately NOT reclassified as client-class.
+            # It stays non-evicting here only because the MCP dispatch path passes no
+            # on_exception (see TestToolLifecycleEviction below) — the classifier itself
+            # still calls this a "genuine failure" (evict=True), consistent with the
+            # http_request built-in path, where a dead credential DOES evict.
+            (
+                OAuthReauthRequiredError("refresh token is no longer valid"),
+                True,
+                "refresh token is no longer valid",
+                {},
+            ),
             # Genuine failures — also evict the sandbox.
             (_InternalAiosError("internal boom"), True, "internal boom", {}),
             # A 5xx WITH detail still gets the json-suffixed message (the detail-format

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -17,7 +17,12 @@ from pydantic import SecretStr
 from aios.crypto.vault import BLOB_VERSION, KEY_BYTES, NONCE_BYTES, CryptoBox, EncryptedBlob
 from aios.db import queries
 from aios.db.queries import EnvVarCredentialRow
-from aios.errors import CryptoDecryptError, OAuthRefreshError, ValidationError
+from aios.errors import (
+    CryptoDecryptError,
+    OAuthReauthRequiredError,
+    OAuthRefreshError,
+    ValidationError,
+)
 from aios.models.environments import EnvironmentConfig, UnrestrictedNetworking
 from aios.models.vaults import (
     TokenEndpointAuthBasic,
@@ -1305,6 +1310,86 @@ class TestRefreshCredential:
         assert not any(
             "UPDATE vault_credentials" in str(c.args[0]) for c in conn.execute.await_args_list
         )
+
+    @pytest.mark.asyncio
+    async def test_invalid_grant_raises_reauth_required(self, crypto_box: CryptoBox) -> None:
+        """#192: Google's real invalid_grant error body (a dead/revoked refresh
+        token) must raise the distinguishable :class:`OAuthReauthRequiredError`,
+        not the generic :class:`OAuthRefreshError` — so a caller can tell
+        "reconnect this" from "retry me"."""
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        payload = _expiring_oauth_payload()
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
+        conn = _conn_with_transaction()
+        client = _async_client_returning(
+            _http_response(
+                status=400,
+                body={
+                    "error": "invalid_grant",
+                    "error_description": "Token has been expired or revoked.",
+                },
+            )
+        )
+
+        with (
+            patch.object(
+                queries,
+                "lock_oauth_credential_for_refresh",
+                AsyncMock(return_value=("vc_1", blob)),
+            ),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
+            pytest.raises(OAuthReauthRequiredError) as exc_info,
+        ):
+            await refresh_credential(
+                crypto_box,
+                fake_pool_yielding_conn(conn),
+                vault_id="vlt_1",
+                target_url="https://mcp.example.com",
+                account_id=account_id,
+            )
+
+        # A distinguishable subclass — a caller that only knows OAuthRefreshError
+        # (the pre-#192 contract) still catches it (it IS one), but a caller
+        # that wants to branch on "needs reconnect" can isinstance-check the
+        # narrower type.
+        assert isinstance(exc_info.value, OAuthRefreshError)
+        assert exc_info.value.error_type == "oauth_reauth_required"
+        assert exc_info.value.status_code == 502  # severity/eviction wiring untouched
+
+    @pytest.mark.asyncio
+    async def test_non_invalid_grant_400_stays_generic_refresh_error(
+        self, crypto_box: CryptoBox
+    ) -> None:
+        """A 400 for a DIFFERENT reason (not invalid_grant) must NOT be
+        misclassified as reauth-required — only the specific RFC 6749 code
+        triggers the narrower error."""
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        payload = _expiring_oauth_payload()
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
+        conn = _conn_with_transaction()
+        client = _async_client_returning(
+            _http_response(status=400, body={"error": "invalid_request"})
+        )
+
+        with (
+            patch.object(
+                queries,
+                "lock_oauth_credential_for_refresh",
+                AsyncMock(return_value=("vc_1", blob)),
+            ),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
+            pytest.raises(OAuthRefreshError) as exc_info,
+        ):
+            await refresh_credential(
+                crypto_box,
+                fake_pool_yielding_conn(conn),
+                vault_id="vlt_1",
+                target_url="https://mcp.example.com",
+                account_id=account_id,
+            )
+
+        assert not isinstance(exc_info.value, OAuthReauthRequiredError)
+        assert exc_info.value.error_type == "oauth_refresh_error"
 
     @pytest.mark.asyncio
     async def test_malformed_response_raises(self, crypto_box: CryptoBox) -> None:


### PR DESCRIPTION
## Summary

RFC 6749 §5.2 `invalid_grant` (revoked/expired/dead OAuth refresh token) is now raised as `OAuthReauthRequiredError`, a subclass of the existing `OAuthRefreshError`, distinguishable by `error_type: "oauth_reauth_required"` and an actionable message. This is the aios-side half of eumemic/jarbot#192 ("Gmail: automated guard/test for restricted-scope refresh token expiry in Testing mode") — the jarbot issue's proposed direction explicitly asks for the failure to be "surfaced as a distinguishable error kind/code, not a bare 401."

Cross-repo scope was explicitly authorized by Tom (relayed via Sam/Chief-of-Staff) after an initial escalation — see the issue thread. **This PR should not be merged without Sam looping back in first**, per that authorization's condition.

### What this does NOT change
- `status_code` stays 502 (unchanged) — deliberately not touching severity/eviction semantics.
- Eviction wiring is untouched. Audited before writing any code: sandbox eviction only fires when `_tool_lifecycle` is called with `on_exception=_evict_session_container`, which is wired ONLY on the built-in-tool dispatch path (`_execute_tool_async`). Gmail (and every MCP server) dispatches via `_execute_mcp_tool_admitted` → `_tool_lifecycle(..., log_prefix="mcp_tool")`, which passes no `on_exception` — so a dead Gmail token was never evicting the sandbox, contrary to my own initial (corrected) claim during triage. The `http_request` built-in's `oauth2_refresh` path DOES pass the eviction hook, and a dead credential there genuinely should still evict — this PR preserves that.
- Every other refresh failure (missing fields, decrypt failure, network error, a non-`invalid_grant` 4xx/5xx, missing `access_token` in the response) is untouched and still raises the plain `OAuthRefreshError`.

### Audit performed before touching the classifier
- Every `AiosError` subclass with `status_code >= 500`: `CryptoDecryptError` (500), `OAuthRefreshError`/`OAuthFlowError`/`ConnectorCallFailedError` (502), `SSEPreflightFailedError` (503), `ManagementCallTimeoutError` (504). None of these are touched by this PR.
- Every `OAuthRefreshError` raise site (all in `services/vaults.py::_refresh_credential_serialized`) — only the token-endpoint-HTTP-error site gains the new `invalid_grant` branch; the other ~6 sites (missing credential, decrypt failure, missing refresh fields, plaintext-http refusal, missing `access_token`, lost-race re-check) are unchanged.
- No caller today catches `OAuthRefreshError` specially outside of tests — this is additive with no observed blast radius beyond the new subclass.

## Substrate state changes

None — code-only change. (The new `error_type: "oauth_reauth_required"` value is a new, additive value in the existing `{"error": {"type", "message", "detail"}}` envelope — no existing consumer branches on `error_type` for this family today, confirmed by audit above, so no external contract is broken; a future consumer, e.g. jarbot's observer, can opt into keying off it.)

## Test plan

- `tests/unit/test_vault.py::TestRefreshCredential::test_invalid_grant_raises_reauth_required` — mocks the token endpoint returning Google's real `invalid_grant` error body shape (`{"error": "invalid_grant", "error_description": "Token has been expired or revoked."}`), asserts `OAuthReauthRequiredError` is raised with `error_type == "oauth_reauth_required"` and `status_code == 502`.
- `tests/unit/test_vault.py::TestRefreshCredential::test_non_invalid_grant_400_stays_generic_refresh_error` — negative case: a 400 for a *different* reason (`invalid_request`) must NOT be misclassified, stays a plain `OAuthRefreshError`.
- `tests/unit/test_tool_dispatch.py::TestClassifyToolError::test_classification` — new parametrized case asserting `OAuthReauthRequiredError` classifies as a genuine failure (`evict=True`) like its parent, consistent with the "severity unchanged" design — it only avoids eviction in practice because the MCP dispatch path passes no `on_exception`.
- Ran full `tests/unit/test_vault.py` (103 passed), `tests/unit/test_tool_dispatch.py` (56 passed), `tests/unit/test_mcp_client.py` (34 passed) for regressions. `ruff check` and `mypy --strict` clean on all touched files.
- No live/manufactured revoked Gmail credential was used to trigger a real `invalid_grant` — that's Casey's (Google/CASA verification) domain and burning a real user's token state wasn't mine to do unilaterally. Will confirm against the next naturally-occurring dead token in production (unverified-app Testing-mode tokens expire routinely at present) via logs once merged.

## Risk / rollback

Low risk: additive-only exception subclass + one new `isinstance`-free `if` branch on a parsed response body, guarded by a broad try/except that degrades to the pre-existing behavior on any unexpected shape. Rollback is a straight revert — no data/schema changes, no migration.