### PR TITLE
fix(ci): job timeouts, local invariant gates, stack-aware migration-collision check

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Every job carries timeout-minutes so a wedged step fails fast with a
+# log instead of riding GitHub's 360-min default — the 2026-08-27
+# cache-service outage left a unit job running wedged for 3h19m.
+
 jobs:
   # Mirrors the pre-commit hook's short-circuit: docs-only changes skip
   # the heavy validation pipeline.  Widened beyond the hook's `.py$`
@@ -23,6 +27,7 @@ jobs:
   # the workflow itself).
   detect:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       run_checks: ${{ steps.filter.outputs.run_checks }}
       sandbox_changed: ${{ steps.filter.outputs.sandbox_changed }}
@@ -112,6 +117,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     env:
       # ``get_settings()`` is called at module import by code that ruff/mypy
@@ -137,7 +143,7 @@ jobs:
         run: uv sync --dev
 
       - name: Pooled connection await invariant
-        run: uv run python scripts/pooled_connection_lint.py src
+        run: uv run python scripts/pooled_connection_lint.py
 
       - name: Verify pooled-await exception issues are open
         env:
@@ -150,7 +156,7 @@ jobs:
           # pointed at a CLOSED issue for two months while this step reported success.
           # Two mechanisms parsing one syntax with different rules is how a blind spot
           # appears; the linter is now the single source of truth.
-          uv run python scripts/pooled_connection_lint.py --list-exemptions src \
+          uv run python scripts/pooled_connection_lint.py --list-exemptions \
             | sort -u > /tmp/exemptions.tsv
 
           # FAIL CLOSED ON AN EMPTY ENUMERATION. If the linter crashes, the path is
@@ -211,6 +217,7 @@ jobs:
     needs: detect
     if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     env:
       AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
@@ -237,12 +244,15 @@ jobs:
         # fixed ports (broker tests bind port 0 / mkdtemp UDS paths),
         # per-worker ``AIOS_INSTANCE_ID`` via tests/conftest.py.
         # Measured locally: 45 s serial → 17 s at ``-n 4``.
-        run: uv run pytest tests/unit -q -n 4
+        # ``faulthandler_timeout``: a hung test dumps tracebacks instead of
+        # sitting silent until timeout-minutes fires (mirrors integration).
+        run: uv run pytest tests/unit -q -n 4 -o faulthandler_timeout=120
 
   connectors:
     needs: detect
     if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -297,6 +307,8 @@ jobs:
     needs: detect
     if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
+    # Generous: covers the flake-retry path re-running the full suite.
+    timeout-minutes: 30
 
     env:
       # Parse-only: ``get_settings()`` must see a valid Postgres DSN at
@@ -356,6 +368,9 @@ jobs:
   e2e:
     needs: detect
     runs-on: ubuntu-latest
+    # Generous: covers the sandbox-build fallback and the non-docker
+    # shard's full-suite flake retry.
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/.github/workflows/gvisor-validation.yml
+++ b/.github/workflows/gvisor-validation.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   gvisor-validation:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     env:
       # Parse-only: ``get_settings()`` must see a valid Postgres DSN at

--- a/.github/workflows/migration-collision-check.yml
+++ b/.github/workflows/migration-collision-check.yml
@@ -5,6 +5,15 @@ name: Migration collision check
 # duplicate revisions after they reach master; this check gives the later PR an
 # advisory red check before merge so it can renumber and re-point down_revision.
 #
+# Collisions are keyed by (number, filename): the same number under two
+# DIFFERENT filenames is a collision; the IDENTICAL filename in both PRs'
+# diffs is one migration seen twice through a stack — a child PR retargeted
+# to master mid-stack-merge carries its still-open ancestor's commits in its
+# cumulative diff — and is deliberately not flagged. (Two unrelated PRs
+# adding the identical filename with different content also go unflagged:
+# git blocks the second merge with an add/add conflict, and the chain
+# canary covers anything that lands anyway.)
+#
 # Security note: this workflow does not interpolate any untrusted ${{ }}
 # expression (issue/PR titles, head_ref, commit messages, bodies) into run:
 # commands. Only trusted contexts (github.repository,
@@ -41,7 +50,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          migration_numbers_for_pr() {
+          migration_files_for_pr() {
             local pr_number="$1"
             local files
 
@@ -54,13 +63,12 @@ jobs:
 
             printf '%s\n' "${files}" \
               | grep '^migrations/versions/[0-9][0-9][0-9][0-9]_.*\.py$' \
-              | sed 's|migrations/versions/||; s|_.*||' \
               | sort -u \
               || true
           }
 
-          own_numbers=$(migration_numbers_for_pr "${PR_NUMBER}")
-          if [ -z "${own_numbers}" ]; then
+          own_files=$(migration_files_for_pr "${PR_NUMBER}")
+          if [ -z "${own_files}" ]; then
             exit 0
           fi
 
@@ -77,17 +85,25 @@ jobs:
               continue
             fi
 
-            other_numbers=$(migration_numbers_for_pr "${other_pr}")
-            if [ -z "${other_numbers}" ]; then
+            other_files=$(migration_files_for_pr "${other_pr}")
+            if [ -z "${other_files}" ]; then
               continue
             fi
 
-            while IFS= read -r own_number; do
-              if printf '%s\n' "${other_numbers}" | grep -Fxq "${own_number}"; then
-                echo "MIGRATION COLLISION: ${own_number} also claimed by PR #${other_pr} — whichever merges second must renumber to the next free number and re-point down_revision"
+            while IFS= read -r own_file; do
+              own_number=$(basename "${own_file}" | cut -d_ -f1)
+
+              # -Fxv: the identical filename in both diffs is stacked-PR
+              # inheritance (see header), not a collision.
+              colliding=$(printf '%s\n' "${other_files}" \
+                | grep "^migrations/versions/${own_number}_" \
+                | grep -Fxv "${own_file}" \
+                || true)
+              if [ -n "${colliding}" ]; then
+                echo "MIGRATION COLLISION: ${own_file} vs PR #${other_pr}'s ${colliding//$'\n'/ } — same number ${own_number}; whichever merges second must renumber to the next free number and re-point down_revision"
                 collision_found=1
               fi
-            done <<< "${own_numbers}"
+            done <<< "${own_files}"
           done <<< "${open_prs}"
 
           exit "${collision_found}"

--- a/.github/workflows/reconcile-agents.yml
+++ b/.github/workflows/reconcile-agents.yml
@@ -45,6 +45,7 @@ env:
 jobs:
   reconcile:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-aios-sdk.yml
+++ b/.github/workflows/release-aios-sdk.yml
@@ -56,6 +56,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write  # for ``gh release create`` / ``gh release upload``
 

--- a/scripts/pooled_connection_lint.py
+++ b/scripts/pooled_connection_lint.py
@@ -657,7 +657,10 @@ def iter_exemption_refs(root: str = "src") -> list[tuple[str, int, int]]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("paths", nargs="+", type=Path)
+    # Defaulting to ``src`` keeps every call site (CI lint job,
+    # scripts/run-checks.sh) argument-free, so the target can't drift
+    # between them — same construction as check_migration_heads.py.
+    parser.add_argument("paths", nargs="*", type=Path, default=[Path("src")])
     parser.add_argument(
         "--list-exemptions",
         action="store_true",

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -8,7 +8,8 @@
 #   scripts/run-checks.sh --fail-on-autofix # fail if ruff auto-formats (for pre-commit)
 #   scripts/run-checks.sh --fail-fast      # stop at first failure
 #
-# Checks: ruff, mypy, tests (unit + connector suites — e2e needs Docker)
+# Checks: ruff, invariants (pooled-await lint, migration heads), mypy,
+# tests (unit + connector suites — e2e needs Docker)
 
 set -uo pipefail
 
@@ -68,6 +69,20 @@ if ! should_skip ruff; then
         uv run ruff check "${LINT_TARGETS[@]}" || fail
         uv run ruff format --check "${LINT_TARGETS[@]}" || fail
     fi
+fi
+
+# ── Static invariants ──────────────────────────────────────────────────────────
+
+# Kept in lock-step with the CI gates that have no ruff/pytest equivalent:
+# the PCA002 pooled-connection lint (code-validation.yml lint job) and the
+# alembic single-head check (migration-head-check.yml).  Both are offline
+# and sub-second.  The remaining CI-only gates (exemption-issue liveness,
+# isolated-install smoke, cross-PR migration collision) need the network
+# and stay CI-only.
+if ! should_skip invariants; then
+    echo "── invariants ──"
+    uv run python scripts/pooled_connection_lint.py || fail
+    uv run python scripts/check_migration_heads.py || fail
 fi
 
 # ── Mypy ───────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_ci_pytest_diagnostics.py
+++ b/tests/unit/test_ci_pytest_diagnostics.py
@@ -31,3 +31,13 @@ def test_integration_pytest_invocations_dump_stalled_test_stacks() -> None:
     assert all(
         "-o faulthandler_timeout=120" in invocation for invocation in integration_invocations
     )
+
+
+def test_unit_pytest_invocation_dumps_stalled_test_stacks() -> None:
+    workflow = _WORKFLOW.read_text()
+    unit_invocations = [
+        line.strip() for line in workflow.splitlines() if "uv run pytest tests/unit" in line
+    ]
+
+    assert len(unit_invocations) == 1
+    assert all("-o faulthandler_timeout=120" in invocation for invocation in unit_invocations)


### PR DESCRIPTION
Fixes the three CI problems surfaced during the jarbot#106 browser-stack merge (2026-08-27). All three claims were re-verified against the workflows and the actual run data before fixing.

## 1. Job timeouts + hang self-diagnosis

No job in `code-validation.yml` (or gvisor/reconcile-agents/release-aios-sdk) carried `timeout-minutes`, so a wedged step rode GitHub's 360-min default with no traceback.

- Every job now has a timeout: detect 5 / lint, unit, connectors 15 / integration, e2e 30 / gvisor 45 / reconcile-agents 10 / release-aios-sdk 15. Headroom verified against real run timings (worst legitimate case per job clears 2x, including cold-cache uv sync, flake retries, and the e2e build fallback).
- The unit lane gets `-o faulthandler_timeout=120` (mirrors integration) so a hung test dumps every thread's traceback into the log. Pinned by extending the existing `test_ci_pytest_diagnostics.py` drift test to the unit invocation.

**Refinement of the incident report while verifying:** the cancelled run's annotations do show the cache-service outage ("Failed to restore: Cache service responded with 400" / "services aren't available"), but in run 33093379850 the unit job sat **queued** 59 min then ran clean in 92s — queue time is not counted by `timeout-minutes`. The sibling outage-day run 33099554422 had unit **running wedged for 3h19m**, which is exactly what the timeout+faulthandler combination now kills with a traceback.

## 2. Local pre-commit ≡ cheap CI gates

`run-checks.sh` grows a **Static invariants** section running the PCA002 pooled-connection lint and the alembic single-head check — both offline and sub-second, so the pre-commit hook now catches what previously only CI flagged. `pooled_connection_lint.py` defaults its paths to `src` (same construction as `check_migration_heads.py`), so the target list cannot drift between the CI lint job and the local runner; both call sites are now argument-free.

**Partial debunk from the report:** the openapi + SDK drift guards are *not* CI-only — they are unit tests (`test_openapi_snapshot.py`, `test_sdk_snapshot.py`) and already ran locally via `pytest tests/unit`. The genuinely CI-only gates that remain (exemption-issue liveness, slack isolated-install smoke, cross-PR migration checks) all need the network and stay CI-only deliberately.

## 3. Stack-aware migration-collision check

The check compared migration **numbers** extracted from each PR's cumulative file diff, so a stacked child retargeted to master (as bottom-up stacked merges require) inherited its still-open ancestor's migration file and false-collided (#2277 flagged against #2276's 0175).

Collisions are now keyed by **(number, filename)**: the same number under two different filenames is a collision; the identical filename in both diffs is one migration seen twice through a stack and falls out clean — no stack-topology special case needed, and the rule is invariant under the dev-pipeline's branch rebases (a git-ancestry check would not be). The accepted residual (two unrelated PRs adding the byte-identical filename with different content) is documented in the header: git blocks the second merge with an add/add conflict, and the chain canary covers anything that lands anyway.

Verified by extracting the script and driving it with stubbed `gh` responses through the four cases: stack-inherited same file (clean), same number different file (collision), no overlap (clean), mixed shared+colliding (collision).

## Residuals (deliberately not done)

- CI's lint job consuming `run-checks.sh` directly (single source of truth): declined for now — drift between them fails loud at PR time, and per-step failure attribution in CI is worth keeping.
- `LINT_TARGETS` being spelled in both the workflow and `run-checks.sh` predates this PR and keeps its existing lock-step comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)