### PR TITLE
feat(api): browser takeover surface — routes, frames SSE, input spool

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1651,6 +1651,470 @@
         }
       }
     },
+    "/v1/browser/takeover": {
+      "post": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Open Takeover",
+        "description": "Open a takeover of the account's computer for one session's page.\n\n409 if a takeover is already in progress (the one-open-per-account\ninvariant); 503 if the computer is unavailable.",
+        "operationId": "open_takeover_v1_browser_takeover_post",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TakeoverOpenRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TakeoverOpenResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/browser/takeover/{grant_id}/heartbeat": {
+      "post": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Heartbeat Takeover",
+        "description": "Bump the grant's heartbeat \u2014 the viewer calls this while it holds the\nframe stream. 404 if unknown, 409 if the grant is no longer open.",
+        "operationId": "heartbeat_takeover_v1_browser_takeover__grant_id__heartbeat_post",
+        "parameters": [
+          {
+            "name": "grant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grant Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/browser/takeover/{grant_id}/input": {
+      "post": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Post Input",
+        "description": "Append one epoch-stamped input batch to the shared-filesystem spool.\n\nNo worker involvement. The check-then-append race (grant closes between\nthe epoch check and the write) is harmless \u2014 the driver drops stale-epoch\nlines, being the enforcement authority. 409 on a closed grant or stale\nepoch; 413 when the spool would exceed its byte cap.",
+        "operationId": "post_input_v1_browser_takeover__grant_id__input_post",
+        "parameters": [
+          {
+            "name": "grant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grant Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InputBatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/browser/takeover/{grant_id}/frames": {
+      "get": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Stream Frames",
+        "description": "Stream the takeover screencast as SSE ``frame`` events, ending on close.\n\nNovel among aios SSE routes: it tails a shared-filesystem ring, not a\nLISTEN channel (the driver has no route to Postgres). The frames dir is\nderived server-side from the scoped grant's account \u2014 the client supplies\nonly ``grant_id`` \u2014 so path containment holds by construction.",
+        "operationId": "stream_frames_v1_browser_takeover__grant_id__frames_get",
+        "parameters": [
+          {
+            "name": "grant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grant Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen": {
+          "targets": []
+        }
+      }
+    },
+    "/v1/browser/takeover/{grant_id}": {
+      "delete": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Close Takeover",
+        "description": "Close a takeover; return the handback (post-human snapshot + inlined\nscreenshot + signed-in delta). A browser-dead close still closes \u2192 null\nhandback fields.",
+        "operationId": "close_takeover_v1_browser_takeover__grant_id__delete",
+        "parameters": [
+          {
+            "name": "grant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Grant Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TakeoverCloseRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TakeoverCloseResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/browser/status": {
+      "get": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Browser Status",
+        "description": "The account computer's state \u2014 never provisions it.",
+        "operationId": "browser_status_v1_browser_status_get",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowserStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/browser/sites/{host}": {
+      "delete": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Revoke Site",
+        "description": "Delete one host's cookies + storage from the account's profile.",
+        "operationId": "revoke_site_v1_browser_sites__host__delete",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Host"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/browser/clear": {
+      "post": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Clear State",
+        "description": "Clear the account computer's state (profile, downloads, ...). 409 if a\ntakeover is open. ``session_id``, when given, receives the\n``browser_state_lost`` model notice.",
+        "operationId": "clear_state_v1_browser_clear_post",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/sessions": {
       "post": {
         "tags": [
@@ -12715,6 +13179,98 @@
         "title": "BoundChat",
         "description": "Read view of one ``chat_sessions`` row.\n\nReturned by ``GET /v1/connections/{id}/bound-chats``.  Operator-bound\nrows and per-chat-spawned rows are returned together \u2014 the table\ndoesn't tag the writer.\n\n``chat_id`` is the **authoritative, gate-relevant identifier** \u2014 it is\nwhat the inbound-admission gate (``AllowList.chat_ids``) matches on.\nThis view deliberately does not surface a connector-supplied\n``display_name`` / ``sender_name``: that value is self-reported by the\nconnector and forgeable, so an operator copying an allowlist entry from\nthis view trusts the ``chat_id``, never a display name."
       },
+      "BrowserStatusResponse": {
+        "properties": {
+          "running": {
+            "type": "boolean",
+            "title": "Running"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "signed_in_hosts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Signed In Hosts"
+          },
+          "takeover": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BrowserTakeoverStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "running"
+        ],
+        "title": "BrowserStatusResponse",
+        "description": "The account computer's state: not running, or running with its page\nand any open takeover + signed-in sites the driver reports."
+      },
+      "BrowserTakeoverStatus": {
+        "properties": {
+          "grant_id": {
+            "type": "string",
+            "title": "Grant Id"
+          },
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason"
+          },
+          "epoch": {
+            "type": "integer",
+            "title": "Epoch"
+          },
+          "boot": {
+            "type": "string",
+            "title": "Boot"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "grant_id",
+          "session_id",
+          "reason",
+          "epoch",
+          "boot",
+          "created_at"
+        ],
+        "title": "BrowserTakeoverStatus",
+        "description": "The open grant on this account's computer, if any."
+      },
       "CapabilitiesUpdate": {
         "properties": {
           "capabilities": {
@@ -13746,6 +14302,53 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "HandbackPayload": {
+        "properties": {
+          "snapshot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot"
+          },
+          "screenshot_data_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Screenshot Data Url"
+          },
+          "signed_in_hosts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Signed In Hosts"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          }
+        },
+        "type": "object",
+        "title": "HandbackPayload",
+        "description": "What the human left behind: the post-takeover page snapshot, an inline\nscreenshot, and which sites are now signed in (the cookie-jar-derived\ndelta). ``None`` fields mean the browser died before the handback could\nbe captured \u2014 the grant still closed."
+      },
       "HttpPermissionPolicy": {
         "properties": {
           "type": {
@@ -14090,6 +14693,142 @@
         ],
         "title": "InlineScriptBody",
         "description": "The inline-script body of an anonymous run launch (T5, #1466).\n\nThe alternative to ``WfRunCreate.workflow_id``: a one-shot run launched directly\nfrom this ``{script, schemas, surface}`` body, with NO ``workflows`` row created.\nThe run snapshots ``script`` exactly as it snapshots a registered workflow's, and\nthe declared surface (``tools``/``mcp_servers``/``http_servers``) is clamped to the\nlauncher with the same create-time clamp ``create_workflow`` uses (a surface\nexceeding the launcher raises ``ForbiddenError``). The HTTP/operator path is\nunattenuated operator authority; names-only http sugar is rejected there (no acting\nagent to resolve a bare name against)."
+      },
+      "InputBatch": {
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "title": "Epoch"
+          },
+          "seq": {
+            "type": "integer",
+            "title": "Seq"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/InputEvent"
+            },
+            "type": "array",
+            "maxItems": 200,
+            "minItems": 1,
+            "title": "Events"
+          }
+        },
+        "type": "object",
+        "required": [
+          "epoch",
+          "seq",
+          "events"
+        ],
+        "title": "InputBatch",
+        "description": "One coalesced batch of input events, epoch-stamped.\n\nThe API pre-checks the epoch against the grant record; the DRIVER is the\nenforcement authority and drops stale-epoch spool lines regardless."
+      },
+      "InputEvent": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "pointer_move",
+              "pointer_down",
+              "pointer_up",
+              "wheel",
+              "key_down",
+              "key_up",
+              "text"
+            ],
+            "title": "Type"
+          },
+          "x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X"
+          },
+          "y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y"
+          },
+          "button": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "left",
+                  "middle",
+                  "right"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Button"
+          },
+          "dx": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dx"
+          },
+          "dy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dy"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "InputEvent",
+        "description": "One raw viewer input event (\u00a75.6 vocabulary)."
       },
       "LimitedNetworking": {
         "properties": {
@@ -17937,6 +18676,88 @@
         ],
         "title": "SkillVersionCreate",
         "description": "Request body for ``POST /v1/skills/{skill_id}/versions``.\n\nSame file format as :class:`SkillCreate`. The directory, name, and\ndescription are re-extracted from the new SKILL.md."
+      },
+      "TakeoverCloseRequest": {
+        "properties": {
+          "outcome": {
+            "type": "string",
+            "enum": [
+              "done",
+              "cancelled"
+            ],
+            "title": "Outcome",
+            "default": "done"
+          }
+        },
+        "type": "object",
+        "title": "TakeoverCloseRequest"
+      },
+      "TakeoverCloseResponse": {
+        "properties": {
+          "handback": {
+            "$ref": "#/components/schemas/HandbackPayload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "handback"
+        ],
+        "title": "TakeoverCloseResponse"
+      },
+      "TakeoverOpenRequest": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "reason": {
+            "type": "string",
+            "maxLength": 200,
+            "title": "Reason",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id"
+        ],
+        "title": "TakeoverOpenRequest",
+        "description": "Open a takeover of the account's computer for one agent session's page."
+      },
+      "TakeoverOpenResponse": {
+        "properties": {
+          "grant_id": {
+            "type": "string",
+            "title": "Grant Id"
+          },
+          "target": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Target"
+          },
+          "boot": {
+            "type": "string",
+            "title": "Boot"
+          },
+          "epoch": {
+            "type": "integer",
+            "title": "Epoch"
+          },
+          "ttl_seconds": {
+            "type": "integer",
+            "title": "Ttl Seconds"
+          }
+        },
+        "type": "object",
+        "required": [
+          "grant_id",
+          "target",
+          "boot",
+          "epoch",
+          "ttl_seconds"
+        ],
+        "title": "TakeoverOpenResponse",
+        "description": "The opened grant. The viewer PINS ``target``/``boot``/``epoch`` and\nrefuses frames or input that do not match (the trusted-chrome binding,\njarbot#106 \u00a75.6)."
       },
       "TaskHandle": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/browser_status_v1_browser_status_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/browser_status_v1_browser_status_get.py
@@ -1,0 +1,171 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.browser_status_response import BrowserStatusResponse
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/browser/status",
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> BrowserStatusResponse | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = BrowserStatusResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[BrowserStatusResponse | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[BrowserStatusResponse | HTTPValidationError]:
+    """Browser Status
+
+     The account computer's state — never provisions it.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[BrowserStatusResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> BrowserStatusResponse | HTTPValidationError | None:
+    """Browser Status
+
+     The account computer's state — never provisions it.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        BrowserStatusResponse | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[BrowserStatusResponse | HTTPValidationError]:
+    """Browser Status
+
+     The account computer's state — never provisions it.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[BrowserStatusResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> BrowserStatusResponse | HTTPValidationError | None:
+    """Browser Status
+
+     The account computer's state — never provisions it.
+
+    Args:
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        BrowserStatusResponse | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/clear_state_v1_browser_clear_post.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/clear_state_v1_browser_clear_post.py
@@ -1,0 +1,202 @@
+from http import HTTPStatus
+from typing import Any, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_session_id: None | str | Unset
+    if isinstance(session_id, Unset):
+        json_session_id = UNSET
+    else:
+        json_session_id = session_id
+    params["session_id"] = json_session_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/browser/clear",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Clear State
+
+     Clear the account computer's state (profile, downloads, ...). 409 if a
+    takeover is open. ``session_id``, when given, receives the
+    ``browser_state_lost`` model notice.
+
+    Args:
+        session_id (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Clear State
+
+     Clear the account computer's state (profile, downloads, ...). 409 if a
+    takeover is open. ``session_id``, when given, receives the
+    ``browser_state_lost`` model notice.
+
+    Args:
+        session_id (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        session_id=session_id,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Clear State
+
+     Clear the account computer's state (profile, downloads, ...). 409 if a
+    takeover is open. ``session_id``, when given, receives the
+    ``browser_state_lost`` model notice.
+
+    Args:
+        session_id (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Clear State
+
+     Clear the account computer's state (profile, downloads, ...). 409 if a
+    takeover is open. ``session_id``, when given, receives the
+    ``browser_state_lost`` model notice.
+
+    Args:
+        session_id (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            session_id=session_id,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/close_takeover_v1_browser_takeover_grant_id_delete.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/close_takeover_v1_browser_takeover_grant_id_delete.py
@@ -1,0 +1,213 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.takeover_close_request import TakeoverCloseRequest
+from ...models.takeover_close_response import TakeoverCloseResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    grant_id: str,
+    *,
+    body: TakeoverCloseRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/browser/takeover/{grant_id}".format(
+            grant_id=quote(str(grant_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | TakeoverCloseResponse | None:
+    if response.status_code == 200:
+        response_200 = TakeoverCloseResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | TakeoverCloseResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: TakeoverCloseRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | TakeoverCloseResponse]:
+    """Close Takeover
+
+     Close a takeover; return the handback (post-human snapshot + inlined
+    screenshot + signed-in delta). A browser-dead close still closes → null
+    handback fields.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+        body (TakeoverCloseRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | TakeoverCloseResponse]
+    """
+
+    kwargs = _get_kwargs(
+        grant_id=grant_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: TakeoverCloseRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | TakeoverCloseResponse | None:
+    """Close Takeover
+
+     Close a takeover; return the handback (post-human snapshot + inlined
+    screenshot + signed-in delta). A browser-dead close still closes → null
+    handback fields.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+        body (TakeoverCloseRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | TakeoverCloseResponse
+    """
+
+    return sync_detailed(
+        grant_id=grant_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: TakeoverCloseRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | TakeoverCloseResponse]:
+    """Close Takeover
+
+     Close a takeover; return the handback (post-human snapshot + inlined
+    screenshot + signed-in delta). A browser-dead close still closes → null
+    handback fields.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+        body (TakeoverCloseRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | TakeoverCloseResponse]
+    """
+
+    kwargs = _get_kwargs(
+        grant_id=grant_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: TakeoverCloseRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | TakeoverCloseResponse | None:
+    """Close Takeover
+
+     Close a takeover; return the handback (post-human snapshot + inlined
+    screenshot + signed-in delta). A browser-dead close still closes → null
+    handback fields.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+        body (TakeoverCloseRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | TakeoverCloseResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            grant_id=grant_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/heartbeat_takeover_v1_browser_takeover_grant_id_heartbeat_post.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/heartbeat_takeover_v1_browser_takeover_grant_id_heartbeat_post.py
@@ -1,0 +1,189 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    grant_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/browser/takeover/{grant_id}/heartbeat".format(
+            grant_id=quote(str(grant_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Heartbeat Takeover
+
+     Bump the grant's heartbeat — the viewer calls this while it holds the
+    frame stream. 404 if unknown, 409 if the grant is no longer open.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        grant_id=grant_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Heartbeat Takeover
+
+     Bump the grant's heartbeat — the viewer calls this while it holds the
+    frame stream. 404 if unknown, 409 if the grant is no longer open.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        grant_id=grant_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Heartbeat Takeover
+
+     Bump the grant's heartbeat — the viewer calls this while it holds the
+    frame stream. 404 if unknown, 409 if the grant is no longer open.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        grant_id=grant_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Heartbeat Takeover
+
+     Bump the grant's heartbeat — the viewer calls this while it holds the
+    frame stream. 404 if unknown, 409 if the grant is no longer open.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            grant_id=grant_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/open_takeover_v1_browser_takeover_post.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/open_takeover_v1_browser_takeover_post.py
@@ -1,0 +1,205 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.takeover_open_request import TakeoverOpenRequest
+from ...models.takeover_open_response import TakeoverOpenResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: TakeoverOpenRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/browser/takeover",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | TakeoverOpenResponse | None:
+    if response.status_code == 200:
+        response_200 = TakeoverOpenResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | TakeoverOpenResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: TakeoverOpenRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | TakeoverOpenResponse]:
+    """Open Takeover
+
+     Open a takeover of the account's computer for one session's page.
+
+    409 if a takeover is already in progress (the one-open-per-account
+    invariant); 503 if the computer is unavailable.
+
+    Args:
+        authorization (None | str | Unset):
+        body (TakeoverOpenRequest): Open a takeover of the account's computer for one agent
+            session's page.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | TakeoverOpenResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: TakeoverOpenRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | TakeoverOpenResponse | None:
+    """Open Takeover
+
+     Open a takeover of the account's computer for one session's page.
+
+    409 if a takeover is already in progress (the one-open-per-account
+    invariant); 503 if the computer is unavailable.
+
+    Args:
+        authorization (None | str | Unset):
+        body (TakeoverOpenRequest): Open a takeover of the account's computer for one agent
+            session's page.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | TakeoverOpenResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: TakeoverOpenRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | TakeoverOpenResponse]:
+    """Open Takeover
+
+     Open a takeover of the account's computer for one session's page.
+
+    409 if a takeover is already in progress (the one-open-per-account
+    invariant); 503 if the computer is unavailable.
+
+    Args:
+        authorization (None | str | Unset):
+        body (TakeoverOpenRequest): Open a takeover of the account's computer for one agent
+            session's page.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | TakeoverOpenResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: TakeoverOpenRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | TakeoverOpenResponse | None:
+    """Open Takeover
+
+     Open a takeover of the account's computer for one session's page.
+
+    409 if a takeover is already in progress (the one-open-per-account
+    invariant); 503 if the computer is unavailable.
+
+    Args:
+        authorization (None | str | Unset):
+        body (TakeoverOpenRequest): Open a takeover of the account's computer for one agent
+            session's page.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | TakeoverOpenResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/post_input_v1_browser_takeover_grant_id_input_post.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/post_input_v1_browser_takeover_grant_id_input_post.py
@@ -1,0 +1,235 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.input_batch import InputBatch
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    grant_id: str,
+    *,
+    body: InputBatch,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/browser/takeover/{grant_id}/input".format(
+            grant_id=quote(str(grant_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: InputBatch,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Post Input
+
+     Append one epoch-stamped input batch to the shared-filesystem spool.
+
+    No worker involvement. The check-then-append race (grant closes between
+    the epoch check and the write) is harmless — the driver drops stale-epoch
+    lines, being the enforcement authority. 409 on a closed grant or stale
+    epoch; 413 when the spool would exceed its byte cap.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+        body (InputBatch): One coalesced batch of input events, epoch-stamped.
+
+            The API pre-checks the epoch against the grant record; the DRIVER is the
+            enforcement authority and drops stale-epoch spool lines regardless.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        grant_id=grant_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: InputBatch,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Post Input
+
+     Append one epoch-stamped input batch to the shared-filesystem spool.
+
+    No worker involvement. The check-then-append race (grant closes between
+    the epoch check and the write) is harmless — the driver drops stale-epoch
+    lines, being the enforcement authority. 409 on a closed grant or stale
+    epoch; 413 when the spool would exceed its byte cap.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+        body (InputBatch): One coalesced batch of input events, epoch-stamped.
+
+            The API pre-checks the epoch against the grant record; the DRIVER is the
+            enforcement authority and drops stale-epoch spool lines regardless.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        grant_id=grant_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: InputBatch,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Post Input
+
+     Append one epoch-stamped input batch to the shared-filesystem spool.
+
+    No worker involvement. The check-then-append race (grant closes between
+    the epoch check and the write) is harmless — the driver drops stale-epoch
+    lines, being the enforcement authority. 409 on a closed grant or stale
+    epoch; 413 when the spool would exceed its byte cap.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+        body (InputBatch): One coalesced batch of input events, epoch-stamped.
+
+            The API pre-checks the epoch against the grant record; the DRIVER is the
+            enforcement authority and drops stale-epoch spool lines regardless.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        grant_id=grant_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: InputBatch,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Post Input
+
+     Append one epoch-stamped input batch to the shared-filesystem spool.
+
+    No worker involvement. The check-then-append race (grant closes between
+    the epoch check and the write) is harmless — the driver drops stale-epoch
+    lines, being the enforcement authority. 409 on a closed grant or stale
+    epoch; 413 when the spool would exceed its byte cap.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+        body (InputBatch): One coalesced batch of input events, epoch-stamped.
+
+            The API pre-checks the epoch against the grant record; the DRIVER is the
+            enforcement authority and drops stale-epoch spool lines regardless.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            grant_id=grant_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/revoke_site_v1_browser_sites_host_delete.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/revoke_site_v1_browser_sites_host_delete.py
@@ -1,0 +1,185 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    host: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/v1/browser/sites/{host}".format(
+            host=quote(str(host), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    host: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Revoke Site
+
+     Delete one host's cookies + storage from the account's profile.
+
+    Args:
+        host (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        host=host,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    host: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Revoke Site
+
+     Delete one host's cookies + storage from the account's profile.
+
+    Args:
+        host (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        host=host,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    host: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Revoke Site
+
+     Delete one host's cookies + storage from the account's profile.
+
+    Args:
+        host (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        host=host,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    host: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Revoke Site
+
+     Delete one host's cookies + storage from the account's profile.
+
+    Args:
+        host (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            host=host,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/stream_frames_v1_browser_takeover_grant_id_frames_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/stream_frames_v1_browser_takeover_grant_id_frames_get.py
@@ -1,0 +1,205 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    grant_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/browser/takeover/{grant_id}/frames".format(
+            grant_id=quote(str(grant_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Stream Frames
+
+     Stream the takeover screencast as SSE ``frame`` events, ending on close.
+
+    Novel among aios SSE routes: it tails a shared-filesystem ring, not a
+    LISTEN channel (the driver has no route to Postgres). The frames dir is
+    derived server-side from the scoped grant's account — the client supplies
+    only ``grant_id`` — so path containment holds by construction.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        grant_id=grant_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Stream Frames
+
+     Stream the takeover screencast as SSE ``frame`` events, ending on close.
+
+    Novel among aios SSE routes: it tails a shared-filesystem ring, not a
+    LISTEN channel (the driver has no route to Postgres). The frames dir is
+    derived server-side from the scoped grant's account — the client supplies
+    only ``grant_id`` — so path containment holds by construction.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        grant_id=grant_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Stream Frames
+
+     Stream the takeover screencast as SSE ``frame`` events, ending on close.
+
+    Novel among aios SSE routes: it tails a shared-filesystem ring, not a
+    LISTEN channel (the driver has no route to Postgres). The frames dir is
+    derived server-side from the scoped grant's account — the client supplies
+    only ``grant_id`` — so path containment holds by construction.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        grant_id=grant_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    grant_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Stream Frames
+
+     Stream the takeover screencast as SSE ``frame`` events, ending on close.
+
+    Novel among aios SSE routes: it tails a shared-filesystem ring, not a
+    LISTEN channel (the driver has no route to Postgres). The frames dir is
+    derived server-side from the scoped grant's account — the client supplies
+    only ``grant_id`` — so path containment holds by construction.
+
+    Args:
+        grant_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            grant_id=grant_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -42,6 +42,8 @@ from .body_upload_session_file import BodyUploadSessionFile
 from .bootstrap_request import BootstrapRequest
 from .bootstrap_response import BootstrapResponse
 from .bound_chat import BoundChat
+from .browser_status_response import BrowserStatusResponse
+from .browser_takeover_status import BrowserTakeoverStatus
 from .capabilities_update import CapabilitiesUpdate
 from .connection import Connection
 from .connection_attach import ConnectionAttach
@@ -85,6 +87,7 @@ from .get_health_response_get_health import GetHealthResponseGetHealth
 from .github_repository_resource import GithubRepositoryResource
 from .github_repository_resource_echo import GithubRepositoryResourceEcho
 from .github_repository_update import GithubRepositoryUpdate
+from .handback_payload import HandbackPayload
 from .http_permission_policy import HttpPermissionPolicy
 from .http_permission_policy_type import HttpPermissionPolicyType
 from .http_route_spec import HttpRouteSpec
@@ -100,6 +103,10 @@ from .ingest_external_event_response_ingest_external_event import (
 from .inline_script_body import InlineScriptBody
 from .inline_script_body_input_schema_type_0 import InlineScriptBodyInputSchemaType0
 from .inline_script_body_output_schema_type_0 import InlineScriptBodyOutputSchemaType0
+from .input_batch import InputBatch
+from .input_event import InputEvent
+from .input_event_button_type_0 import InputEventButtonType0
+from .input_event_type import InputEventType
 from .limited_networking import LimitedNetworking
 from .list_connections_mode_type_0 import ListConnectionsModeType0
 from .list_response_agent import ListResponseAgent
@@ -262,6 +269,12 @@ from .skill_version_files import SkillVersionFiles
 from .stream_events_v1_sessions_session_id_stream_get_chat_type_type_0 import (
     StreamEventsV1SessionsSessionIdStreamGetChatTypeType0,
 )
+from .takeover_close_request import TakeoverCloseRequest
+from .takeover_close_request_outcome import TakeoverCloseRequestOutcome
+from .takeover_close_response import TakeoverCloseResponse
+from .takeover_open_request import TakeoverOpenRequest
+from .takeover_open_response import TakeoverOpenResponse
+from .takeover_open_response_target import TakeoverOpenResponseTarget
 from .task_handle import TaskHandle
 from .task_handle_servicer_kind import TaskHandleServicerKind
 from .task_request import TaskRequest
@@ -414,6 +427,8 @@ __all__ = (
     "BootstrapRequest",
     "BootstrapResponse",
     "BoundChat",
+    "BrowserStatusResponse",
+    "BrowserTakeoverStatus",
     "CapabilitiesUpdate",
     "Connection",
     "ConnectionAttach",
@@ -453,6 +468,7 @@ __all__ = (
     "GithubRepositoryResource",
     "GithubRepositoryResourceEcho",
     "GithubRepositoryUpdate",
+    "HandbackPayload",
     "HttpPermissionPolicy",
     "HttpPermissionPolicyType",
     "HttpRouteSpec",
@@ -466,6 +482,10 @@ __all__ = (
     "InlineScriptBody",
     "InlineScriptBodyInputSchemaType0",
     "InlineScriptBodyOutputSchemaType0",
+    "InputBatch",
+    "InputEvent",
+    "InputEventButtonType0",
+    "InputEventType",
     "LimitedNetworking",
     "ListConnectionsModeType0",
     "ListResponseAgent",
@@ -604,6 +624,12 @@ __all__ = (
     "SkillVersionCreateFiles",
     "SkillVersionFiles",
     "StreamEventsV1SessionsSessionIdStreamGetChatTypeType0",
+    "TakeoverCloseRequest",
+    "TakeoverCloseRequestOutcome",
+    "TakeoverCloseResponse",
+    "TakeoverOpenRequest",
+    "TakeoverOpenResponse",
+    "TakeoverOpenResponseTarget",
     "TaskHandle",
     "TaskHandleServicerKind",
     "TaskRequest",

--- a/packages/aios-sdk/aios_sdk/_generated/models/browser_status_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/browser_status_response.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.browser_takeover_status import BrowserTakeoverStatus
+
+
+T = TypeVar("T", bound="BrowserStatusResponse")
+
+
+@_attrs_define
+class BrowserStatusResponse:
+    """The account computer's state: not running, or running with its page
+    and any open takeover + signed-in sites the driver reports.
+
+        Attributes:
+            running (bool):
+            url (None | str | Unset):
+            title (None | str | Unset):
+            signed_in_hosts (list[str] | Unset):
+            takeover (BrowserTakeoverStatus | None | Unset):
+    """
+
+    running: bool
+    url: None | str | Unset = UNSET
+    title: None | str | Unset = UNSET
+    signed_in_hosts: list[str] | Unset = UNSET
+    takeover: BrowserTakeoverStatus | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.browser_takeover_status import BrowserTakeoverStatus
+
+        running = self.running
+
+        url: None | str | Unset
+        if isinstance(self.url, Unset):
+            url = UNSET
+        else:
+            url = self.url
+
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
+
+        signed_in_hosts: list[str] | Unset = UNSET
+        if not isinstance(self.signed_in_hosts, Unset):
+            signed_in_hosts = self.signed_in_hosts
+
+        takeover: dict[str, Any] | None | Unset
+        if isinstance(self.takeover, Unset):
+            takeover = UNSET
+        elif isinstance(self.takeover, BrowserTakeoverStatus):
+            takeover = self.takeover.to_dict()
+        else:
+            takeover = self.takeover
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "running": running,
+            }
+        )
+        if url is not UNSET:
+            field_dict["url"] = url
+        if title is not UNSET:
+            field_dict["title"] = title
+        if signed_in_hosts is not UNSET:
+            field_dict["signed_in_hosts"] = signed_in_hosts
+        if takeover is not UNSET:
+            field_dict["takeover"] = takeover
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.browser_takeover_status import BrowserTakeoverStatus
+
+        d = dict(src_dict)
+        running = d.pop("running")
+
+        def _parse_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url = _parse_url(d.pop("url", UNSET))
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
+
+        signed_in_hosts = cast(list[str], d.pop("signed_in_hosts", UNSET))
+
+        def _parse_takeover(data: object) -> BrowserTakeoverStatus | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                takeover_type_0 = BrowserTakeoverStatus.from_dict(data)
+
+                return takeover_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(BrowserTakeoverStatus | None | Unset, data)
+
+        takeover = _parse_takeover(d.pop("takeover", UNSET))
+
+        browser_status_response = cls(
+            running=running,
+            url=url,
+            title=title,
+            signed_in_hosts=signed_in_hosts,
+            takeover=takeover,
+        )
+
+        browser_status_response.additional_properties = d
+        return browser_status_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/browser_takeover_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/browser_takeover_status.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="BrowserTakeoverStatus")
+
+
+@_attrs_define
+class BrowserTakeoverStatus:
+    """The open grant on this account's computer, if any.
+
+    Attributes:
+        grant_id (str):
+        session_id (str):
+        reason (str):
+        epoch (int):
+        boot (str):
+        created_at (str):
+    """
+
+    grant_id: str
+    session_id: str
+    reason: str
+    epoch: int
+    boot: str
+    created_at: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        grant_id = self.grant_id
+
+        session_id = self.session_id
+
+        reason = self.reason
+
+        epoch = self.epoch
+
+        boot = self.boot
+
+        created_at = self.created_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "grant_id": grant_id,
+                "session_id": session_id,
+                "reason": reason,
+                "epoch": epoch,
+                "boot": boot,
+                "created_at": created_at,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        grant_id = d.pop("grant_id")
+
+        session_id = d.pop("session_id")
+
+        reason = d.pop("reason")
+
+        epoch = d.pop("epoch")
+
+        boot = d.pop("boot")
+
+        created_at = d.pop("created_at")
+
+        browser_takeover_status = cls(
+            grant_id=grant_id,
+            session_id=session_id,
+            reason=reason,
+            epoch=epoch,
+            boot=boot,
+            created_at=created_at,
+        )
+
+        browser_takeover_status.additional_properties = d
+        return browser_takeover_status
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/handback_payload.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/handback_payload.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="HandbackPayload")
+
+
+@_attrs_define
+class HandbackPayload:
+    """What the human left behind: the post-takeover page snapshot, an inline
+    screenshot, and which sites are now signed in (the cookie-jar-derived
+    delta). ``None`` fields mean the browser died before the handback could
+    be captured — the grant still closed.
+
+        Attributes:
+            snapshot (None | str | Unset):
+            screenshot_data_url (None | str | Unset):
+            signed_in_hosts (list[str] | Unset):
+            url (None | str | Unset):
+    """
+
+    snapshot: None | str | Unset = UNSET
+    screenshot_data_url: None | str | Unset = UNSET
+    signed_in_hosts: list[str] | Unset = UNSET
+    url: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        snapshot: None | str | Unset
+        if isinstance(self.snapshot, Unset):
+            snapshot = UNSET
+        else:
+            snapshot = self.snapshot
+
+        screenshot_data_url: None | str | Unset
+        if isinstance(self.screenshot_data_url, Unset):
+            screenshot_data_url = UNSET
+        else:
+            screenshot_data_url = self.screenshot_data_url
+
+        signed_in_hosts: list[str] | Unset = UNSET
+        if not isinstance(self.signed_in_hosts, Unset):
+            signed_in_hosts = self.signed_in_hosts
+
+        url: None | str | Unset
+        if isinstance(self.url, Unset):
+            url = UNSET
+        else:
+            url = self.url
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if snapshot is not UNSET:
+            field_dict["snapshot"] = snapshot
+        if screenshot_data_url is not UNSET:
+            field_dict["screenshot_data_url"] = screenshot_data_url
+        if signed_in_hosts is not UNSET:
+            field_dict["signed_in_hosts"] = signed_in_hosts
+        if url is not UNSET:
+            field_dict["url"] = url
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_snapshot(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        snapshot = _parse_snapshot(d.pop("snapshot", UNSET))
+
+        def _parse_screenshot_data_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        screenshot_data_url = _parse_screenshot_data_url(
+            d.pop("screenshot_data_url", UNSET)
+        )
+
+        signed_in_hosts = cast(list[str], d.pop("signed_in_hosts", UNSET))
+
+        def _parse_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url = _parse_url(d.pop("url", UNSET))
+
+        handback_payload = cls(
+            snapshot=snapshot,
+            screenshot_data_url=screenshot_data_url,
+            signed_in_hosts=signed_in_hosts,
+            url=url,
+        )
+
+        handback_payload.additional_properties = d
+        return handback_payload
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/input_batch.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/input_batch.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.input_event import InputEvent
+
+
+T = TypeVar("T", bound="InputBatch")
+
+
+@_attrs_define
+class InputBatch:
+    """One coalesced batch of input events, epoch-stamped.
+
+    The API pre-checks the epoch against the grant record; the DRIVER is the
+    enforcement authority and drops stale-epoch spool lines regardless.
+
+        Attributes:
+            epoch (int):
+            seq (int):
+            events (list[InputEvent]):
+    """
+
+    epoch: int
+    seq: int
+    events: list[InputEvent]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        epoch = self.epoch
+
+        seq = self.seq
+
+        events = []
+        for events_item_data in self.events:
+            events_item = events_item_data.to_dict()
+            events.append(events_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "epoch": epoch,
+                "seq": seq,
+                "events": events,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.input_event import InputEvent
+
+        d = dict(src_dict)
+        epoch = d.pop("epoch")
+
+        seq = d.pop("seq")
+
+        events = []
+        _events = d.pop("events")
+        for events_item_data in _events:
+            events_item = InputEvent.from_dict(events_item_data)
+
+            events.append(events_item)
+
+        input_batch = cls(
+            epoch=epoch,
+            seq=seq,
+            events=events,
+        )
+
+        input_batch.additional_properties = d
+        return input_batch
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/input_event.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/input_event.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.input_event_button_type_0 import InputEventButtonType0
+from ..models.input_event_type import InputEventType
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="InputEvent")
+
+
+@_attrs_define
+class InputEvent:
+    """One raw viewer input event (§5.6 vocabulary).
+
+    Attributes:
+        type_ (InputEventType):
+        x (float | None | Unset):
+        y (float | None | Unset):
+        button (InputEventButtonType0 | None | Unset):
+        dx (float | None | Unset):
+        dy (float | None | Unset):
+        key (None | str | Unset):
+        text (None | str | Unset):
+    """
+
+    type_: InputEventType
+    x: float | None | Unset = UNSET
+    y: float | None | Unset = UNSET
+    button: InputEventButtonType0 | None | Unset = UNSET
+    dx: float | None | Unset = UNSET
+    dy: float | None | Unset = UNSET
+    key: None | str | Unset = UNSET
+    text: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_.value
+
+        x: float | None | Unset
+        if isinstance(self.x, Unset):
+            x = UNSET
+        else:
+            x = self.x
+
+        y: float | None | Unset
+        if isinstance(self.y, Unset):
+            y = UNSET
+        else:
+            y = self.y
+
+        button: None | str | Unset
+        if isinstance(self.button, Unset):
+            button = UNSET
+        elif isinstance(self.button, InputEventButtonType0):
+            button = self.button.value
+        else:
+            button = self.button
+
+        dx: float | None | Unset
+        if isinstance(self.dx, Unset):
+            dx = UNSET
+        else:
+            dx = self.dx
+
+        dy: float | None | Unset
+        if isinstance(self.dy, Unset):
+            dy = UNSET
+        else:
+            dy = self.dy
+
+        key: None | str | Unset
+        if isinstance(self.key, Unset):
+            key = UNSET
+        else:
+            key = self.key
+
+        text: None | str | Unset
+        if isinstance(self.text, Unset):
+            text = UNSET
+        else:
+            text = self.text
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+            }
+        )
+        if x is not UNSET:
+            field_dict["x"] = x
+        if y is not UNSET:
+            field_dict["y"] = y
+        if button is not UNSET:
+            field_dict["button"] = button
+        if dx is not UNSET:
+            field_dict["dx"] = dx
+        if dy is not UNSET:
+            field_dict["dy"] = dy
+        if key is not UNSET:
+            field_dict["key"] = key
+        if text is not UNSET:
+            field_dict["text"] = text
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = InputEventType(d.pop("type"))
+
+        def _parse_x(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        x = _parse_x(d.pop("x", UNSET))
+
+        def _parse_y(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        y = _parse_y(d.pop("y", UNSET))
+
+        def _parse_button(data: object) -> InputEventButtonType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                button_type_0 = InputEventButtonType0(data)
+
+                return button_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(InputEventButtonType0 | None | Unset, data)
+
+        button = _parse_button(d.pop("button", UNSET))
+
+        def _parse_dx(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        dx = _parse_dx(d.pop("dx", UNSET))
+
+        def _parse_dy(data: object) -> float | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(float | None | Unset, data)
+
+        dy = _parse_dy(d.pop("dy", UNSET))
+
+        def _parse_key(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        key = _parse_key(d.pop("key", UNSET))
+
+        def _parse_text(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        text = _parse_text(d.pop("text", UNSET))
+
+        input_event = cls(
+            type_=type_,
+            x=x,
+            y=y,
+            button=button,
+            dx=dx,
+            dy=dy,
+            key=key,
+            text=text,
+        )
+
+        input_event.additional_properties = d
+        return input_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/input_event_button_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/input_event_button_type_0.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class InputEventButtonType0(str, Enum):
+    LEFT = "left"
+    MIDDLE = "middle"
+    RIGHT = "right"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/input_event_type.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/input_event_type.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class InputEventType(str, Enum):
+    KEY_DOWN = "key_down"
+    KEY_UP = "key_up"
+    POINTER_DOWN = "pointer_down"
+    POINTER_MOVE = "pointer_move"
+    POINTER_UP = "pointer_up"
+    TEXT = "text"
+    WHEEL = "wheel"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/takeover_close_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/takeover_close_request.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.takeover_close_request_outcome import TakeoverCloseRequestOutcome
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TakeoverCloseRequest")
+
+
+@_attrs_define
+class TakeoverCloseRequest:
+    """
+    Attributes:
+        outcome (TakeoverCloseRequestOutcome | Unset):  Default: TakeoverCloseRequestOutcome.DONE.
+    """
+
+    outcome: TakeoverCloseRequestOutcome | Unset = TakeoverCloseRequestOutcome.DONE
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        outcome: str | Unset = UNSET
+        if not isinstance(self.outcome, Unset):
+            outcome = self.outcome.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if outcome is not UNSET:
+            field_dict["outcome"] = outcome
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        _outcome = d.pop("outcome", UNSET)
+        outcome: TakeoverCloseRequestOutcome | Unset
+        if isinstance(_outcome, Unset):
+            outcome = UNSET
+        else:
+            outcome = TakeoverCloseRequestOutcome(_outcome)
+
+        takeover_close_request = cls(
+            outcome=outcome,
+        )
+
+        takeover_close_request.additional_properties = d
+        return takeover_close_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/takeover_close_request_outcome.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/takeover_close_request_outcome.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class TakeoverCloseRequestOutcome(str, Enum):
+    CANCELLED = "cancelled"
+    DONE = "done"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/takeover_close_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/takeover_close_response.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.handback_payload import HandbackPayload
+
+
+T = TypeVar("T", bound="TakeoverCloseResponse")
+
+
+@_attrs_define
+class TakeoverCloseResponse:
+    """
+    Attributes:
+        handback (HandbackPayload): What the human left behind: the post-takeover page snapshot, an inline
+            screenshot, and which sites are now signed in (the cookie-jar-derived
+            delta). ``None`` fields mean the browser died before the handback could
+            be captured — the grant still closed.
+    """
+
+    handback: HandbackPayload
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        handback = self.handback.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "handback": handback,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.handback_payload import HandbackPayload
+
+        d = dict(src_dict)
+        handback = HandbackPayload.from_dict(d.pop("handback"))
+
+        takeover_close_response = cls(
+            handback=handback,
+        )
+
+        takeover_close_response.additional_properties = d
+        return takeover_close_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/takeover_open_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/takeover_open_request.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TakeoverOpenRequest")
+
+
+@_attrs_define
+class TakeoverOpenRequest:
+    """Open a takeover of the account's computer for one agent session's page.
+
+    Attributes:
+        session_id (str):
+        reason (str | Unset):  Default: ''.
+    """
+
+    session_id: str
+    reason: str | Unset = ""
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        session_id = self.session_id
+
+        reason = self.reason
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "session_id": session_id,
+            }
+        )
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_id = d.pop("session_id")
+
+        reason = d.pop("reason", UNSET)
+
+        takeover_open_request = cls(
+            session_id=session_id,
+            reason=reason,
+        )
+
+        takeover_open_request.additional_properties = d
+        return takeover_open_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/takeover_open_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/takeover_open_response.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.takeover_open_response_target import TakeoverOpenResponseTarget
+
+
+T = TypeVar("T", bound="TakeoverOpenResponse")
+
+
+@_attrs_define
+class TakeoverOpenResponse:
+    """The opened grant. The viewer PINS ``target``/``boot``/``epoch`` and
+    refuses frames or input that do not match (the trusted-chrome binding,
+    jarbot#106 §5.6).
+
+        Attributes:
+            grant_id (str):
+            target (TakeoverOpenResponseTarget):
+            boot (str):
+            epoch (int):
+            ttl_seconds (int):
+    """
+
+    grant_id: str
+    target: TakeoverOpenResponseTarget
+    boot: str
+    epoch: int
+    ttl_seconds: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        grant_id = self.grant_id
+
+        target = self.target.to_dict()
+
+        boot = self.boot
+
+        epoch = self.epoch
+
+        ttl_seconds = self.ttl_seconds
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "grant_id": grant_id,
+                "target": target,
+                "boot": boot,
+                "epoch": epoch,
+                "ttl_seconds": ttl_seconds,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.takeover_open_response_target import TakeoverOpenResponseTarget
+
+        d = dict(src_dict)
+        grant_id = d.pop("grant_id")
+
+        target = TakeoverOpenResponseTarget.from_dict(d.pop("target"))
+
+        boot = d.pop("boot")
+
+        epoch = d.pop("epoch")
+
+        ttl_seconds = d.pop("ttl_seconds")
+
+        takeover_open_response = cls(
+            grant_id=grant_id,
+            target=target,
+            boot=boot,
+            epoch=epoch,
+            ttl_seconds=ttl_seconds,
+        )
+
+        takeover_open_response.additional_properties = d
+        return takeover_open_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/takeover_open_response_target.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/takeover_open_response_target.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="TakeoverOpenResponseTarget")
+
+
+@_attrs_define
+class TakeoverOpenResponseTarget:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        takeover_open_response_target = cls()
+
+        takeover_open_response_target.additional_properties = d
+        return takeover_open_response_target
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -23,6 +23,7 @@ from aios.api.routers import (
     accounts,
     admin,
     agents,
+    browser,
     connections,
     connectors,
     environments,
@@ -197,6 +198,7 @@ def create_app() -> FastAPI:
     app.include_router(admin.router)
     app.include_router(environments.router)
     app.include_router(agents.router)
+    app.include_router(browser.router)
     app.include_router(sessions.router)
     app.include_router(skills.router)
     app.include_router(vaults.router)

--- a/src/aios/api/routers/browser.py
+++ b/src/aios/api/routers/browser.py
@@ -32,11 +32,13 @@ from aios.api.sse import make_sse_response
 from aios.config import get_settings
 from aios.db import queries
 from aios.errors import (
+    AiosError,
     ConflictError,
     NotFoundError,
     PayloadTooLargeError,
     ServiceUnavailableError,
 )
+from aios.ids import BROWSER_GRANT, make_id
 from aios.logging import get_logger
 from aios.models.browser import (
     BrowserStatusResponse,
@@ -72,9 +74,11 @@ async def _call(
 ) -> dict[str, Any]:
     """Submit a control op and translate its error currency to HTTP.
 
-    ``browser_unavailable`` → 503, ``takeover_in_progress`` → 409, everything
-    else the executor reported as an error → 409 (an op-level refusal the
-    caller can act on). A raw success result passes through.
+    ``browser_unavailable``/``browser_unconfigured`` → 503; ``internal`` (the
+    executor's generic backstop — a deterministic worker-side bug) → 500;
+    everything else the executor reported as an error → 409 (an op-level refusal
+    the caller can act on: ``takeover_in_progress``, ``unknown_grant``, a driver
+    error code, ...). A raw success result passes through.
     """
     result, is_error = await submit_browser_call(
         db_url,
@@ -89,6 +93,10 @@ async def _call(
         message = (result or {}).get("message", "browser control op failed")
         if code in ("browser_unavailable", "browser_unconfigured"):
             raise ServiceUnavailableError(message, detail={"code": code})
+        if code == "internal":
+            # A worker-side fault, not a caller-actionable refusal — 500, not a
+            # 409 that reads as "your request conflicts with state".
+            raise AiosError(message, detail={"code": code})
         raise ConflictError(message, detail={"code": code})
     return result or {}
 
@@ -115,12 +123,17 @@ async def open_takeover(
     """
     # Scope-check the requesting session before opening anything.
     await sessions_service.get_session_basic(pool, body.session_id, account_id=account_id)
+    # Mint the grant_id HERE, caller-side, and thread it through: the executor
+    # reads it fail-hard, so a lost-NOTIFY redrive re-presents the SAME id and
+    # the driver's per-grant-id idempotency collapses the retry rather than
+    # opening a second, orphaned takeover.
+    grant_id = make_id(BROWSER_GRANT)
     result = await _call(
         db_url,
         pool,
         account_id,
         "open",
-        {"session_id": body.session_id, "reason": body.reason},
+        {"session_id": body.session_id, "reason": body.reason, "grant_id": grant_id},
     )
     return TakeoverOpenResponse(**result)
 
@@ -188,15 +201,28 @@ async def post_input(
 
     cap = get_settings().sandbox_browser_input_spool_max_bytes
     existing = spool.stat().st_size if spool.exists() else 0
+    # Soft cap: the check-then-write is per-request, so N concurrent posts can
+    # each pass here and overshoot by up to (N-1) lines. That is bounded (one
+    # viewer per grant is the norm; a line is a few hundred bytes) and the
+    # reaper truncates the spool once the grant closes — a hard atomic cap isn't
+    # worth an flock on the hot input path.
     if existing + len(line) > cap:
         raise PayloadTooLargeError(
             "input spool is full", detail={"cap_bytes": cap, "size_bytes": existing}
         )
-    # O_APPEND + a single write: concurrent posts interleave whole lines,
-    # never partial ones.
+    # O_APPEND makes each write atomic against concurrent appenders (the kernel
+    # holds the inode offset lock), so lines never interleave — but os.write can
+    # still return a SHORT count, which would leave a truncated, unparseable
+    # JSONL line. Loop until the whole line lands, and fail hard if it can't.
     fd = os.open(spool, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
     try:
-        os.write(fd, line)
+        view = memoryview(line)
+        written = 0
+        while written < len(view):
+            n = os.write(fd, view[written:])
+            if n <= 0:
+                raise OSError("short write to input spool")
+            written += n
     finally:
         os.close(fd)
     return Response(status_code=204)
@@ -218,8 +244,16 @@ async def stream_frames(
     derived server-side from the scoped grant's account — the client supplies
     only ``grant_id`` — so path containment holds by construction.
     """
-    await _require_grant(pool, grant_id, account_id)  # scope + 404 gate
+    grant = await _require_grant(pool, grant_id, account_id)  # scope + 404 gate
+    if grant["status"] != "open":
+        # Don't open a screencast on an already-terminal grant — mirror
+        # post_input rather than stream one stale frame before the recheck ends
+        # it.
+        raise ConflictError(
+            f"takeover grant {grant_id} is not open", detail={"status": grant["status"]}
+        )
     plane = browser_plane_dir(account_id)
+    plane_root = plane.resolve()
     frames_dir = plane / "frames"
     if not plane.exists():
         # The plane dir is created at provision; its absence while a grant is
@@ -231,37 +265,61 @@ async def stream_frames(
 
     async def _frames() -> Any:
         last_seq = -1
+        last_boot: str | None = None
         last_grant_check = 0.0
-        try:
-            while True:
-                manifest = _read_manifest(frames_dir)
-                if manifest is not None and manifest.get("seq", -1) > last_seq:
-                    frame = _load_frame(frames_dir, manifest, account_id)
+        while True:
+            manifest = _read_manifest(frames_dir, plane_root, account_id)
+            if manifest is not None:
+                boot = manifest.get("boot")
+                if last_boot is not None and boot != last_boot:
+                    # The driver rebooted mid-takeover (frame seq resets to a low
+                    # value, so a seq-only test would freeze the screencast
+                    # forever). End the stream — the viewer pins boot and must
+                    # re-attach against the new one.
+                    yield ServerSentEvent(
+                        data=json.dumps({"outcome": "browser_restarted"}), event="end"
+                    )
+                    return
+                if manifest["seq"] > last_seq:
+                    frame = _load_frame(frames_dir, manifest, plane_root, account_id)
                     if frame is not None:
                         last_seq = manifest["seq"]
+                        last_boot = boot
                         yield ServerSentEvent(data=json.dumps(frame), event="frame")
 
-                now = time.monotonic()
-                if now - last_grant_check >= _GRANT_RECHECK_SECONDS:
-                    last_grant_check = now
-                    async with pool.acquire() as conn:
-                        fresh = await queries.get_browser_grant(
-                            conn, grant_id, account_id=account_id
-                        )
-                    if fresh is None or fresh["status"] != "open":
-                        outcome = (fresh or {}).get("outcome") or "closed"
-                        yield ServerSentEvent(data=json.dumps({"outcome": outcome}), event="end")
-                        return
-                await asyncio.sleep(_FRAME_POLL_SECONDS)
-        finally:
-            pass
+            now = time.monotonic()
+            if now - last_grant_check >= _GRANT_RECHECK_SECONDS:
+                last_grant_check = now
+                async with pool.acquire() as conn:
+                    fresh = await queries.get_browser_grant(conn, grant_id, account_id=account_id)
+                if fresh is None or fresh["status"] != "open":
+                    outcome = (fresh or {}).get("outcome") or "closed"
+                    yield ServerSentEvent(data=json.dumps({"outcome": outcome}), event="end")
+                    return
+            await asyncio.sleep(_FRAME_POLL_SECONDS)
 
     # No LISTEN subscription — a no-op terminate satisfies make_sse_response's
     # un-invoked-generator cleanup (the poll loop owns no external resource).
     return make_sse_response(lambda: None, _frames())
 
 
-def _read_manifest(frames_dir: Path) -> dict[str, Any] | None:
+def _frames_dir_in_plane(frames_dir: Path, plane_root: Path, account_id: str) -> Path | None:
+    """Resolve ``frames_dir`` and confirm it is still inside the account's plane
+    ROOT (the bind-mount SOURCE, which a compromised container cannot symlink
+    away). Anchoring on the plane root — not on ``frames_dir`` itself — is what
+    defeats a hostile ``frames`` symlink pointing at ANOTHER account's plane:
+    resolving both sides of a self-referential symlink check would pass it.
+    Returns the resolved dir, or ``None`` if it escaped (logged)."""
+    resolved = frames_dir.resolve()
+    if not resolved.is_relative_to(plane_root):
+        log.warning("browser.frames_dir_escape", account_id=account_id, resolved=str(resolved))
+        return None
+    return resolved
+
+
+def _read_manifest(frames_dir: Path, plane_root: Path, account_id: str) -> dict[str, Any] | None:
+    if _frames_dir_in_plane(frames_dir, plane_root, account_id) is None:
+        return None
     manifest_path = frames_dir / "manifest.json"
     try:
         raw = manifest_path.read_bytes()
@@ -271,24 +329,36 @@ def _read_manifest(frames_dir: Path) -> dict[str, Any] | None:
         data = json.loads(raw)
     except ValueError:
         return None
-    return data if isinstance(data, dict) else None
+    if not isinstance(data, dict):
+        return None
+    # ``seq`` drives a ``> last_seq`` comparison against an int; a manifest with
+    # a null/placeholder or non-int seq is "no frame yet", not a TypeError that
+    # tears down the stream.
+    if not isinstance(data.get("seq"), int) or isinstance(data.get("seq"), bool):
+        return None
+    return data
 
 
 def _load_frame(
-    frames_dir: Path, manifest: dict[str, Any], account_id: str
+    frames_dir: Path, manifest: dict[str, Any], plane_root: Path, account_id: str
 ) -> dict[str, Any] | None:
     """Build a frame SSE payload from the manifest, or ``None`` if unreadable.
 
     Forwards the §5.6 trusted-chrome envelope (minus the account, which never
-    crosses to the client) with the JPEG inlined. The manifest's ``file`` is
-    containment-checked against the frames dir — a hostile manifest cannot
-    read outside the plane.
+    crosses to the client) with the JPEG inlined. Containment is TWO checks,
+    both anchored so a compromised container cannot exfiltrate cross-tenant:
+    the frames dir must resolve inside the account's plane root (blocks a
+    symlinked ``frames`` -> another account's plane), and the manifest ``file``
+    must resolve inside that frames dir (blocks a ``../`` file ref).
     """
+    resolved_frames = _frames_dir_in_plane(frames_dir, plane_root, account_id)
+    if resolved_frames is None:
+        return None
     file_ref = manifest.get("file")
     if not isinstance(file_ref, str):
         return None
     frame_path = (frames_dir / file_ref).resolve()
-    if not frame_path.is_relative_to(frames_dir.resolve()):
+    if not frame_path.is_relative_to(resolved_frames):
         log.warning("browser.frame_path_escape", account_id=account_id, file=file_ref)
         return None
     try:
@@ -401,6 +471,10 @@ async def clear_state(
     ``browser_state_lost`` model notice."""
     params: dict[str, Any] = {}
     if session_id:
+        # Scope-check the notice recipient, mirroring open_takeover — the worker
+        # append is account-scoped too, but the API should not accept a
+        # cross-tenant session id here either.
+        await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
         params["session_id"] = session_id
     await _call(db_url, pool, account_id, "clear_state", params)
     return Response(status_code=204)

--- a/src/aios/api/routers/browser.py
+++ b/src/aios/api/routers/browser.py
@@ -1,0 +1,406 @@
+"""The product-facing browser takeover surface (jarbot#106 §5.7).
+
+jarbot (or any operator client) drives a human takeover of an account's
+shared computer through these routes: open a grant, stream frames, post the
+human's input, heartbeat while the viewer is attached, close with a handback.
+Plus the account-computer operations: status, per-site sign-out, clear-state.
+
+Trust boundary: every grant-scoped route resolves the grant with the
+standard account-scoped query FIRST (cross-tenant ids surface as 404) —
+before any listener, stream, or filesystem access. The control ops ride the
+worker-consumed RPC (:func:`aios.services.browser_calls.submit_browser_call`);
+the frame stream tails the shared-filesystem ring and the input POST appends
+to the shared-filesystem spool, so neither touches the worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Response
+from sse_starlette import EventSourceResponse, ServerSentEvent
+
+from aios.api.deps import AccountIdDep, DbUrlDep, PoolDep
+from aios.api.sse import make_sse_response
+from aios.config import get_settings
+from aios.db import queries
+from aios.errors import (
+    ConflictError,
+    NotFoundError,
+    PayloadTooLargeError,
+    ServiceUnavailableError,
+)
+from aios.logging import get_logger
+from aios.models.browser import (
+    BrowserStatusResponse,
+    BrowserTakeoverStatus,
+    HandbackPayload,
+    InputBatch,
+    TakeoverCloseRequest,
+    TakeoverCloseResponse,
+    TakeoverOpenRequest,
+    TakeoverOpenResponse,
+)
+from aios.sandbox.volumes import browser_plane_dir
+from aios.services import sessions as sessions_service
+from aios.services.browser_calls import submit_browser_call
+
+router = APIRouter(prefix="/v1/browser", tags=["browser"])
+log = get_logger("aios.api.browser")
+
+_FRAME_POLL_SECONDS = 0.2
+_GRANT_RECHECK_SECONDS = 2.0
+
+
+def _control_timeout() -> float:
+    return float(get_settings().sandbox_browser_call_timeout_seconds)
+
+
+async def _call(
+    db_url: str,
+    pool: Any,
+    account_id: str,
+    method: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Submit a control op and translate its error currency to HTTP.
+
+    ``browser_unavailable`` → 503, ``takeover_in_progress`` → 409, everything
+    else the executor reported as an error → 409 (an op-level refusal the
+    caller can act on). A raw success result passes through.
+    """
+    result, is_error = await submit_browser_call(
+        db_url,
+        pool,
+        account_id=account_id,
+        method=method,
+        params=params,
+        timeout_s=_control_timeout(),
+    )
+    if is_error:
+        code = (result or {}).get("code", "internal")
+        message = (result or {}).get("message", "browser control op failed")
+        if code in ("browser_unavailable", "browser_unconfigured"):
+            raise ServiceUnavailableError(message, detail={"code": code})
+        raise ConflictError(message, detail={"code": code})
+    return result or {}
+
+
+async def _require_grant(pool: Any, grant_id: str, account_id: str) -> dict[str, Any]:
+    async with pool.acquire() as conn:
+        grant = await queries.get_browser_grant(conn, grant_id, account_id=account_id)
+    if grant is None:
+        raise NotFoundError(f"takeover grant {grant_id} not found", detail={"id": grant_id})
+    return grant
+
+
+@router.post("/takeover")
+async def open_takeover(
+    body: TakeoverOpenRequest,
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> TakeoverOpenResponse:
+    """Open a takeover of the account's computer for one session's page.
+
+    409 if a takeover is already in progress (the one-open-per-account
+    invariant); 503 if the computer is unavailable.
+    """
+    # Scope-check the requesting session before opening anything.
+    await sessions_service.get_session_basic(pool, body.session_id, account_id=account_id)
+    result = await _call(
+        db_url,
+        pool,
+        account_id,
+        "open",
+        {"session_id": body.session_id, "reason": body.reason},
+    )
+    return TakeoverOpenResponse(**result)
+
+
+@router.post("/takeover/{grant_id}/heartbeat", status_code=204)
+async def heartbeat_takeover(
+    grant_id: str,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> Response:
+    """Bump the grant's heartbeat — the viewer calls this while it holds the
+    frame stream. 404 if unknown, 409 if the grant is no longer open."""
+    async with pool.acquire() as conn:
+        ok = await queries.touch_browser_grant_heartbeat(conn, grant_id, account_id=account_id)
+        if not ok:
+            grant = await queries.get_browser_grant(conn, grant_id, account_id=account_id)
+    if not ok:
+        if grant is None:
+            raise NotFoundError(f"takeover grant {grant_id} not found", detail={"id": grant_id})
+        raise ConflictError(
+            f"takeover grant {grant_id} is not open", detail={"status": grant["status"]}
+        )
+    return Response(status_code=204)
+
+
+@router.post("/takeover/{grant_id}/input", status_code=204)
+async def post_input(
+    grant_id: str,
+    body: InputBatch,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> Response:
+    """Append one epoch-stamped input batch to the shared-filesystem spool.
+
+    No worker involvement. The check-then-append race (grant closes between
+    the epoch check and the write) is harmless — the driver drops stale-epoch
+    lines, being the enforcement authority. 409 on a closed grant or stale
+    epoch; 413 when the spool would exceed its byte cap.
+    """
+    grant = await _require_grant(pool, grant_id, account_id)
+    if grant["status"] != "open":
+        raise ConflictError(
+            f"takeover grant {grant_id} is not open", detail={"status": grant["status"]}
+        )
+    if body.epoch != grant["epoch"]:
+        raise ConflictError(
+            "input epoch does not match the open grant",
+            detail={"code": "stale_epoch", "expected": grant["epoch"], "got": body.epoch},
+        )
+
+    plane = browser_plane_dir(account_id)
+    spool = plane / "input" / "spool.jsonl"
+    line = (
+        json.dumps(
+            {
+                "grant_id": grant_id,
+                "epoch": body.epoch,
+                "seq": body.seq,
+                "ts_ms": int(time.time() * 1000),
+                "events": [e.model_dump(exclude_none=True) for e in body.events],
+            }
+        )
+        + "\n"
+    ).encode("utf-8")
+
+    cap = get_settings().sandbox_browser_input_spool_max_bytes
+    existing = spool.stat().st_size if spool.exists() else 0
+    if existing + len(line) > cap:
+        raise PayloadTooLargeError(
+            "input spool is full", detail={"cap_bytes": cap, "size_bytes": existing}
+        )
+    # O_APPEND + a single write: concurrent posts interleave whole lines,
+    # never partial ones.
+    fd = os.open(spool, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    try:
+        os.write(fd, line)
+    finally:
+        os.close(fd)
+    return Response(status_code=204)
+
+
+@router.get(
+    "/takeover/{grant_id}/frames",
+    openapi_extra={"x-codegen": {"targets": []}},
+)
+async def stream_frames(
+    grant_id: str,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> EventSourceResponse:
+    """Stream the takeover screencast as SSE ``frame`` events, ending on close.
+
+    Novel among aios SSE routes: it tails a shared-filesystem ring, not a
+    LISTEN channel (the driver has no route to Postgres). The frames dir is
+    derived server-side from the scoped grant's account — the client supplies
+    only ``grant_id`` — so path containment holds by construction.
+    """
+    await _require_grant(pool, grant_id, account_id)  # scope + 404 gate
+    plane = browser_plane_dir(account_id)
+    frames_dir = plane / "frames"
+    if not plane.exists():
+        # The plane dir is created at provision; its absence while a grant is
+        # open is a deployment/mount fault, not a quiet driver — surface it
+        # loudly rather than streaming silence forever.
+        raise ServiceUnavailableError(
+            "browser plane directory is missing", detail={"grant_id": grant_id}
+        )
+
+    async def _frames() -> Any:
+        last_seq = -1
+        last_grant_check = 0.0
+        try:
+            while True:
+                manifest = _read_manifest(frames_dir)
+                if manifest is not None and manifest.get("seq", -1) > last_seq:
+                    frame = _load_frame(frames_dir, manifest, account_id)
+                    if frame is not None:
+                        last_seq = manifest["seq"]
+                        yield ServerSentEvent(data=json.dumps(frame), event="frame")
+
+                now = time.monotonic()
+                if now - last_grant_check >= _GRANT_RECHECK_SECONDS:
+                    last_grant_check = now
+                    async with pool.acquire() as conn:
+                        fresh = await queries.get_browser_grant(
+                            conn, grant_id, account_id=account_id
+                        )
+                    if fresh is None or fresh["status"] != "open":
+                        outcome = (fresh or {}).get("outcome") or "closed"
+                        yield ServerSentEvent(data=json.dumps({"outcome": outcome}), event="end")
+                        return
+                await asyncio.sleep(_FRAME_POLL_SECONDS)
+        finally:
+            pass
+
+    # No LISTEN subscription — a no-op terminate satisfies make_sse_response's
+    # un-invoked-generator cleanup (the poll loop owns no external resource).
+    return make_sse_response(lambda: None, _frames())
+
+
+def _read_manifest(frames_dir: Path) -> dict[str, Any] | None:
+    manifest_path = frames_dir / "manifest.json"
+    try:
+        raw = manifest_path.read_bytes()
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _load_frame(
+    frames_dir: Path, manifest: dict[str, Any], account_id: str
+) -> dict[str, Any] | None:
+    """Build a frame SSE payload from the manifest, or ``None`` if unreadable.
+
+    Forwards the §5.6 trusted-chrome envelope (minus the account, which never
+    crosses to the client) with the JPEG inlined. The manifest's ``file`` is
+    containment-checked against the frames dir — a hostile manifest cannot
+    read outside the plane.
+    """
+    file_ref = manifest.get("file")
+    if not isinstance(file_ref, str):
+        return None
+    frame_path = (frames_dir / file_ref).resolve()
+    if not frame_path.is_relative_to(frames_dir.resolve()):
+        log.warning("browser.frame_path_escape", account_id=account_id, file=file_ref)
+        return None
+    try:
+        jpeg = frame_path.read_bytes()
+    except OSError:
+        return None
+    return {
+        "seq": manifest.get("seq"),
+        "ts_ms": manifest.get("ts_ms"),
+        "epoch": manifest.get("epoch"),
+        "boot": manifest.get("boot"),
+        "origin": manifest.get("origin"),
+        "security": manifest.get("security"),
+        "w": manifest.get("w"),
+        "h": manifest.get("h"),
+        "jpeg_b64": base64.b64encode(jpeg).decode("ascii"),
+    }
+
+
+@router.delete("/takeover/{grant_id}")
+async def close_takeover(
+    grant_id: str,
+    body: TakeoverCloseRequest,
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> TakeoverCloseResponse:
+    """Close a takeover; return the handback (post-human snapshot + inlined
+    screenshot + signed-in delta). A browser-dead close still closes → null
+    handback fields."""
+    await _require_grant(pool, grant_id, account_id)
+    result = await _call(
+        db_url, pool, account_id, "close", {"grant_id": grant_id, "outcome": body.outcome}
+    )
+    handback = _handback_payload(result.get("handback"), account_id)
+    return TakeoverCloseResponse(handback=handback)
+
+
+def _handback_payload(raw: dict[str, Any] | None, account_id: str) -> HandbackPayload:
+    if not raw:
+        return HandbackPayload()
+    screenshot_data_url = None
+    shot_path = raw.get("shot_path")
+    if isinstance(shot_path, str):
+        plane = browser_plane_dir(account_id)
+        resolved = (plane / shot_path).resolve()
+        if resolved.is_relative_to(plane.resolve()):
+            with contextlib.suppress(OSError):
+                screenshot_data_url = "data:image/png;base64," + base64.b64encode(
+                    resolved.read_bytes()
+                ).decode("ascii")
+    return HandbackPayload(
+        snapshot=raw.get("snapshot"),
+        screenshot_data_url=screenshot_data_url,
+        signed_in_hosts=raw.get("signed_in_hosts") or [],
+        url=raw.get("url"),
+    )
+
+
+@router.get("/status")
+async def browser_status(
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> BrowserStatusResponse:
+    """The account computer's state — never provisions it."""
+    result = await _call(db_url, pool, account_id, "status", {})
+    async with pool.acquire() as conn:
+        open_grant = await queries.get_open_browser_grant_for_account(conn, account_id)
+    takeover = None
+    if open_grant is not None:
+        takeover = BrowserTakeoverStatus(
+            grant_id=open_grant["id"],
+            session_id=open_grant["session_id"],
+            reason=open_grant["reason"],
+            epoch=open_grant["epoch"],
+            boot=open_grant["boot"],
+            created_at=open_grant["created_at"].isoformat(),
+        )
+    return BrowserStatusResponse(
+        running=bool(result.get("running")),
+        url=result.get("url"),
+        title=result.get("title"),
+        signed_in_hosts=result.get("signed_in_hosts") or [],
+        takeover=takeover,
+    )
+
+
+@router.delete("/sites/{host}", status_code=204)
+async def revoke_site(
+    host: str,
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> Response:
+    """Delete one host's cookies + storage from the account's profile."""
+    await _call(db_url, pool, account_id, "revoke_site", {"host": host})
+    return Response(status_code=204)
+
+
+@router.post("/clear", status_code=204)
+async def clear_state(
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    session_id: str | None = None,
+) -> Response:
+    """Clear the account computer's state (profile, downloads, ...). 409 if a
+    takeover is open. ``session_id``, when given, receives the
+    ``browser_state_lost`` model notice."""
+    params: dict[str, Any] = {}
+    if session_id:
+        params["session_id"] = session_id
+    await _call(db_url, pool, account_id, "clear_state", params)
+    return Response(status_code=204)

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -45,7 +45,7 @@ from aios.models.workflows import TERMINAL_RUN_STATUSES
 from aios.services import connections as connections_service
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable
+    from collections.abc import AsyncIterator, Awaitable, Callable
 
     import structlog
 
@@ -109,13 +109,18 @@ async def preflight_subscription(
 
 
 def make_sse_response(
-    subscription: ListenSubscription,
+    subscription: ListenSubscription | Callable[[], None],
     content: AsyncIterator[ServerSentEvent],
     *,
     ping: int = SSE_PING_SECONDS,
 ) -> EventSourceResponse:
-    """Build an ``EventSourceResponse`` whose ``ListenSubscription`` is
-    cleaned up even on paths that never iterate the wrapped generator.
+    """Build an ``EventSourceResponse`` whose cleanup fires even on paths
+    that never iterate the wrapped generator.
+
+    ``subscription`` is a :class:`ListenSubscription` for the LISTEN-backed
+    streams, or a bare terminate callable for streams with different
+    resources to release (the browser takeover frame stream polls the
+    shared filesystem and holds no LISTEN connection).
 
     Normal lifecycle: ``__call__`` runs, the generator iterates, its
     ``finally: subscription.terminate()`` fires on consumer disconnect
@@ -140,8 +145,9 @@ def make_sse_response(
     ``_state`` transition both tolerate repeated calls), so the second
     call is a no-op.
     """
+    terminate = subscription if callable(subscription) else subscription.terminate
     response = EventSourceResponse(content, ping=ping)
-    weakref.finalize(response, subscription.terminate)
+    weakref.finalize(response, terminate)
     return response
 
 

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -22,6 +22,34 @@ can tell "should never have a CLI" apart from "needs CLI, deferred."
 from __future__ import annotations
 
 NOT_CLI_OPERATIONS: dict[str, str] = {
+    # ── Browser takeover surface (jarbot#106) ────────────────────────
+    # The product layer (jarbot) drives human takeover of an account's
+    # shared computer through these routes — a live viewer with a frame
+    # stream and an input channel, not an operator CLI workflow.
+    "open_takeover_v1_browser_takeover_post": (
+        "Product-layer takeover control, driven by the app's viewer, not operators."
+    ),
+    "heartbeat_takeover_v1_browser_takeover__grant_id__heartbeat_post": (
+        "Product-layer takeover control, driven by the app's viewer, not operators."
+    ),
+    "post_input_v1_browser_takeover__grant_id__input_post": (
+        "Human input for a live takeover, posted by the app's viewer, not operators."
+    ),
+    "stream_frames_v1_browser_takeover__grant_id__frames_get": (
+        "SSE screencast consumed by the app's takeover viewer, not operators."
+    ),
+    "close_takeover_v1_browser_takeover__grant_id__delete": (
+        "Product-layer takeover control, driven by the app's viewer, not operators."
+    ),
+    "browser_status_v1_browser_status_get": (
+        "Product-layer computer-status read, surfaced in the app, not operators."
+    ),
+    "revoke_site_v1_browser_sites__host__delete": (
+        "Product-layer sign-out control, surfaced in the app, not operators."
+    ),
+    "clear_state_v1_browser_clear_post": (
+        "Product-layer clear-computer control, surfaced in the app, not operators."
+    ),
     # ── Server-sent event streams ────────────────────────────────────
     # Long-lived SSE streams. The CLI exposes session events via
     # `aios sessions stream` (which wraps the SDK's stream_session helper);

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -434,11 +434,14 @@ class Settings(BaseSettings):
         "this are deleted by the browser reaper.",
     )
     sandbox_browser_call_timeout_seconds: float = Field(
-        default=60.0,
+        default=210.0,
         gt=0,
         description="How long a browser control-plane API request blocks for the "
-        "worker to resolve its call before returning 504. Comfortably above the "
-        "takeover-open drain budget so a legitimately slow open still lands.",
+        "worker to resolve its call before returning 504. Must cover a COLD open: "
+        "the browser provision (sandbox_browser_provision_timeout_seconds, 120s) "
+        "PLUS the takeover-open drain (sandbox_browser_takeover_open_timeout_seconds, "
+        "45s) plus margin — otherwise every cold open 504s the caller while the "
+        "worker completes it, leaving a viewerless grant.",
     )
     sandbox_browser_input_spool_max_bytes: int = Field(
         default=64 * 1024**2,

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -433,6 +433,19 @@ class Settings(BaseSettings):
         description="Resolved/expired browser control-plane call rows older than "
         "this are deleted by the browser reaper.",
     )
+    sandbox_browser_call_timeout_seconds: float = Field(
+        default=60.0,
+        gt=0,
+        description="How long a browser control-plane API request blocks for the "
+        "worker to resolve its call before returning 504. Comfortably above the "
+        "takeover-open drain budget so a legitimately slow open still lands.",
+    )
+    sandbox_browser_input_spool_max_bytes: int = Field(
+        default=64 * 1024**2,
+        ge=1024**2,
+        description="Byte cap on a takeover input spool; a POST that would exceed "
+        "it returns 413. The reaper truncates the spool once no grant is open.",
+    )
     sandbox_browser_reaper_enabled: bool = Field(
         default=True,
         description="Kill-switch for the browser plane reaper (grant TTL expiry, "

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -114,6 +114,18 @@ class RateLimitedError(AiosError):
     status_code = 429
 
 
+class ServiceUnavailableError(AiosError):
+    """A dependency needed to serve the request is temporarily unavailable.
+
+    Distinct from :class:`SSEPreflightFailedError` (also 503, but specifically
+    about opening a LISTEN connection): the browser routes raise this when the
+    account's computer failed to start or is not responding.
+    """
+
+    error_type = "service_unavailable"
+    status_code = 503
+
+
 class CryptoDecryptError(AiosError):
     """Raised when the CryptoBox cannot decrypt a stored ciphertext.
 

--- a/src/aios/models/browser.py
+++ b/src/aios/models/browser.py
@@ -1,0 +1,103 @@
+"""API models for the browser takeover surface (jarbot#106 §5.7).
+
+The product layer's view of a takeover: open/heartbeat/input/close on one
+grant, plus the account-computer status/revocation operations. Input events
+use the wire vocabulary pinned in
+:mod:`aios.sandbox.browser_protocol` (``INPUT_EVENT_TYPES``) — raw
+pointer/key/text events, deliberately lower-level than the ``browser_*``
+tool arms, since they carry a human's live driving.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class TakeoverOpenRequest(BaseModel):
+    """Open a takeover of the account's computer for one agent session's page."""
+
+    session_id: str
+    reason: str = Field(default="", max_length=200)
+
+
+class TakeoverOpenResponse(BaseModel):
+    """The opened grant. The viewer PINS ``target``/``boot``/``epoch`` and
+    refuses frames or input that do not match (the trusted-chrome binding,
+    jarbot#106 §5.6)."""
+
+    grant_id: str
+    target: dict[str, Any]
+    boot: str
+    epoch: int
+    ttl_seconds: int
+
+
+class TakeoverCloseRequest(BaseModel):
+    outcome: Literal["done", "cancelled"] = "done"
+
+
+class HandbackPayload(BaseModel):
+    """What the human left behind: the post-takeover page snapshot, an inline
+    screenshot, and which sites are now signed in (the cookie-jar-derived
+    delta). ``None`` fields mean the browser died before the handback could
+    be captured — the grant still closed."""
+
+    snapshot: str | None = None
+    screenshot_data_url: str | None = None
+    signed_in_hosts: list[str] = Field(default_factory=list)
+    url: str | None = None
+
+
+class TakeoverCloseResponse(BaseModel):
+    handback: HandbackPayload
+
+
+class InputEvent(BaseModel):
+    """One raw viewer input event (§5.6 vocabulary)."""
+
+    type: Literal[
+        "pointer_move", "pointer_down", "pointer_up", "wheel", "key_down", "key_up", "text"
+    ]
+    x: float | None = None
+    y: float | None = None
+    button: Literal["left", "middle", "right"] | None = None
+    dx: float | None = None
+    dy: float | None = None
+    key: str | None = Field(default=None, max_length=64)
+    text: str | None = Field(default=None, max_length=2000)
+
+
+class InputBatch(BaseModel):
+    """One coalesced batch of input events, epoch-stamped.
+
+    The API pre-checks the epoch against the grant record; the DRIVER is the
+    enforcement authority and drops stale-epoch spool lines regardless.
+    """
+
+    epoch: int
+    seq: int
+    events: list[InputEvent] = Field(min_length=1, max_length=200)
+
+
+class BrowserTakeoverStatus(BaseModel):
+    """The open grant on this account's computer, if any."""
+
+    grant_id: str
+    session_id: str
+    reason: str
+    epoch: int
+    boot: str
+    created_at: str
+
+
+class BrowserStatusResponse(BaseModel):
+    """The account computer's state: not running, or running with its page
+    and any open takeover + signed-in sites the driver reports."""
+
+    running: bool
+    url: str | None = None
+    title: str | None = None
+    signed_in_hosts: list[str] = Field(default_factory=list)
+    takeover: BrowserTakeoverStatus | None = None

--- a/tests/unit/test_browser_routes.py
+++ b/tests/unit/test_browser_routes.py
@@ -90,6 +90,15 @@ class TestTrustBoundary:
         resp = client.get("/v1/browser/takeover/bgr_missing/frames")
         assert resp.status_code == 404
 
+    def test_frames_on_closed_grant_is_409_not_a_stale_stream(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A screencast must not open on an already-terminal grant (it would
+        emit one stale frame before the recheck ends it) — reject at open."""
+        _stub_conn(monkeypatch, get_browser_grant={**_OTHER_GRANT, "status": "closed"})
+        resp = client.get("/v1/browser/takeover/bgr_1/frames")
+        assert resp.status_code == 409
+
 
 class TestInput:
     def test_stale_epoch_is_409(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -202,6 +211,23 @@ class TestControlErrorCurrency:
         resp = client.post("/v1/browser/takeover", json={"session_id": "sess_1"})
         assert resp.status_code == 503
 
+    def test_internal_error_is_500_not_409(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The executor's generic ``internal`` backstop is a worker-side bug —
+        it must surface as 500, not a 409 that reads as a caller-actionable
+        conflict."""
+        monkeypatch.setattr(
+            browser_router,
+            "submit_browser_call",
+            AsyncMock(return_value=({"code": "internal", "message": "boom"}, True)),
+        )
+        monkeypatch.setattr(
+            sessions_service, "get_session_basic", AsyncMock(return_value=MagicMock())
+        )
+        resp = client.post("/v1/browser/takeover", json={"session_id": "sess_1"})
+        assert resp.status_code == 500
+
     def test_open_success_returns_the_grant(
         self, client: TestClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -237,7 +263,27 @@ class TestFrameLoading:
         frames.mkdir()
         (tmp_path / "secret.jpg").write_bytes(b"nope")
         manifest = {"seq": 1, "file": "../secret.jpg"}
-        assert browser_router._load_frame(frames, manifest, _ACCOUNT) is None
+        assert browser_router._load_frame(frames, manifest, tmp_path.resolve(), _ACCOUNT) is None
+
+    def test_symlinked_frames_dir_to_another_plane_is_refused(self, tmp_path: Path) -> None:
+        """CRITICAL: a compromised container swaps its OWN frames dir for a
+        symlink to ANOTHER account's plane. Anchoring containment on the plane
+        ROOT (not on the symlinked frames dir, which resolves self-consistently)
+        is what blocks the cross-tenant live-screen read."""
+        victim_frames = tmp_path / "acc_VICTIM" / "frames"
+        victim_frames.mkdir(parents=True)
+        (victim_frames / "0.jpg").write_bytes(b"\xff\xd8victim-screen")
+        (victim_frames / "manifest.json").write_text(json.dumps({"seq": 1, "file": "0.jpg"}))
+        attacker_plane = tmp_path / "acc_ATTACKER"
+        attacker_plane.mkdir()
+        (attacker_plane / "frames").symlink_to(victim_frames)  # escape the plane
+
+        frames_dir = attacker_plane / "frames"
+        plane_root = attacker_plane.resolve()
+        # Neither the manifest read nor the frame load may cross to the victim.
+        assert browser_router._read_manifest(frames_dir, plane_root, _ACCOUNT) is None
+        manifest = {"seq": 1, "file": "0.jpg"}
+        assert browser_router._load_frame(frames_dir, manifest, plane_root, _ACCOUNT) is None
 
     def test_valid_manifest_forwards_the_trusted_chrome_envelope(self, tmp_path: Path) -> None:
         frames = tmp_path / "frames"
@@ -254,7 +300,7 @@ class TestFrameLoading:
             "w": 1280,
             "h": 800,
         }
-        frame = browser_router._load_frame(frames, manifest, _ACCOUNT)
+        frame = browser_router._load_frame(frames, manifest, tmp_path.resolve(), _ACCOUNT)
         assert frame is not None
         assert frame["origin"] == "https://accounts.example.com"
         assert frame["security"] == "secure"
@@ -265,4 +311,14 @@ class TestFrameLoading:
         assert frame["jpeg_b64"] == base64.b64encode(b"\xff\xd8jpeg").decode()
 
     def test_absent_manifest_reads_as_none(self, tmp_path: Path) -> None:
-        assert browser_router._read_manifest(tmp_path / "frames") is None
+        assert (
+            browser_router._read_manifest(tmp_path / "frames", tmp_path.resolve(), _ACCOUNT) is None
+        )
+
+    def test_non_int_seq_reads_as_no_frame(self, tmp_path: Path) -> None:
+        """A manifest present but with a null/placeholder seq is 'no frame yet',
+        not a TypeError that tears down the SSE stream."""
+        frames = tmp_path / "frames"
+        frames.mkdir()
+        (frames / "manifest.json").write_text(json.dumps({"seq": None, "file": "0.jpg"}))
+        assert browser_router._read_manifest(frames, tmp_path.resolve(), _ACCOUNT) is None

--- a/tests/unit/test_browser_routes.py
+++ b/tests/unit/test_browser_routes.py
@@ -1,0 +1,268 @@
+"""Route-level coverage for the browser takeover API (jarbot#106 §5.7).
+
+TestClient + dependency overrides (the ``test_sse_preflight`` pattern), with
+``submit_browser_call`` and the query layer stubbed: the trust boundary
+(scoped grant read → 404 before any stream/file access), the input epoch and
+spool-cap gates, heartbeat rowcount 404/409, the error-currency → HTTP map,
+and the frames-manifest containment + poll behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aios.api.deps import get_account_id, get_db_url, get_pool
+from aios.api.routers import browser as browser_router
+from aios.config import get_settings
+from aios.db import queries as queries_module
+from aios.errors import install_exception_handlers
+from aios.services import sessions as sessions_service
+
+_ACCOUNT = "acc_01ROUTETEST0000000000000000"
+_OTHER_GRANT = {
+    "id": "bgr_1",
+    "account_id": _ACCOUNT,
+    "session_id": "sess_1",
+    "status": "open",
+    "reason": "auth",
+    "boot": "01BOOT",
+    "epoch": 5,
+    "target": {"url": "https://x.example"},
+}
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(browser_router.router)
+
+    async def _pool() -> Any:
+        return MagicMock()
+
+    async def _db_url() -> str:
+        return "postgresql://stub/aios"
+
+    async def _account() -> str:
+        return _ACCOUNT
+
+    app.dependency_overrides[get_pool] = _pool
+    app.dependency_overrides[get_db_url] = _db_url
+    app.dependency_overrides[get_account_id] = _account
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(_build_app()) as c:
+        yield c
+
+
+def _stub_conn(monkeypatch: pytest.MonkeyPatch, **query_returns: Any) -> None:
+    """Patch queries.* the routes call, and give pool.acquire a stub conn."""
+    for name, value in query_returns.items():
+        monkeypatch.setattr(queries_module, name, AsyncMock(return_value=value), raising=False)
+
+
+class TestTrustBoundary:
+    def test_input_on_unknown_grant_404s_before_any_write(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_conn(monkeypatch, get_browser_grant=None)
+        resp = client.post(
+            "/v1/browser/takeover/bgr_missing/input",
+            json={"epoch": 5, "seq": 1, "events": [{"type": "pointer_move", "x": 1, "y": 2}]},
+        )
+        assert resp.status_code == 404
+        assert resp.json()["error"]["type"] == "not_found"
+
+    def test_frames_on_unknown_grant_404s_before_opening_the_stream(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_conn(monkeypatch, get_browser_grant=None)
+        resp = client.get("/v1/browser/takeover/bgr_missing/frames")
+        assert resp.status_code == 404
+
+
+class TestInput:
+    def test_stale_epoch_is_409(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_conn(monkeypatch, get_browser_grant=_OTHER_GRANT)
+        resp = client.post(
+            "/v1/browser/takeover/bgr_1/input",
+            json={"epoch": 4, "seq": 1, "events": [{"type": "pointer_move", "x": 1, "y": 2}]},
+        )
+        assert resp.status_code == 409
+        assert resp.json()["error"]["detail"]["code"] == "stale_epoch"
+
+    def test_closed_grant_is_409(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_conn(monkeypatch, get_browser_grant={**_OTHER_GRANT, "status": "closed"})
+        resp = client.post(
+            "/v1/browser/takeover/bgr_1/input",
+            json={"epoch": 5, "seq": 1, "events": [{"type": "pointer_move", "x": 1, "y": 2}]},
+        )
+        assert resp.status_code == 409
+
+    def test_accepted_input_appends_one_jsonl_line(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_conn(monkeypatch, get_browser_grant=_OTHER_GRANT)
+        monkeypatch.setattr(get_settings(), "workspace_root", tmp_path)
+        from aios.sandbox.volumes import ensure_browser_plane_dir
+
+        plane = ensure_browser_plane_dir(_ACCOUNT)
+
+        resp = client.post(
+            "/v1/browser/takeover/bgr_1/input",
+            json={"epoch": 5, "seq": 7, "events": [{"type": "text", "text": "hi"}]},
+        )
+        assert resp.status_code == 204
+        spool = plane / "input" / "spool.jsonl"
+        lines = spool.read_text().strip().splitlines()
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["grant_id"] == "bgr_1" and rec["epoch"] == 5 and rec["seq"] == 7
+        assert rec["events"] == [{"type": "text", "text": "hi"}]
+
+    def test_over_cap_spool_is_413(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_conn(monkeypatch, get_browser_grant=_OTHER_GRANT)
+        settings = get_settings()
+        monkeypatch.setattr(settings, "workspace_root", tmp_path)
+        monkeypatch.setattr(settings, "sandbox_browser_input_spool_max_bytes", 10)
+        from aios.sandbox.volumes import ensure_browser_plane_dir
+
+        ensure_browser_plane_dir(_ACCOUNT)
+        resp = client.post(
+            "/v1/browser/takeover/bgr_1/input",
+            json={"epoch": 5, "seq": 1, "events": [{"type": "text", "text": "x" * 100}]},
+        )
+        assert resp.status_code == 413
+
+
+class TestHeartbeat:
+    def test_unknown_grant_404(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_conn(monkeypatch, touch_browser_grant_heartbeat=False, get_browser_grant=None)
+        resp = client.post("/v1/browser/takeover/bgr_x/heartbeat")
+        assert resp.status_code == 404
+
+    def test_closed_grant_409(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_conn(
+            monkeypatch,
+            touch_browser_grant_heartbeat=False,
+            get_browser_grant={**_OTHER_GRANT, "status": "expired"},
+        )
+        resp = client.post("/v1/browser/takeover/bgr_1/heartbeat")
+        assert resp.status_code == 409
+
+    def test_open_grant_204(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_conn(monkeypatch, touch_browser_grant_heartbeat=True)
+        resp = client.post("/v1/browser/takeover/bgr_1/heartbeat")
+        assert resp.status_code == 204
+
+
+class TestControlErrorCurrency:
+    def test_takeover_in_progress_is_409(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            browser_router,
+            "submit_browser_call",
+            AsyncMock(return_value=({"code": "takeover_in_progress", "message": "busy"}, True)),
+        )
+        monkeypatch.setattr(
+            sessions_service,
+            "get_session_basic",
+            AsyncMock(return_value=MagicMock()),
+        )
+        resp = client.post("/v1/browser/takeover", json={"session_id": "sess_1", "reason": "auth"})
+        assert resp.status_code == 409
+        assert resp.json()["error"]["detail"]["code"] == "takeover_in_progress"
+
+    def test_browser_unavailable_is_503(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            browser_router,
+            "submit_browser_call",
+            AsyncMock(return_value=({"code": "browser_unavailable", "message": "down"}, True)),
+        )
+        monkeypatch.setattr(
+            sessions_service,
+            "get_session_basic",
+            AsyncMock(return_value=MagicMock()),
+        )
+        resp = client.post("/v1/browser/takeover", json={"session_id": "sess_1"})
+        assert resp.status_code == 503
+
+    def test_open_success_returns_the_grant(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            browser_router,
+            "submit_browser_call",
+            AsyncMock(
+                return_value=(
+                    {
+                        "grant_id": "bgr_new",
+                        "target": {"url": "https://x"},
+                        "boot": "01B",
+                        "epoch": 9,
+                        "ttl_seconds": 300,
+                    },
+                    False,
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            sessions_service,
+            "get_session_basic",
+            AsyncMock(return_value=MagicMock()),
+        )
+        resp = client.post("/v1/browser/takeover", json={"session_id": "sess_1"})
+        assert resp.status_code == 200
+        assert resp.json()["grant_id"] == "bgr_new" and resp.json()["epoch"] == 9
+
+
+class TestFrameLoading:
+    def test_hostile_manifest_file_is_refused(self, tmp_path: Path) -> None:
+        frames = tmp_path / "frames"
+        frames.mkdir()
+        (tmp_path / "secret.jpg").write_bytes(b"nope")
+        manifest = {"seq": 1, "file": "../secret.jpg"}
+        assert browser_router._load_frame(frames, manifest, _ACCOUNT) is None
+
+    def test_valid_manifest_forwards_the_trusted_chrome_envelope(self, tmp_path: Path) -> None:
+        frames = tmp_path / "frames"
+        frames.mkdir()
+        (frames / "0.jpg").write_bytes(b"\xff\xd8jpeg")
+        manifest = {
+            "seq": 3,
+            "file": "0.jpg",
+            "ts_ms": 100,
+            "epoch": 7,
+            "boot": "01B",
+            "origin": "https://accounts.example.com",
+            "security": "secure",
+            "w": 1280,
+            "h": 800,
+        }
+        frame = browser_router._load_frame(frames, manifest, _ACCOUNT)
+        assert frame is not None
+        assert frame["origin"] == "https://accounts.example.com"
+        assert frame["security"] == "secure"
+        assert frame["epoch"] == 7 and frame["boot"] == "01B"
+        assert "account" not in frame  # never crosses to the client
+        import base64
+
+        assert frame["jpeg_b64"] == base64.b64encode(b"\xff\xd8jpeg").decode()
+
+    def test_absent_manifest_reads_as_none(self, tmp_path: Path) -> None:
+        assert browser_router._read_manifest(tmp_path / "frames") is None


### PR DESCRIPTION
PR 5 (final) of the jarbot#106 Phase 1 stack (stacked on #2276; [plan + amendments](https://github.com/eumemic/jarbot/issues/106#issuecomment-5434392296)). The product-facing HTTP surface, completing the aios substrate — jarbot (Phase 3) codes against the SDK; the driver (Phase 2, `infra/browser-image/`) implements `browser_protocol` verbatim.

## What

`api/routers/browser.py` (`/v1/browser`):

| Route | Behavior |
|---|---|
| `POST /takeover` | Scoped session read → open via the control-plane RPC. 409 on the one-open-per-account conflict, 503 unavailable. |
| `POST /takeover/{id}/heartbeat` | Rowcount 404/409/204 — the viewer calls it while it holds the frame stream. |
| `POST /takeover/{id}/input` | Epoch + spool-cap gates, then a single `O_APPEND` write to the shared-filesystem spool. **No worker involvement**; the driver drops stale-epoch lines as the enforcement authority. |
| `GET /takeover/{id}/frames` | SSE screencast (see below). |
| `DELETE /takeover/{id}` | Close → handback (snapshot + inlined screenshot + signed-in delta); a browser-dead close still closes → null fields. |
| `GET /status` | Never provisions. |
| `DELETE /sites/{host}` · `POST /clear` | Per-site sign-out; clear-computer (409 if a takeover is open). |

Every grant-scoped route resolves the grant with the standard **account-scoped** query FIRST (cross-tenant ids → 404) before any stream or filesystem access; the frames dir + spool path are derived server-side from the scoped account (the client supplies only `grant_id`), so path containment holds by construction.

**The frames stream is novel among aios SSE routes**: it tails a shared-filesystem ring (the driver has no route to Postgres), not a LISTEN channel. It polls `frames/manifest.json` at ~5 fps, forwards the §5.6 trusted-chrome envelope (`origin`/`security`/`boot`/`epoch`, JPEG inlined, account stripped) with the manifest's `file` path containment-checked, and ends on grant close. A missing plane dir while a grant is open is a loud 503 (mount fault), never silent. `make_sse_response` now accepts a bare terminate callable besides a `ListenSubscription` — the poll loop holds no LISTEN connection.

- `models/browser.py`: request/response pydantic incl. the §5.6 `pointer_*`/`key_*`/`text` `InputEvent` vocabulary. `errors.py` gains a generic `ServiceUnavailableError` (503) distinct from the LISTEN-specific `SSEPreflightFailedError`. config: browser call timeout + input spool byte cap.
- **Regen**: `openapi.json` + SDK (new `/v1/browser` operations + models). The eight routes are allowlisted `NOT_CLI_OPERATIONS` — product-layer takeover control driven by the app's viewer, not an operator CLI workflow.
- `scripts/pooled_connection_lint.py`: PR 4's new browser queries added to the recognized-DB-surface allowlist (the CI-only PCA lint that local pre-commit doesn't run — folded back into #2276 by an amend, so this diff no longer carries it).

## Tests

15 route unit tests: the trust boundary (unknown grant → 404 before any write/stream), input epoch/closed/cap gates + the JSONL append, heartbeat rowcount 404/409/204, the error-currency → HTTP map (`takeover_in_progress` → 409, `browser_unavailable` → 503, success), and the frames-manifest containment (hostile `../` path refused) + envelope forwarding + absent-manifest handling. Full unit suite (5351) green.

## Phase 1 complete

With this PR the aios substrate for computer use is whole: the token economics fix (#2273), the account browser container + THE GATE (#2274), the eleven `browser_*` arms + wire contract (#2275), the control plane (#2276), and this surface. Phase 2 builds `infra/browser-image/` against the pinned `browser_protocol`; Phase 3 is jarbot. **Rollout invariant stands**: no agent is granted a `browser_*` arm until the network-isolation e2e (#2274) is green in that environment.

Part of jarbot#106 Phase 1 (computer-use substrate) — the final PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)