### PR TITLE
feat(browser): Phase 2 PR2 — the Chromium-backed driver core

### DIFF
--- a/packages/aios-browser-driver/aios_browser_driver/actions.py
+++ b/packages/aios-browser-driver/aios_browser_driver/actions.py
@@ -1,0 +1,327 @@
+"""The eleven action ops, mapped onto playwright.
+
+Each handler acts on the session's active page and raises
+:class:`~aios_browser_driver.errors.ActionError` for classified failures;
+the host's ``handle`` boundary turns those into the ``ok: false`` envelope.
+Audit-only arguments (``description``; ``modifiers`` where the action has no
+chord semantics) are accepted and ignored — never a validation error.
+
+The credential guardrail lives here: typing into a password field, and
+pressing keys while one is focused, is refused (``not_interactable``) — the
+account owner signs in via takeover, the agent never handles credentials.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import AsyncIterator
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any, Literal, cast, get_args
+
+from ulid import ULID
+
+from aios_browser_driver import guards
+from aios_browser_driver.browser_protocol import SHOTS_DIR
+from aios_browser_driver.errors import (
+    ActionError,
+    first_line,
+    require_int,
+    require_number,
+    require_str,
+)
+from aios_browser_driver.snapshot.refs import resolve_ref
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from playwright.async_api import Page
+
+    from aios_browser_driver.host import PageEntry
+
+_Modifier = Literal["Alt", "Control", "Meta", "Shift"]
+_Button = Literal["left", "middle", "right"]
+_MODIFIER_NAMES = frozenset(get_args(_Modifier))
+_BUTTONS = frozenset(get_args(_Button))
+_DIRECTIONS = frozenset({"up", "down", "left", "right"})
+
+# The fixed viewport — the one definition; the host launches at this size and
+# "scroll one page" means exactly it.
+VIEWPORT_WIDTH = 1280
+VIEWPORT_HEIGHT = 800
+_WHEEL_STEP_PX = 120
+_SHOTS_SUBDIR = PurePosixPath(SHOTS_DIR).name
+
+# Keep playwright's own timeouts strictly INSIDE dispatch's deadline so an
+# element op that exhausts its budget reports not_interactable (specific)
+# rather than racing dispatch's action_timeout (generic) at the same instant.
+_INNER_MARGIN_MS = 500.0
+
+_IS_PASSWORD_JS = "el => el instanceof HTMLInputElement && el.type === 'password'"
+# Pierce open shadow roots to find the actually-focused element.
+_FOCUSED_PASSWORD_JS = """() => {
+  let el = document.activeElement;
+  while (el && el.shadowRoot && el.shadowRoot.activeElement) el = el.shadowRoot.activeElement;
+  return !!el && el instanceof HTMLInputElement && el.type === "password";
+}"""
+
+_PASSWORD_REFUSAL = (
+    "refused: this field takes a password. The agent never types credentials — "
+    "the account owner signs in directly via a takeover."
+)
+
+
+def _remaining_ms(deadline: float) -> float:
+    return max(250.0, (deadline - time.monotonic()) * 1000.0 - _INNER_MARGIN_MS)
+
+
+def _modifiers(args: dict[str, Any]) -> list[_Modifier]:
+    raw = args.get("modifiers") or []
+    if not isinstance(raw, list):
+        raise ActionError("invalid_request", "'modifiers' must be a list")
+    return [cast(_Modifier, m) for m in raw if m in _MODIFIER_NAMES]
+
+
+@contextlib.asynccontextmanager
+async def _holding(page: Page, modifiers: list[_Modifier]) -> AsyncIterator[None]:
+    """Hold modifier keys around a raw mouse gesture (which has no
+    ``modifiers`` parameter of its own).
+
+    The presses are INSIDE the try so a cancellation mid-setup still releases
+    what was already pressed — a modifier left latched would silently apply to
+    every later action on the page."""
+    pressed: list[_Modifier] = []
+    try:
+        for m in modifiers:
+            await page.keyboard.down(m)
+            pressed.append(m)
+        yield
+    finally:
+        for m in reversed(pressed):
+            with contextlib.suppress(Exception):
+                await page.keyboard.up(m)
+
+
+async def run(
+    entry: PageEntry,
+    page: Page,
+    op: str,
+    args: dict[str, Any],
+    *,
+    deadline: float,
+    allow_private_nav: bool,
+    workspace: Path,
+) -> str | None:
+    """Run one action op; return the plane-relative shot path (screenshot only)."""
+    if op == "snapshot":
+        return None  # the host's post-action snapshot IS the observation
+    if op == "navigate":
+        await _navigate(page, args, deadline=deadline, allow_private=allow_private_nav)
+    elif op == "click":
+        await _click(entry, page, args, deadline=deadline)
+    elif op == "click_xy":
+        await _click_xy(page, args)
+    elif op == "type":
+        await _type(entry, page, args, deadline=deadline)
+    elif op == "press_key":
+        await _press_key(page, args)
+    elif op == "scroll":
+        await _scroll(entry, page, args)
+    elif op == "drag":
+        await _drag(entry, page, args)
+    elif op == "hover":
+        await _hover(entry, page, args, deadline=deadline)
+    elif op == "select_option":
+        await _select_option(entry, page, args, deadline=deadline)
+    elif op == "screenshot":
+        return await _screenshot(page, args, deadline=deadline, workspace=workspace)
+    else:  # pragma: no cover — dispatch validated op against BrowserOp already
+        raise ActionError("unknown_op", f"unknown action op {op!r}")
+    await _settle(page, deadline=deadline)
+    return None
+
+
+async def _settle(page: Page, *, deadline: float) -> None:
+    """Give the page a beat to react before the snapshot.
+
+    Double-rAF plus a fixed 100ms: two frames flush layout and most
+    same-document reactions. If the action navigated, the evaluate lands in a
+    destroyed context — fall through to waiting for the new document's load
+    state instead. Best-effort by design: a page that never settles should
+    still be observed as-is, not fail the action that succeeded.
+    """
+    try:
+        await page.evaluate(
+            "() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))"
+        )
+        await asyncio.sleep(0.1)
+    except Exception:
+        with contextlib.suppress(Exception):
+            await page.wait_for_load_state("load", timeout=min(5_000.0, _remaining_ms(deadline)))
+
+
+async def _navigate(
+    page: Page, args: dict[str, Any], *, deadline: float, allow_private: bool
+) -> None:
+    from playwright._impl._errors import TargetClosedError
+    from playwright.async_api import Error as PlaywrightError
+
+    url = require_str(args, "url")
+    await guards.check_url(url, allow_private=allow_private)
+    try:
+        await page.goto(url, timeout=_remaining_ms(deadline))
+    except TargetClosedError:
+        raise  # a crash mid-navigation is browser_crashed, not a nav failure
+    except PlaywrightError as exc:
+        raise ActionError("navigation_failed", first_line(exc)) from exc
+    # Post-commit re-check: a redirect chain may have landed somewhere the
+    # pre-flight check never saw. On violation, get off the page before
+    # reporting — its content must not be observed.
+    try:
+        await guards.check_url(page.url, allow_private=allow_private)
+    except ActionError:
+        try:
+            await page.goto("about:blank")
+        except PlaywrightError:
+            # If we cannot even blank it, the page is still on the blocked
+            # address — close it so nothing downstream can snapshot it (the
+            # session recreates a fresh page on its next action).
+            with contextlib.suppress(PlaywrightError):
+                await page.close()
+        raise ActionError(
+            "navigation_failed",
+            f"{url} redirected to a blocked address; the page was closed",
+        ) from None
+
+
+async def _click(entry: PageEntry, page: Page, args: dict[str, Any], *, deadline: float) -> None:
+    handle = await resolve_ref(page, entry, require_str(args, "ref"))
+    await handle.click(modifiers=_modifiers(args), timeout=_remaining_ms(deadline))
+
+
+async def _click_xy(page: Page, args: dict[str, Any]) -> None:
+    x = require_number(args, "x")
+    y = require_number(args, "y")
+    button = args.get("button") or "left"
+    if button not in _BUTTONS:
+        raise ActionError("invalid_request", f"'button' must be one of {sorted(_BUTTONS)}")
+    count = require_int(args, "count", lo=1, hi=3) if args.get("count") is not None else 1
+    async with _holding(page, _modifiers(args)):
+        await page.mouse.click(x, y, button=cast(_Button, button), click_count=count)
+
+
+async def _type(entry: PageEntry, page: Page, args: dict[str, Any], *, deadline: float) -> None:
+    handle = await resolve_ref(page, entry, require_str(args, "ref"))
+    text = require_str(args, "text", allow_empty=True)  # "" clears the field
+    if await handle.evaluate(_IS_PASSWORD_JS):
+        raise ActionError("not_interactable", _PASSWORD_REFUSAL, guardrail=True)
+    await handle.fill(text, timeout=_remaining_ms(deadline))
+    if args.get("submit"):
+        await handle.press("Enter", timeout=_remaining_ms(deadline))
+
+
+async def _press_key(page: Page, args: dict[str, Any]) -> None:
+    key = require_str(args, "key")
+    if await page.evaluate(_FOCUSED_PASSWORD_JS):
+        raise ActionError("not_interactable", _PASSWORD_REFUSAL, guardrail=True)
+    await page.keyboard.press(key)
+
+
+async def _scroll(entry: PageEntry, page: Page, args: dict[str, Any]) -> None:
+    direction = require_str(args, "direction")
+    if direction not in _DIRECTIONS:
+        raise ActionError("invalid_request", f"'direction' must be one of {sorted(_DIRECTIONS)}")
+    horizontal = direction in ("left", "right")
+    if args.get("amount") is not None:
+        magnitude = require_int(args, "amount", lo=1, hi=20) * _WHEEL_STEP_PX
+    else:
+        magnitude = VIEWPORT_WIDTH if horizontal else VIEWPORT_HEIGHT
+    sign = 1 if direction in ("down", "right") else -1
+    dx, dy = (sign * magnitude, 0) if horizontal else (0, sign * magnitude)
+
+    at = args.get("at")
+    if isinstance(at, dict):
+        await page.mouse.move(require_number(at, "x"), require_number(at, "y"))
+        await page.mouse.wheel(dx, dy)
+        return
+    ref = args.get("ref")
+    if isinstance(ref, str) and ref:
+        handle = await resolve_ref(page, entry, ref)
+        await handle.evaluate(
+            "(el, [dx, dy]) => el.scrollBy({left: dx, top: dy, behavior: 'instant'})", [dx, dy]
+        )
+        return
+    await page.mouse.wheel(dx, dy)
+
+
+async def _endpoint(
+    entry: PageEntry, page: Page, args: dict[str, Any], key: str
+) -> tuple[float, float]:
+    spec = args.get(key)
+    if not isinstance(spec, dict):
+        raise ActionError("invalid_request", f"{key!r} must be an object with a ref or x/y")
+    ref = spec.get("ref")
+    if isinstance(ref, str) and ref:
+        handle = await resolve_ref(page, entry, ref)
+        box = await handle.bounding_box()
+        if box is None:
+            raise ActionError("not_interactable", f"{ref} has no on-screen position")
+        return box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
+    return require_number(spec, "x"), require_number(spec, "y")
+
+
+async def _drag(entry: PageEntry, page: Page, args: dict[str, Any]) -> None:
+    start = await _endpoint(entry, page, args, "from")
+    end = await _endpoint(entry, page, args, "to")
+    waypoints: list[tuple[float, float]] = []
+    for point in args.get("path") or []:
+        if not isinstance(point, dict):
+            raise ActionError("invalid_request", "'path' must be a list of {x, y} points")
+        waypoints.append((require_number(point, "x"), require_number(point, "y")))
+
+    async with _holding(page, _modifiers(args)):
+        await page.mouse.move(*start)
+        await page.mouse.down()
+        try:
+            for x, y in [*waypoints, end]:
+                await page.mouse.move(x, y, steps=12)
+        finally:
+            # Release the button even on cancellation — a page left mid-drag
+            # swallows the next click.
+            with contextlib.suppress(Exception):
+                await page.mouse.up()
+
+
+async def _hover(entry: PageEntry, page: Page, args: dict[str, Any], *, deadline: float) -> None:
+    ref = args.get("ref")
+    if isinstance(ref, str) and ref:
+        handle = await resolve_ref(page, entry, ref)
+        await handle.hover(timeout=_remaining_ms(deadline))
+        return
+    if "x" in args and "y" in args:
+        await page.mouse.move(require_number(args, "x"), require_number(args, "y"))
+        return
+    raise ActionError("invalid_request", "hover needs a 'ref' or viewport 'x'/'y'")
+
+
+async def _select_option(
+    entry: PageEntry, page: Page, args: dict[str, Any], *, deadline: float
+) -> None:
+    handle = await resolve_ref(page, entry, require_str(args, "ref"))
+    values = args.get("values")
+    if not isinstance(values, list) or not values or not all(isinstance(v, str) for v in values):
+        raise ActionError("invalid_request", "'values' must be a non-empty list of strings")
+    await handle.select_option(cast(list[str], values), timeout=_remaining_ms(deadline))
+
+
+async def _screenshot(page: Page, args: dict[str, Any], *, deadline: float, workspace: Path) -> str:
+    name = f"shot-{ULID()!s}.png"
+    shots_dir = workspace / _SHOTS_SUBDIR
+    shots_dir.mkdir(parents=True, exist_ok=True)
+    await page.screenshot(
+        path=shots_dir / name,
+        full_page=bool(args.get("full_page")),
+        timeout=_remaining_ms(deadline),
+    )
+    return f"{_SHOTS_SUBDIR}/{name}"

--- a/packages/aios-browser-driver/aios_browser_driver/browser_protocol.py
+++ b/packages/aios-browser-driver/aios_browser_driver/browser_protocol.py
@@ -228,8 +228,8 @@ class BrowserResponse(BaseModel):
     snapshot: str | None = None
     snapshot_truncated: bool = False
     duration_ms: int = 0
-    # Plane-relative path (e.g. "shots/....png") for ``screenshot`` and
-    # on-error captures; the worker resolves it against the plane dir.
+    # Plane-relative path (e.g. "shots/....png") from ``screenshot``; the
+    # worker resolves it against the plane dir.
     shot_path: str | None = None
     # True when the calling session's page had to be recreated because the
     # driver (re)booted since the page last existed — the per-call

--- a/packages/aios-browser-driver/aios_browser_driver/daemon.py
+++ b/packages/aios-browser-driver/aios_browser_driver/daemon.py
@@ -1,9 +1,9 @@
 """``aios-browser-driver`` — the image CMD.
 
-Binds the request socket and serves. In this skeleton the host answers only
-``status``; PR2 swaps in the real Chromium-backed ``BrowserHost`` (same
-:class:`~aios_browser_driver.dispatch.Host` protocol), leaving this wiring
-unchanged.
+Binds the request socket FIRST (so ``browser-cli`` can attach the instant the
+container starts; early requests wait on the host's readiness), then launches
+Chromium. Every startup or relaunch failure crashes the process visibly — a
+crash-looping container beats a live one that answers nothing.
 """
 
 from __future__ import annotations
@@ -11,36 +11,25 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
 import signal
 import sys
 
-from ulid import ULID
-
-from aios_browser_driver.browser_protocol import BrowserRequest, BrowserResponse
 from aios_browser_driver.dispatch import dispatch
+from aios_browser_driver.host import BrowserHost
 from aios_browser_driver.server import serve
 
 log = logging.getLogger("aios_browser_driver")
 
-
-class SkeletonHost:
-    """The PR1 placeholder host: answers ``status`` with a valid envelope and
-    raises ``NotImplementedError`` (→ ``unknown_op``) for every other op until
-    PR2 wires Chromium. It exists so the image boots, the socket serves, and the
-    invocation/exit-code contract is exercisable before the browser lands."""
-
-    def __init__(self) -> None:
-        self.boot = str(ULID())
-        self.epoch = 0
-
-    async def handle(self, request: BrowserRequest, *, deadline: float) -> BrowserResponse:
-        if request.op == "status":
-            return BrowserResponse(ok=True, boot=self.boot, epoch=self.epoch)
-        raise NotImplementedError(request.op)
+# The hermetic-test knob: bypasses the navigate guard's public-address check
+# (never the scheme check) so e2e suites can serve fixtures from loopback.
+# Unsettable through aios by construction — the browser container spec pins
+# ``environment={}``.
+_ALLOW_PRIVATE_NAV_ENV = "AIOS_BROWSER_DRIVER_ALLOW_PRIVATE_NAV"
 
 
 async def _run() -> None:
-    host = SkeletonHost()
+    host = BrowserHost(allow_private_nav=os.environ.get(_ALLOW_PRIVATE_NAV_ENV) == "1")
     ready = asyncio.Event()
     stop = asyncio.Event()
     loop = asyncio.get_running_loop()
@@ -50,28 +39,40 @@ async def _run() -> None:
 
     server_task = asyncio.create_task(serve(lambda raw: dispatch(raw, host), ready=ready))
 
-    # Wait for the socket to bind — but if serve() dies during startup (e.g.
-    # a PermissionError binding /run/aios as uid 1000), re-raise its exception
-    # so the process CRASHES visibly instead of hanging forever on ready.wait()
-    # with a live-but-never-serving container.
-    ready_task = asyncio.create_task(ready.wait())
-    done, _ = await asyncio.wait({ready_task, server_task}, return_when=asyncio.FIRST_COMPLETED)
-    if server_task in done:
-        ready_task.cancel()
-        await server_task  # startup failed — surface the cause
-    log.info("driver ready (boot=%s)", host.boot)
+    try:
+        # Wait for the socket to bind — but if serve() dies during startup
+        # (e.g. a PermissionError binding /run/aios as uid 1000), re-raise its
+        # exception so the process CRASHES visibly instead of hanging forever
+        # on ready.wait() with a live-but-never-serving container.
+        ready_task = asyncio.create_task(ready.wait())
+        done, _ = await asyncio.wait({ready_task, server_task}, return_when=asyncio.FIRST_COMPLETED)
+        if server_task in done:
+            ready_task.cancel()
+            await server_task  # startup failed — surface the cause
 
-    stop_task = asyncio.create_task(stop.wait())
-    done, _ = await asyncio.wait({stop_task, server_task}, return_when=asyncio.FIRST_COMPLETED)
-    stop_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await stop_task
-    if server_task in done:
-        await server_task  # serve() exited on its own — re-raise any error
-    else:
-        server_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await server_task
+        await host.start()  # raises if Chromium cannot launch — crash visibly
+        log.info("driver ready (boot=%s)", host.boot)
+
+        stop_task = asyncio.create_task(stop.wait())
+        failed_task = asyncio.create_task(host.failed())
+        done, _ = await asyncio.wait(
+            {stop_task, server_task, failed_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in (stop_task, failed_task):
+            if task not in done:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        if failed_task in done:
+            await failed_task  # the browser died and could not relaunch
+        if server_task in done:
+            await server_task  # serve() exited on its own — re-raise any error
+        else:
+            server_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await server_task
+    finally:
+        await host.close()
 
 
 def main() -> int:

--- a/packages/aios-browser-driver/aios_browser_driver/dispatch.py
+++ b/packages/aios-browser-driver/aios_browser_driver/dispatch.py
@@ -14,17 +14,12 @@ import json
 import time
 from typing import Protocol, get_args
 
-from aios_browser_driver.browser_protocol import (
-    BrowserError,
-    BrowserOp,
-    BrowserRequest,
-    BrowserResponse,
-)
+from aios_browser_driver.browser_protocol import BrowserOp, BrowserRequest, BrowserResponse
+from aios_browser_driver.errors import error_response, first_line
 
 # The driver self-reports before the exec wrapper's SIGKILL: keep the handler's
 # own deadline this far below the request's ``timeout_ms``.
 _DEADLINE_MARGIN_S = 2.0
-_ERROR_MESSAGE_MAX = 200
 
 _OPS: frozenset[str] = frozenset(get_args(BrowserOp))
 
@@ -39,15 +34,8 @@ class Host(Protocol):
     async def handle(self, request: BrowserRequest, *, deadline: float) -> BrowserResponse: ...
 
 
-def _short(exc: BaseException) -> str:
-    text = str(exc)
-    return text.splitlines()[0][:_ERROR_MESSAGE_MAX] if text else type(exc).__name__
-
-
 def _error(host: Host, code: str, message: str) -> BrowserResponse:
-    return BrowserResponse(
-        ok=False, boot=host.boot, epoch=host.epoch, error=BrowserError(code=code, message=message)
-    )
+    return error_response(host.boot, host.epoch, code, message)
 
 
 async def dispatch(raw: str, host: Host) -> str:
@@ -72,7 +60,7 @@ async def _dispatch(raw: str, host: Host) -> BrowserResponse:
     try:
         request = BrowserRequest.model_validate(doc)
     except ValueError as exc:  # pydantic ValidationError is a ValueError
-        return _error(host, "invalid_request", _short(exc))
+        return _error(host, "invalid_request", first_line(exc))
 
     delay = max(0.0, request.timeout_ms / 1000.0 - _DEADLINE_MARGIN_S)
     deadline = time.monotonic() + delay
@@ -84,4 +72,4 @@ async def _dispatch(raw: str, host: Host) -> BrowserResponse:
     except NotImplementedError:
         return _error(host, "unknown_op", f"{request.op} is not implemented by this driver build")
     except Exception as exc:  # a handler fault must degrade to an envelope, never crash
-        return _error(host, "internal", _short(exc))
+        return _error(host, "internal", first_line(exc))

--- a/packages/aios-browser-driver/aios_browser_driver/errors.py
+++ b/packages/aios-browser-driver/aios_browser_driver/errors.py
@@ -1,0 +1,76 @@
+"""The driver's action-failure currency and the shared envelope helpers.
+
+Guards, ref resolution, and action handlers raise :class:`ActionError` with a
+wire error code from ``browser_protocol.ERROR_CODES``; the host's ``handle``
+boundary is the currency's total sink — it turns any :class:`ActionError`
+into an ``ok: false`` envelope (an action response also attaches a fresh
+snapshot so the model can self-correct). ``guardrail`` marks the credential
+guardrail's refusals for logging.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios_browser_driver.browser_protocol import BrowserError, BrowserResponse
+
+_ERROR_MESSAGE_MAX = 200
+
+
+class ActionError(Exception):
+    def __init__(self, code: str, message: str, *, guardrail: bool = False) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.guardrail = guardrail
+
+
+def first_line(exc: BaseException) -> str:
+    """The exception's first line, truncated — the model-visible error text.
+
+    One home for the wire error-message policy (dispatch, host, and actions all
+    format exceptions this way)."""
+    text = str(exc)
+    return text.splitlines()[0][:_ERROR_MESSAGE_MAX] if text else type(exc).__name__
+
+
+def error_response(boot: str, epoch: int, code: str, message: str) -> BrowserResponse:
+    """A bare ``ok: false`` envelope — no page observation. Shared by dispatch
+    (protocol-shape errors) and the host (control-op failures)."""
+    return BrowserResponse(
+        ok=False, boot=boot, epoch=epoch, error=BrowserError(code=code, message=message)
+    )
+
+
+# ── request-argument helpers (raise the currency; the boundary envelopes it) ─
+
+
+def require_str(args: dict[str, Any], key: str, *, allow_empty: bool = False) -> str:
+    value = args.get(key)
+    if not isinstance(value, str) or (not value and not allow_empty):
+        suffix = "a string" if allow_empty else "a non-empty string"
+        raise ActionError("invalid_request", f"{key!r} must be {suffix}")
+    return value
+
+
+def require_number(args: dict[str, Any], key: str) -> float:
+    value = args.get(key)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ActionError("invalid_request", f"{key!r} must be a number")
+    return float(value)
+
+
+def require_int(args: dict[str, Any], key: str, *, lo: int, hi: int) -> int:
+    """An integer in ``[lo, hi]``, accepting an integral float (``2.0``).
+
+    Draft 2020-12 ``"integer"`` validation — which the worker's tool schema
+    gate applies — accepts ``2.0``; rejecting it here would make the two
+    validation layers of one pipeline disagree."""
+    value = args.get(key)
+    if isinstance(value, bool):
+        raise ActionError("invalid_request", f"{key!r} must be an integer from {lo} to {hi}")
+    if isinstance(value, float) and value.is_integer():
+        value = int(value)
+    if not isinstance(value, int) or not lo <= value <= hi:
+        raise ActionError("invalid_request", f"{key!r} must be an integer from {lo} to {hi}")
+    return value

--- a/packages/aios-browser-driver/aios_browser_driver/guards.py
+++ b/packages/aios-browser-driver/aios_browser_driver/guards.py
@@ -1,0 +1,53 @@
+"""Navigation guard: agent-driven navigation goes to public http(s) only.
+
+Scheme + resolved-address checks run before ``page.goto`` and again against
+the post-commit final URL (redirect laundering). The address check is
+userspace and navigate-only — subresource fetches don't pass through here;
+the L3 deny-internal egress on the browser network is the boundary that
+holds regardless. ``allow_private_nav`` (the hermetic-test knob, read once at
+daemon start) bypasses only the address check, never the scheme check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from aios_browser_driver.errors import ActionError
+
+_SCHEMES = frozenset({"http", "https"})
+
+
+def _blocked(message: str) -> ActionError:
+    return ActionError("navigation_failed", message)
+
+
+async def check_url(url: str, *, allow_private: bool) -> None:
+    """Raise ``ActionError(navigation_failed)`` unless ``url`` is public http(s)."""
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in _SCHEMES:
+        raise _blocked(f"only http(s) URLs can be opened, not {parsed.scheme or 'a relative'} URLs")
+    host = parsed.hostname
+    if not host:
+        raise _blocked("the URL has no host")
+    if allow_private:
+        return
+    port = parsed.port or (443 if parsed.scheme.lower() == "https" else 80)
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise _blocked(f"could not resolve {host}: {exc}") from exc
+    if not infos:
+        raise _blocked(f"could not resolve {host}")
+    for _family, _type, _proto, _canon, sockaddr in infos:
+        # IPv6 link-local addresses come back with a %scope suffix.
+        addr = str(sockaddr[0]).split("%", 1)[0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError as exc:
+            raise _blocked(f"{host} resolved to an unparseable address {addr!r}") from exc
+        if not ip.is_global:
+            raise _blocked(f"{host} resolves to a non-public address ({ip}); refusing to open it")

--- a/packages/aios-browser-driver/aios_browser_driver/host.py
+++ b/packages/aios-browser-driver/aios_browser_driver/host.py
@@ -1,0 +1,537 @@
+"""The Chromium-backed browser host.
+
+One persistent context over the plane profile, one page per agent session,
+popups auto-followed. ``boot`` identifies the Chromium-context generation: it
+rotates on EVERY (re)launch — daemon start and in-container relaunch alike —
+because both lose page state, and boot is the wire signal for that loss.
+
+Restart truth (``driver_restarted``) is a per-session ledger at the plane
+root (``/workspace/.aios/sessions.json`` — outside the five subdirs, so
+``clear_state``'s subdir wipe and the reaper never touch it): each session
+records the boot it last held a page under, and a first touch under a
+different boot reports the loss. The ledger advances only when an ``ok``
+response actually carries the flag, so a cancelled or ``ok: false`` first
+touch does not silently spend the once-per-restart signal. A single page
+dying without Chromium dying (renderer crash) sets the entry's ``page_lost``
+flag instead — same report, no boot rotation.
+
+Death handling is unified through :meth:`_trigger_relaunch`. Chromium death
+fires the context ``close`` event → relaunch under a fresh boot (page state is
+gone; in-flight ops fail ``browser_crashed``). Death of playwright's own driver
+subprocess fires NO context event, so a ``TargetClosedError`` surfacing from
+any operation ALSO triggers a relaunch — which then fails to launch (the
+connection is gone) and resolves :meth:`failed`, crashing the daemon visibly. A
+crash-looping container beats a live one that answers nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from ulid import ULID
+
+from aios_browser_driver import actions
+from aios_browser_driver.browser_protocol import (
+    DOWNLOADS_DIR,
+    PROFILE_DIR,
+    BrowserError,
+    BrowserRequest,
+    BrowserResponse,
+    BrowserTab,
+)
+from aios_browser_driver.errors import ActionError, error_response, first_line, require_str
+from aios_browser_driver.hosts import normalize_host, signed_in_hosts
+from aios_browser_driver.snapshot.snapshot import take_snapshot
+
+if TYPE_CHECKING:
+    from playwright.async_api import (
+        BrowserContext,
+        CDPSession,
+        Dialog,
+        Download,
+        FileChooser,
+        Page,
+        Playwright,
+    )
+
+log = logging.getLogger("aios_browser_driver.host")
+
+WORKSPACE = Path("/workspace")
+_LEDGER_RELPATH = Path(".aios/sessions.json")
+_PROFILE_SUBDIR = PurePosixPath(PROFILE_DIR).name
+_DOWNLOADS_SUBDIR = PurePosixPath(DOWNLOADS_DIR).name
+# Background pages must keep rendering (a session's page is "backgrounded"
+# whenever another session's is frontmost); the disk cache is capped and
+# /dev/shm avoided for container-friendliness. NO --no-sandbox — Chromium's
+# own sandbox is the primary boundary and launch must FAIL if it cannot hold.
+# (Absence from this list is not enough: playwright INJECTS --no-sandbox
+# unless ``chromium_sandbox=True`` is passed at launch — see ``_launch``.)
+_LAUNCH_ARGS = [
+    "--disable-background-timer-throttling",
+    "--disable-backgrounding-occluded-windows",
+    "--disable-renderer-backgrounding",
+    "--disk-cache-size=268435456",
+    "--disable-dev-shm-usage",
+]
+_MAX_PAGES_PER_SESSION = 4
+
+
+@dataclass
+class PageEntry:
+    """One session's slot in the page registry: its page(s), snapshot
+    bookkeeping, and the dialog notes the next snapshot will carry. The
+    per-session lock lives on the host (keyed by session id) so it survives
+    entry recreation — the mutual-exclusion invariant must not reset when a
+    page is lost and rebuilt."""
+
+    session_id: str
+    pages: list[Page]
+    generation: int = 0
+    issued: int = 0
+    dialogs: list[str] = field(default_factory=list)
+    page_lost: bool = False
+
+    def open_pages(self) -> list[Page]:
+        self.pages = [p for p in self.pages if not p.is_closed()]
+        return self.pages
+
+    @property
+    def active_page(self) -> Page | None:
+        """The newest open page — popups are auto-followed."""
+        pages = self.open_pages()
+        return pages[-1] if pages else None
+
+    def drain_dialogs(self) -> list[str]:
+        drained = self.dialogs[:]
+        self.dialogs.clear()
+        return drained
+
+
+class BrowserHost:
+    """Implements the dispatch :class:`~aios_browser_driver.dispatch.Host`
+    protocol over a persistent Chromium context."""
+
+    def __init__(self, *, workspace: Path = WORKSPACE, allow_private_nav: bool = False) -> None:
+        self.boot = str(ULID())
+        self.epoch = 0
+        self.workspace = workspace
+        self.allow_private_nav = allow_private_nav
+        self._entries: dict[str, PageEntry] = {}
+        self._session_locks: dict[str, asyncio.Lock] = {}
+        self._registry_lock = asyncio.Lock()
+        self._ledger = _load_ledger(self._ledger_path)
+        self._last_session: str | None = None
+        self._pw: Playwright | None = None
+        self._context: BrowserContext | None = None
+        self._ready = asyncio.Event()
+        self._closing = False
+        self._failure: asyncio.Future[None] | None = None
+        self._relaunch_task: asyncio.Task[None] | None = None
+
+    @property
+    def _ledger_path(self) -> Path:
+        return self.workspace / _LEDGER_RELPATH
+
+    # ── lifecycle ─────────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Launch Chromium. Raises on failure — the daemon must crash visibly
+        rather than serve a browser that never came up."""
+        self._failure = asyncio.get_running_loop().create_future()
+        await self._launch()
+
+    async def failed(self) -> None:
+        """Resolves (with the exception) if the browser dies and cannot be
+        relaunched. Pends forever otherwise — the daemon races it against
+        shutdown."""
+        assert self._failure is not None, "failed() before start()"
+        await self._failure
+
+    async def close(self) -> None:
+        """Best-effort graceful shutdown (SIGTERM path): closing the context
+        flushes the profile to disk before the container is destroyed."""
+        self._closing = True
+        if self._relaunch_task is not None:
+            self._relaunch_task.cancel()
+        if self._context is not None:
+            with contextlib.suppress(Exception):
+                await self._context.close()
+        if self._pw is not None:
+            with contextlib.suppress(Exception):
+                await self._pw.stop()
+
+    async def _launch(self) -> None:
+        from playwright.async_api import async_playwright
+
+        if self._pw is None:
+            self._pw = await async_playwright().start()
+        context = await self._pw.chromium.launch_persistent_context(
+            user_data_dir=str(self.workspace / _PROFILE_SUBDIR),
+            channel="chromium",
+            headless=True,
+            # Playwright DEFAULTS the Chromium sandbox OFF (it injects
+            # --no-sandbox); this opt-in is what actually keeps the primary
+            # boundary up. The browser image's seccomp profile re-permits the
+            # unprivileged USER/PID/NET namespaces the zygote needs, and the
+            # image contract e2e asserts renderers really run namespaced
+            # (and that launch FAILS under the stricter sandbox profile).
+            chromium_sandbox=True,
+            viewport={"width": actions.VIEWPORT_WIDTH, "height": actions.VIEWPORT_HEIGHT},
+            accept_downloads=True,
+            downloads_path=str(self.workspace / _DOWNLOADS_SUBDIR),
+            args=_LAUNCH_ARGS,
+        )
+        context.on("close", self._on_context_close)
+        self._context = context
+        self._ready.set()
+        log.info("chromium up (boot=%s)", self.boot)
+
+    def _on_context_close(self, _context: BrowserContext) -> None:
+        # Chromium died under us (this event does NOT fire for driver-process
+        # death — that path reaches _trigger_relaunch via a TargetClosedError).
+        self._trigger_relaunch()
+
+    def _trigger_relaunch(self) -> None:
+        if self._closing or (self._relaunch_task is not None and not self._relaunch_task.done()):
+            return
+        self._ready.clear()
+        self._relaunch_task = asyncio.get_running_loop().create_task(self._relaunch())
+
+    async def _relaunch(self) -> None:
+        log.warning("browser died (boot=%s); relaunching", self.boot)
+        self.boot = str(ULID())
+        async with self._registry_lock:
+            self._entries.clear()
+        self._last_session = None
+        try:
+            await self._launch()
+        except Exception as exc:
+            # A launch failure here means the playwright driver itself is gone
+            # (Chromium alone would relaunch fine) — unrecoverable in-process.
+            log.error("browser relaunch failed: %s", exc)
+            if self._failure is not None and not self._failure.done():
+                self._failure.set_exception(exc)
+
+    # ── dispatch entry point ──────────────────────────────────────────────
+
+    async def handle(self, request: BrowserRequest, *, deadline: float) -> BrowserResponse:
+        from playwright._impl._errors import TargetClosedError
+
+        if request.op in ("takeover_open", "takeover_close"):
+            raise NotImplementedError(request.op)  # the takeover PR lands these
+        await self._ready.wait()
+        # Stamp the envelope from boot/epoch read at entry, so a relaunch
+        # racing this request can't pair a new boot with old page data.
+        boot, epoch = self.boot, self.epoch
+        try:
+            if request.op == "status":
+                return await self._status(boot, epoch)
+            if request.op == "revoke_site":
+                return await self._revoke_site(request.args, boot, epoch)
+            if not request.session_id:
+                raise ActionError("invalid_request", f"{request.op} requires a session_id")
+            async with self._session_lock(request.session_id):
+                entry, restarted = await self._ensure_entry(request.session_id)
+                self._last_session = request.session_id
+                return await self._run_action(entry, request, restarted, deadline, boot, epoch)
+        except ActionError as exc:
+            # The currency's total sink for the control path + pre-action
+            # checks; an action's own ActionError is enveloped WITH the
+            # observation inside _run_action, so it never reaches here.
+            return error_response(boot, epoch, exc.code, exc.message)
+        except TargetClosedError:
+            self._trigger_relaunch()
+            return error_response(boot, epoch, "browser_crashed", "the browser went away")
+
+    def _session_lock(self, session_id: str) -> asyncio.Lock:
+        lock = self._session_locks.get(session_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_locks[session_id] = lock
+        return lock
+
+    # ── the page registry ─────────────────────────────────────────────────
+
+    def _require_context(self) -> BrowserContext:
+        assert self._context is not None, "context gone while ready was set"
+        return self._context
+
+    async def _ensure_entry(self, session_id: str) -> tuple[PageEntry, bool]:
+        """Get-or-create the session's entry; report a page-state loss.
+
+        Runs under the session lock, so no concurrent request for the same
+        session can be mid-action while this recreates its pages."""
+        async with self._registry_lock:
+            restarted = False
+            entry = self._entries.get(session_id)
+            if entry is not None and entry.page_lost:
+                # The page's renderer died without Chromium dying: same loss,
+                # same report, no boot rotation.
+                restarted = True
+                for page in entry.open_pages():
+                    with contextlib.suppress(Exception):
+                        await page.close()
+                entry = None
+            if entry is not None and entry.active_page is None:
+                # The page closed itself (window.close()) — recreate silently:
+                # nothing was lost that the model didn't do itself.
+                entry = None
+            if entry is None:
+                self._entries.pop(session_id, None)
+                prior_boot = self._ledger.get(session_id)
+                if prior_boot is not None and prior_boot != self.boot:
+                    restarted = True
+                page = await self._require_context().new_page()
+                entry = PageEntry(session_id=session_id, pages=[page])
+                self._attach_page(entry, page)
+                self._entries[session_id] = entry
+            return entry, restarted
+
+    def _attach_page(self, entry: PageEntry, page: Page) -> None:
+        async def on_dialog(dialog: Dialog) -> None:
+            entry.dialogs.append(f'{dialog.type} — "{dialog.message[:200]}"')
+            with contextlib.suppress(Exception):
+                await dialog.dismiss()
+
+        async def on_filechooser(chooser: FileChooser) -> None:
+            entry.dialogs.append("file chooser — dismissed (file upload is not supported)")
+            with contextlib.suppress(Exception):
+                await chooser.set_files([])
+
+        async def on_download(download: Download) -> None:
+            # Persist to the plane with a real name; playwright otherwise stores
+            # the artifact under a GUID and DELETES it on context close.
+            await self._save_download(download)
+
+        def on_crash(_page: Page) -> None:
+            entry.page_lost = True
+
+        async def on_popup(popup: Page) -> None:
+            self._adopt_popup(entry, popup)
+
+        page.on("dialog", on_dialog)
+        page.on("filechooser", on_filechooser)
+        page.on("download", on_download)
+        page.on("crash", on_crash)
+        page.on("popup", on_popup)
+
+    async def _save_download(self, download: Download) -> None:
+        dest_dir = self.workspace / _DOWNLOADS_SUBDIR
+        suggested = download.suggested_filename or "download"
+        dest = dest_dir / f"{ULID()!s}-{suggested}"
+        try:
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            await download.save_as(dest)
+        except Exception as exc:
+            log.warning("download save failed (%s): %s", suggested, exc)
+
+    def _adopt_popup(self, entry: PageEntry, popup: Page) -> None:
+        """A popup becomes the session's active page (newest = active)."""
+        entry.pages.append(popup)
+        self._attach_page(entry, popup)
+        open_pages = entry.open_pages()
+        while len(open_pages) > _MAX_PAGES_PER_SESSION:
+            oldest = open_pages.pop(0)
+            task = asyncio.get_running_loop().create_task(oldest.close())
+            task.add_done_callback(lambda t: t.exception())  # close is best-effort
+
+    # ── the action envelope ───────────────────────────────────────────────
+
+    async def _run_action(
+        self,
+        entry: PageEntry,
+        request: BrowserRequest,
+        restarted: bool,
+        deadline: float,
+        boot: str,
+        epoch: int,
+    ) -> BrowserResponse:
+        from playwright._impl._errors import TargetClosedError
+        from playwright.async_api import Error as PlaywrightError
+        from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
+        started = time.monotonic()
+        page = entry.active_page
+        assert page is not None, "_ensure_entry returned an entry with no page"
+        error: BrowserError | None = None
+        shot_path: str | None = None
+        try:
+            shot_path = await actions.run(
+                entry,
+                page,
+                request.op,
+                request.args,
+                deadline=deadline,
+                allow_private_nav=self.allow_private_nav,
+                workspace=self.workspace,
+            )
+        except ActionError as exc:
+            if exc.guardrail:
+                log.info("guardrail refusal (session=%s op=%s)", entry.session_id, request.op)
+            error = BrowserError(code=exc.code, message=exc.message)
+        except TargetClosedError:
+            self._trigger_relaunch()
+            error = BrowserError(code="browser_crashed", message="the browser page went away")
+        except PlaywrightTimeoutError as exc:
+            # Playwright's own timeout on an element op is its actionability
+            # wait expiring (hidden/covered/disabled); the overall deadline is
+            # dispatch's to enforce.
+            error = BrowserError(code="not_interactable", message=first_line(exc))
+        except PlaywrightError as exc:
+            error = BrowserError(code="internal", message=first_line(exc))
+
+        # The post-action snapshot — also on ok:false, so the model can
+        # self-correct (stale ref → re-target) without a re-observe call.
+        snapshot: str | None = None
+        truncated = False
+        page = entry.active_page or page  # the action may have opened a popup
+        if error is None or error.code != "browser_crashed":
+            try:
+                snapshot, truncated = await take_snapshot(page, entry)
+            except Exception as exc:
+                if error is None:
+                    # The action succeeded but the page cannot be observed —
+                    # that is a failure of the action's contract, not garnish.
+                    if isinstance(exc, TargetClosedError):
+                        self._trigger_relaunch()
+                        error = BrowserError(code="browser_crashed", message=first_line(exc))
+                    else:
+                        error = BrowserError(code="internal", message=first_line(exc))
+
+        url, title, tabs = await self._observe(entry, page)
+        # Deliver-then-consume: advance the ledger only when this ok response
+        # actually carries the restart flag, so a cancelled/failed first touch
+        # leaves the once-per-restart signal for the next response.
+        if error is None and self._ledger.get(entry.session_id) != boot:
+            self._ledger[entry.session_id] = boot
+            _save_ledger(self._ledger_path, self._ledger)
+        return BrowserResponse(
+            ok=error is None,
+            boot=boot,
+            epoch=epoch,
+            url=url,
+            title=title,
+            tabs=tabs,
+            snapshot=snapshot,
+            snapshot_truncated=truncated,
+            duration_ms=int((time.monotonic() - started) * 1000),
+            shot_path=shot_path,
+            driver_restarted=restarted,
+            error=error,
+        )
+
+    async def _observe(
+        self, entry: PageEntry, page: Page
+    ) -> tuple[str | None, str | None, list[BrowserTab]]:
+        """url/title/tabs, every field coerced — one null field would fail the
+        whole response's validation worker-side."""
+        url: str | None = None
+        active_title: str | None = None
+        with contextlib.suppress(Exception):
+            url = page.url
+        with contextlib.suppress(Exception):
+            active_title = await page.title()
+        tabs: list[BrowserTab] = []
+        for index, open_page in enumerate(entry.open_pages()):
+            is_active = open_page is page
+            tab_title = active_title if is_active else None  # reuse the active read
+            if tab_title is None:
+                with contextlib.suppress(Exception):
+                    tab_title = await open_page.title()
+            tabs.append(
+                BrowserTab(
+                    index=index,
+                    url=open_page.url or "",
+                    title=tab_title or "",
+                    active=is_active,
+                )
+            )
+        return url, active_title, tabs
+
+    # ── control ops ───────────────────────────────────────────────────────
+
+    async def _status(self, boot: str, epoch: int) -> BrowserResponse:
+        """Whole-browser state. Page-blind beyond url/title of the current
+        page (protocol pin) — no snapshot, no tabs."""
+        url: str | None = None
+        title: str | None = None
+        entry = self._entries.get(self._last_session) if self._last_session else None
+        page = entry.active_page if entry else None
+        if page is not None:
+            with contextlib.suppress(Exception):
+                url = page.url
+            with contextlib.suppress(Exception):
+                title = await page.title()
+        return BrowserResponse(
+            ok=True,
+            boot=boot,
+            epoch=epoch,
+            url=url,
+            title=title,
+            data={"signed_in_hosts": await self._signed_in_hosts()},
+        )
+
+    async def _revoke_site(self, args: dict[str, Any], boot: str, epoch: int) -> BrowserResponse:
+        host = normalize_host(require_str(args, "host"))
+        context = self._require_context()
+        await context.clear_cookies(domain=host)
+        await context.clear_cookies(domain=f".{host}")
+        await self._clear_origin_storage(context, host)
+        return BrowserResponse(
+            ok=True,
+            boot=boot,
+            epoch=epoch,
+            data={"signed_in_hosts": await self._signed_in_hosts()},
+        )
+
+    async def _signed_in_hosts(self) -> list[str]:
+        cookies = await self._require_context().cookies()
+        return signed_in_hosts(cookies, now=time.time())
+
+    async def _clear_origin_storage(self, context: BrowserContext, host: str) -> None:
+        """CDP ``Storage.clearDataForOrigin`` for both schemes — cookies are
+        cleared context-wide above; this removes local/session storage,
+        IndexedDB, service workers, and cache storage. One temporary page (a
+        rare, owner-driven op) keeps the path single."""
+        page = await context.new_page()
+        cdp: CDPSession | None = None
+        try:
+            cdp = await context.new_cdp_session(page)
+            for origin in (f"https://{host}", f"http://{host}"):
+                await cdp.send(
+                    "Storage.clearDataForOrigin", {"origin": origin, "storageTypes": "all"}
+                )
+        finally:
+            if cdp is not None:
+                with contextlib.suppress(Exception):
+                    await cdp.detach()
+            with contextlib.suppress(Exception):
+                await page.close()
+
+
+# ── the restart ledger ────────────────────────────────────────────────────
+
+
+def _load_ledger(path: Path) -> dict[str, str]:
+    try:
+        raw = json.loads(path.read_text("utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items()}
+
+
+def _save_ledger(path: Path, ledger: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(ledger), "utf-8")
+    os.replace(tmp, path)

--- a/packages/aios-browser-driver/aios_browser_driver/hosts.py
+++ b/packages/aios-browser-driver/aios_browser_driver/hosts.py
@@ -1,0 +1,42 @@
+"""The signed-in-hosts heuristic (jarbot#106 §5.5).
+
+A host counts as "signed in" when the profile holds at least one unexpired
+``HttpOnly`` cookie for it — real session cookies are overwhelmingly HttpOnly,
+and pure-JS state (analytics, consent banners) overwhelmingly is not. A
+heuristic, deliberately: it feeds the owner-facing "where is this browser
+signed in" list and the takeover handback delta, never an enforcement
+decision.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def normalize_host(host: str) -> str:
+    """The canonical host key: no leading dot, lowercased.
+
+    One definition shared by the signed-in-hosts scan and ``revoke_site`` —
+    revoke-then-report only works because the two agree on the key."""
+    return host.strip().lstrip(".").lower()
+
+
+def signed_in_hosts(cookies: Iterable[Mapping[str, Any]], *, now: float) -> list[str]:
+    """Hosts holding ≥1 unexpired HttpOnly cookie, sorted and deduplicated.
+
+    ``cookies`` are playwright ``context.cookies()`` records; ``expires`` is a
+    unix timestamp, with ``-1`` marking a session cookie (unexpired by
+    definition — it lives as long as the profile's session store does).
+    """
+    hosts: set[str] = set()
+    for cookie in cookies:
+        if not cookie.get("httpOnly"):
+            continue
+        expires = float(cookie.get("expires") or -1)
+        if 0 < expires <= now:
+            continue
+        domain = normalize_host(str(cookie.get("domain") or ""))
+        if domain:
+            hosts.add(domain)
+    return sorted(hosts)

--- a/packages/aios-browser-driver/aios_browser_driver/snapshot/__init__.py
+++ b/packages/aios-browser-driver/aios_browser_driver/snapshot/__init__.py
@@ -1,0 +1,4 @@
+"""Text-first page perception: the injected walker, the renderer, and ref
+resolution."""
+
+from __future__ import annotations

--- a/packages/aios-browser-driver/aios_browser_driver/snapshot/refs.py
+++ b/packages/aios-browser-driver/aios_browser_driver/snapshot/refs.py
@@ -1,0 +1,54 @@
+"""Resolve a ``[ref=eN]`` handle back to a live element.
+
+Two facts, one owner each. The PAGE owns only the current snapshot's ref→element
+map (``window.__aiosRefs = {gen, map}``, overwritten wholesale per snapshot; the
+document — hence the registry — is destroyed by navigation). The DRIVER owns the
+``issued`` watermark: refs are numbered sequentially across a page's snapshots,
+so a ref numbered above ``issued`` was never minted (``no_such_ref``, decided
+without a round trip), while one at-or-below ``issued`` that no longer resolves
+was minted by an older, now-superseded snapshot (``stale_snapshot``). Both
+missing cases share the same remedy — take a fresh snapshot.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from aios_browser_driver.errors import ActionError
+
+if TYPE_CHECKING:
+    from playwright.async_api import ElementHandle, Page
+
+    from aios_browser_driver.host import PageEntry
+
+_REF_RE = re.compile(r"^e[1-9][0-9]*$")
+
+# Return the element only if it is from the CURRENT generation and still in the
+# document; anything else (superseded generation, detached node, navigation
+# cleared the registry) returns null → stale_snapshot.
+_FETCH_JS = """([ref, gen]) => {
+  const store = window.__aiosRefs;
+  if (!store || store.gen !== gen) return null;
+  const el = store.map[ref];
+  return el && el.isConnected ? el : null;
+}"""
+
+_RETAKE = "take a fresh browser_snapshot and use its refs"
+
+
+async def resolve_ref(page: Page, entry: PageEntry, ref: str) -> ElementHandle:
+    """Return the live element for ``ref`` or raise the classified failure."""
+    if not _REF_RE.match(ref):
+        raise ActionError("no_such_ref", f"{ref!r} is not a snapshot ref (expected e.g. 'e12')")
+    if int(ref[1:]) > entry.issued:
+        raise ActionError("no_such_ref", f"{ref} was never issued by a snapshot of this page")
+    handle = await page.evaluate_handle(_FETCH_JS, [ref, entry.generation])
+    element = handle.as_element()
+    if element is None:
+        raise ActionError(
+            "stale_snapshot",
+            f"{ref} is from a superseded snapshot (the page was re-observed, "
+            f"navigated, or restarted) — {_RETAKE}",
+        )
+    return element

--- a/packages/aios-browser-driver/aios_browser_driver/snapshot/snapshot.py
+++ b/packages/aios-browser-driver/aios_browser_driver/snapshot/snapshot.py
@@ -1,0 +1,92 @@
+"""Take and render the budgeted a11y snapshot.
+
+``take_snapshot`` injects :mod:`walker.js <aios_browser_driver.snapshot>` into
+the page's main frame, advances the entry's generation, and renders the
+returned items to the opaque text the model reads. Budgets are the protocol's
+``SNAPSHOT_MAX_ELEMENTS`` / ``SNAPSHOT_MAX_CHARS``; auto-dismissed dialogs
+ride the snapshot text (nothing merged reads action-response ``data``).
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from typing import TYPE_CHECKING, Any
+
+from aios_browser_driver.browser_protocol import SNAPSHOT_MAX_CHARS, SNAPSHOT_MAX_ELEMENTS
+
+if TYPE_CHECKING:
+    from playwright.async_api import Page
+
+    from aios_browser_driver.host import PageEntry
+
+_WALKER_JS = (resources.files("aios_browser_driver.snapshot") / "walker.js").read_text("utf-8")
+
+_ELEMENT_BUDGET_MARKER = "[{omitted} more elements omitted — the page exceeds the snapshot budget]"
+_CHAR_BUDGET_MARKER = "[snapshot truncated — the page exceeds the snapshot budget]"
+
+
+async def take_snapshot(page: Page, entry: PageEntry) -> tuple[str, bool]:
+    """Snapshot ``page`` under a fresh generation; return ``(text, truncated)``."""
+    gen = entry.generation + 1
+    result: dict[str, Any] = await page.evaluate(
+        _WALKER_JS, [gen, entry.issued + 1, SNAPSHOT_MAX_ELEMENTS]
+    )
+    entry.generation = gen
+    entry.issued += int(result["assigned"])
+    return render(
+        list(result["items"]),
+        omitted=int(result["omitted"]),
+        dialogs=entry.drain_dialogs(),
+    )
+
+
+def render(items: list[dict[str, Any]], *, omitted: int, dialogs: list[str]) -> tuple[str, bool]:
+    """Render walker items (plus any auto-dismissed dialogs) to snapshot text."""
+    lines = [f"[dialog auto-dismissed: {d}]" for d in dialogs]
+    lines.extend(_render_item(item) for item in items)
+    if omitted:
+        lines.append(_ELEMENT_BUDGET_MARKER.format(omitted=omitted))
+    truncated = omitted > 0
+
+    text = "\n".join(lines)
+    if len(text) > SNAPSHOT_MAX_CHARS:
+        keep = text[: SNAPSHOT_MAX_CHARS - len(_CHAR_BUDGET_MARKER) - 1]
+        text = keep.rsplit("\n", 1)[0] + "\n" + _CHAR_BUDGET_MARKER
+        truncated = True
+    return text, truncated
+
+
+def _render_item(item: dict[str, Any]) -> str:
+    role = str(item.get("role") or "generic")
+    parts = [f"- {role}"]
+    if role == "heading" and item.get("level"):
+        parts.append(f"(h{item['level']})")
+    name_part = f'"{item.get("name") or ""}"'
+    if item.get("value") is not None:
+        name_part += f': "{item["value"]}"'
+    parts.append(name_part)
+    states = [
+        state
+        for state, present in (
+            ("checked", item.get("checked") is True),
+            ("unchecked", item.get("checked") is False),
+            ("disabled", item.get("disabled") is True),
+            ("expanded", item.get("expanded") is True),
+            ("collapsed", item.get("expanded") is False),
+        )
+        if present
+    ]
+    if states:
+        parts.append(f"({', '.join(states)})")
+    options = item.get("options")
+    if options:
+        rendered = ", ".join(
+            f"{opt.get('label') or opt.get('value')!s}{'*' if opt.get('selected') else ''}"
+            + (f" [value={opt['value']}]" if opt.get("value") != opt.get("label") else "")
+            for opt in options
+        )
+        more = f", … {item['optionsOmitted']} more" if item.get("optionsOmitted") else ""
+        parts.append(f"[options: {rendered}{more}]")
+    if item.get("ref"):
+        parts.append(f"[ref={item['ref']}]")
+    return " ".join(parts)

--- a/packages/aios-browser-driver/aios_browser_driver/snapshot/walker.js
+++ b/packages/aios-browser-driver/aios_browser_driver/snapshot/walker.js
@@ -1,0 +1,195 @@
+// The aios snapshot walker — authored for this driver, no third-party code.
+//
+// Injected fresh on every snapshot via page.evaluate. Walks the MAIN frame's
+// DOM (iframes render as unref'd items; their content is not walked — v1),
+// descending open shadow roots, and collects the interactive elements and
+// headings a model can act on. Each collected element gets a [ref=eN] handle
+// registered in the page-scoped global `window.__aiosRefs`, which holds only
+// the CURRENT generation's map (`{gen, map}`) — a newer snapshot overwrites it
+// wholesale, and navigation destroys the document (and the registry with it),
+// so a ref never resolves outside the snapshot that minted it. The driver's
+// own `issued` watermark is what separates "was issued, now superseded"
+// (stale_snapshot) from "never issued" (no_such_ref); the page side keeps no
+// history.
+//
+// Credential safety: this runs in the PAGE's (hostile) realm, so `el.type` can
+// be shadowed by page JS. The password check therefore folds in the type
+// ATTRIBUTE and autocomplete before emitting any input value — best-effort
+// masking; the real guarantee is that credential-bearing fields are the
+// owner's, entered under a human takeover, never typed by the agent.
+//
+// Input:  [gen, startRef, maxElements]
+// Output: {items: [...], assigned: N, omitted: M}
+//   item: {role, name, tag, ref?, level?, value?, checked?, disabled?,
+//          expanded?, options?}
+([gen, startRef, maxElements]) => {
+  const SKIP_SUBTREE = new Set(["script", "style", "noscript", "template", "select", "datalist", "svg", "iframe", "object", "embed"]);
+  const INPUT_ROLES = {
+    checkbox: "checkbox",
+    radio: "radio",
+    range: "slider",
+    button: "button",
+    submit: "button",
+    reset: "button",
+    image: "button",
+    file: "button",
+    search: "searchbox",
+    color: "button",
+  };
+  const TAG_ROLES = { button: "button", textarea: "textbox", summary: "button" };
+  const NAME_MAX = 80;
+  const VALUE_MAX = 60;
+  const OPTIONS_MAX = 12;
+
+  const clip = (text, max) => {
+    const collapsed = (text || "").replace(/\s+/g, " ").trim();
+    return collapsed.length > max ? collapsed.slice(0, max - 1) + "…" : collapsed;
+  };
+
+  // Best-effort in a hostile realm: any of the three signals marks the field
+  // credential-bearing, so its value is never emitted as a value OR a name.
+  const isPasswordish = (el) =>
+    el instanceof HTMLInputElement &&
+    (el.type === "password" ||
+      (el.getAttribute("type") || "").toLowerCase() === "password" ||
+      (el.getAttribute("autocomplete") || "").toLowerCase().includes("password"));
+
+  const accName = (el) => {
+    const aria = el.getAttribute("aria-label");
+    if (aria && aria.trim()) return clip(aria, NAME_MAX);
+    const labelledby = el.getAttribute("aria-labelledby");
+    if (labelledby) {
+      const text = labelledby
+        .split(/\s+/)
+        .map((id) => (el.getRootNode().getElementById?.(id)?.textContent || ""))
+        .join(" ");
+      if (text.trim()) return clip(text, NAME_MAX);
+    }
+    if (el.labels && el.labels.length) {
+      const text = Array.from(el.labels).map((l) => l.textContent || "").join(" ");
+      if (text.trim()) return clip(text, NAME_MAX);
+    }
+    for (const attr of ["alt", "title", "placeholder"]) {
+      const v = el.getAttribute(attr);
+      if (v && v.trim()) return clip(v, NAME_MAX);
+    }
+    if (
+      el instanceof HTMLInputElement &&
+      (el.type === "submit" || el.type === "reset" || el.type === "button") &&
+      el.value &&
+      !isPasswordish(el)
+    ) {
+      return clip(el.value, NAME_MAX);
+    }
+    return clip(el.textContent || "", NAME_MAX);
+  };
+
+  const roleOf = (el) => {
+    const explicit = el.getAttribute("role");
+    if (explicit) return explicit.trim().split(/\s+/)[0].toLowerCase();
+    const tag = el.tagName.toLowerCase();
+    if (tag === "a") return el.hasAttribute("href") ? "link" : null;
+    if (tag === "input") {
+      const type = (el.getAttribute("type") || "text").toLowerCase();
+      if (type === "hidden") return null;
+      return INPUT_ROLES[type] || "textbox";
+    }
+    if (tag === "select") return el.multiple ? "listbox" : "combobox";
+    if (/^h[1-6]$/.test(tag)) return "heading";
+    if (TAG_ROLES[tag]) return TAG_ROLES[tag];
+    if (el.isContentEditable && el.contentEditable === "true") return "textbox";
+    return null;
+  };
+
+  const isInteractive = (el, role) => {
+    if (role !== "generic" && role !== "presentation" && role !== "none") return true;
+    if (el.hasAttribute("onclick")) return true;
+    const tabindex = el.getAttribute("tabindex");
+    return tabindex !== null && Number(tabindex) >= 0;
+  };
+
+  const visible = (el) => {
+    try {
+      if (!el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true })) return false;
+    } catch {
+      return false;
+    }
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  };
+
+  const items = [];
+  let next = startRef;
+  let omitted = 0;
+  const refmap = {};
+
+  const collect = (el) => {
+    const tag = el.tagName.toLowerCase();
+
+    if (tag === "iframe" || tag === "frame") {
+      if (items.length < maxElements) {
+        items.push({ role: "iframe", name: accName(el), tag });
+      } else {
+        omitted += 1;
+      }
+      return;
+    }
+
+    const role = roleOf(el);
+    const heading = role === "heading";
+    if (role === null || (!heading && !isInteractive(el, role))) return;
+    if (!visible(el)) return;
+
+    if (items.length >= maxElements) {
+      omitted += 1;
+      return;
+    }
+
+    const item = { role, name: accName(el), tag };
+    const ref = "e" + next;
+    next += 1;
+    refmap[ref] = el;
+    item.ref = ref;
+
+    if (heading) {
+      const m = tag.match(/^h([1-6])$/);
+      item.level = m ? Number(m[1]) : Number(el.getAttribute("aria-level")) || 2;
+    }
+    if (el.disabled === true || el.getAttribute("aria-disabled") === "true") item.disabled = true;
+    const expanded = el.getAttribute("aria-expanded");
+    if (expanded === "true" || expanded === "false") item.expanded = expanded === "true";
+    if (el instanceof HTMLInputElement) {
+      if (el.type === "checkbox" || el.type === "radio") item.checked = el.checked;
+      // Never a credential value (see isPasswordish — hostile-realm safe).
+      else if (!isPasswordish(el) && el.value) item.value = clip(el.value, VALUE_MAX);
+    } else if (el instanceof HTMLTextAreaElement && el.value) {
+      item.value = clip(el.value, VALUE_MAX);
+    } else if (el instanceof HTMLSelectElement) {
+      item.options = Array.from(el.options)
+        .slice(0, OPTIONS_MAX)
+        .map((o) => ({ value: o.value, label: clip(o.label || o.textContent, VALUE_MAX), selected: o.selected }));
+      if (el.options.length > OPTIONS_MAX) item.optionsOmitted = el.options.length - OPTIONS_MAX;
+    }
+    items.push(item);
+  };
+
+  // Bound recursion: a hostile page can nest the DOM thousands deep, which
+  // would blow the JS stack and turn every snapshot into an `internal` error.
+  const MAX_DEPTH = 200;
+  const walk = (root, depth) => {
+    if (depth > MAX_DEPTH) return;
+    for (const el of root.children) {
+      const tag = el.tagName.toLowerCase();
+      if (el.getAttribute("aria-hidden") === "true") continue;
+      collect(el);
+      if (SKIP_SUBTREE.has(tag)) continue;
+      if (el.shadowRoot) walk(el.shadowRoot, depth + 1);
+      walk(el, depth + 1);
+    }
+  };
+
+  walk(document.body || document.documentElement, 0);
+
+  window.__aiosRefs = { gen, map: refmap };
+  return { items, assigned: next - startRef, omitted };
+}

--- a/packages/aios-browser-driver/pyproject.toml
+++ b/packages/aios-browser-driver/pyproject.toml
@@ -63,7 +63,10 @@ no_implicit_optional = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-addopts = ["-ra", "--strict-markers", "--strict-config"]
+# The browser lane (real Chromium via playwright) is opt-in: run it with
+# `pytest -m browser`. Deselected by default so the unit lane needs no
+# browsers installed.
+addopts = ["-ra", "--strict-markers", "--strict-config", "-m", "not browser"]
 markers = [
-    "browser: exercises a real Chromium via playwright; skipped unless browsers are installed",
+    "browser: exercises a real Chromium via playwright; run explicitly with -m browser",
 ]

--- a/packages/aios-browser-driver/tests/test_errors.py
+++ b/packages/aios-browser-driver/tests/test_errors.py
@@ -1,0 +1,36 @@
+"""The request-argument helpers — notably require_int's integral-float
+acceptance, which keeps the driver from disagreeing with the worker's own
+Draft 2020-12 schema gate (``2.0`` validates as an integer there)."""
+
+from __future__ import annotations
+
+import pytest
+from aios_browser_driver.errors import ActionError, require_int, require_number, require_str
+
+
+def test_require_str_rejects_empty_by_default() -> None:
+    with pytest.raises(ActionError) as info:
+        require_str({"k": ""}, "k")
+    assert info.value.code == "invalid_request"
+
+
+def test_require_str_allows_empty_when_asked() -> None:
+    assert require_str({"k": ""}, "k", allow_empty=True) == ""
+
+
+@pytest.mark.parametrize("value", [2, 2.0])
+def test_require_int_accepts_int_and_integral_float(value: object) -> None:
+    assert require_int({"k": value}, "k", lo=1, hi=3) == 2
+
+
+@pytest.mark.parametrize("value", [2.5, 0, 4, "2", True, None])
+def test_require_int_rejects_non_integral_out_of_range_and_wrong_type(value: object) -> None:
+    with pytest.raises(ActionError) as info:
+        require_int({"k": value}, "k", lo=1, hi=3)
+    assert info.value.code == "invalid_request"
+
+
+def test_require_number_rejects_bool() -> None:
+    # bool is an int subclass — a stray True must not read as 1.
+    with pytest.raises(ActionError):
+        require_number({"k": True}, "k")

--- a/packages/aios-browser-driver/tests/test_guards.py
+++ b/packages/aios-browser-driver/tests/test_guards.py
@@ -1,0 +1,105 @@
+"""The navigate guard's URL matrix: schemes, resolved addresses, the
+hermetic-test knob, and resolution failures — every refusal is
+``navigation_failed``."""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import pytest
+from aios_browser_driver.errors import ActionError
+from aios_browser_driver.guards import check_url
+
+
+def _resolving_to(*addrs: str) -> Any:
+    # The stand-in for socket.getaddrinfo — the loop's executor passes all
+    # six positionals.
+    def fake_getaddrinfo(host: str, port: int, *args: Any, **kwargs: Any) -> list[Any]:
+        return [
+            (socket.AF_INET6 if ":" in a else socket.AF_INET, socket.SOCK_STREAM, 6, "", (a, port))
+            for a in addrs
+        ]
+
+    return fake_getaddrinfo
+
+
+async def _expect_blocked(url: str, *, allow_private: bool = False) -> str:
+    with pytest.raises(ActionError) as info:
+        await check_url(url, allow_private=allow_private)
+    assert info.value.code == "navigation_failed"
+    return info.value.message
+
+
+async def test_public_addresses_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _resolving_to("93.184.216.34"))
+    await check_url("https://example.com/page", allow_private=False)
+    await check_url("http://example.com", allow_private=False)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com/file",
+        "file:///etc/passwd",
+        "chrome://settings",
+        "javascript:alert(1)",
+        "data:text/html,<b>x</b>",
+        "example.com/no-scheme",
+        "https://",
+    ],
+)
+async def test_non_http_schemes_and_hostless_urls_are_blocked_even_with_the_knob(
+    url: str,
+) -> None:
+    # No getaddrinfo patch on purpose: these must be refused before any
+    # resolution — and the knob must not bypass the scheme check.
+    await _expect_blocked(url)
+    await _expect_blocked(url, allow_private=True)
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "10.0.0.8",
+        "192.168.1.1",
+        "172.16.3.4",
+        "127.0.0.1",
+        "169.254.169.254",  # cloud metadata
+        "100.64.0.7",  # CGNAT
+        "0.0.0.0",
+        "::1",
+        "fd00::1",
+        "fe80::1%eth0",  # link-local with a scope suffix
+        "::ffff:10.0.0.1",  # v4-mapped private (is_global delegates to the v4)
+        "::ffff:169.254.169.254",  # v4-mapped metadata — a base-image regression guard
+    ],
+)
+async def test_non_public_addresses_are_blocked(monkeypatch: pytest.MonkeyPatch, addr: str) -> None:
+    monkeypatch.setattr(socket, "getaddrinfo", _resolving_to(addr))
+    message = await _expect_blocked("https://internal.example/")
+    assert "non-public" in message
+
+
+async def test_one_private_addr_among_public_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    # DNS-rebinding shape: a name resolving to both a public and a private
+    # address must be refused outright.
+    monkeypatch.setattr(socket, "getaddrinfo", _resolving_to("93.184.216.34", "10.0.0.8"))
+    await _expect_blocked("https://rebind.example/")
+
+
+async def test_resolution_failure_is_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    def failing(*args: Any, **kwargs: Any) -> list[Any]:
+        raise socket.gaierror(8, "nodename nor servname provided")
+
+    monkeypatch.setattr(socket, "getaddrinfo", failing)
+    message = await _expect_blocked("https://nxdomain.example/")
+    assert "could not resolve" in message
+
+
+async def test_the_knob_allows_private_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    def exploding(*args: Any, **kwargs: Any) -> list[Any]:
+        raise AssertionError("the knob must skip resolution entirely")
+
+    monkeypatch.setattr(socket, "getaddrinfo", exploding)
+    await check_url("http://127.0.0.1:8000/fixture", allow_private=True)

--- a/packages/aios-browser-driver/tests/test_hosts.py
+++ b/packages/aios-browser-driver/tests/test_hosts.py
@@ -1,0 +1,51 @@
+"""The signed-in-hosts heuristic over a fixture cookie jar."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios_browser_driver.hosts import signed_in_hosts
+
+_NOW = 1_700_000_000.0
+
+
+def _cookie(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "sid",
+        "value": "x",
+        "domain": "example.com",
+        "path": "/",
+        "expires": _NOW + 3600,
+        "httpOnly": True,
+        "secure": True,
+        "sameSite": "Lax",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_unexpired_httponly_cookies_count() -> None:
+    jar = [
+        _cookie(domain="github.com"),
+        _cookie(domain=".google.com"),  # leading dot normalized
+        _cookie(domain="expired.example", expires=_NOW - 10),  # expired: out
+        _cookie(domain="analytics.example", httpOnly=False),  # JS cookie: out
+        _cookie(domain="session.example", expires=-1),  # session cookie: in
+        _cookie(domain="github.com", name="second"),  # deduped
+        _cookie(domain=""),  # no domain: out
+    ]
+    assert signed_in_hosts(jar, now=_NOW) == ["github.com", "google.com", "session.example"]
+
+
+def test_empty_jar() -> None:
+    assert signed_in_hosts([], now=_NOW) == []
+
+
+def test_host_with_only_non_httponly_cookies_is_absent() -> None:
+    jar = [_cookie(domain="tracker.example", httpOnly=False)]
+    assert signed_in_hosts(jar, now=_NOW) == []
+
+
+def test_domains_are_lowercased() -> None:
+    jar = [_cookie(domain=".GitHub.COM")]
+    assert signed_in_hosts(jar, now=_NOW) == ["github.com"]

--- a/packages/aios-browser-driver/tests/test_ledger.py
+++ b/packages/aios-browser-driver/tests/test_ledger.py
@@ -1,0 +1,32 @@
+"""The restart ledger: round-trip, corruption tolerance, and its plane-root
+location (outside the five subdirs ``clear_state`` wipes)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aios_browser_driver.host import _LEDGER_RELPATH, _load_ledger, _save_ledger
+
+
+def test_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / ".aios" / "sessions.json"
+    _save_ledger(path, {"sess_a": "01BOOTA", "sess_b": "01BOOTB"})
+    assert _load_ledger(path) == {"sess_a": "01BOOTA", "sess_b": "01BOOTB"}
+
+
+def test_missing_file_is_an_empty_ledger(tmp_path: Path) -> None:
+    assert _load_ledger(tmp_path / "absent.json") == {}
+
+
+def test_corrupt_file_is_an_empty_ledger(tmp_path: Path) -> None:
+    path = tmp_path / "sessions.json"
+    path.write_text("{not json", "utf-8")
+    assert _load_ledger(path) == {}
+    path.write_text('["a", "list"]', "utf-8")
+    assert _load_ledger(path) == {}
+
+
+def test_ledger_lives_at_the_plane_root_not_in_a_swept_subdir() -> None:
+    # clear_state rmtrees profile/shots/frames/downloads/input; the reaper
+    # sweeps shots/frames/downloads. The ledger must sit outside all five.
+    assert _LEDGER_RELPATH.parts[0] == ".aios"

--- a/packages/aios-browser-driver/tests/test_refs_classify.py
+++ b/packages/aios-browser-driver/tests/test_refs_classify.py
@@ -1,0 +1,43 @@
+"""Ref resolution's driver-side decisions — the ones made without a round trip.
+
+Bad format and above-watermark both resolve to their wire code without ever
+touching the page; the live/stale distinction needs a real page and is covered
+by the browser lane (test_walker_browser.py)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aios_browser_driver.errors import ActionError
+from aios_browser_driver.host import PageEntry
+from aios_browser_driver.snapshot.refs import resolve_ref
+
+
+class _ExplodingPage:
+    """Any page round trip is a test failure — these paths must decide
+    driver-side."""
+
+    async def evaluate_handle(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("resolve_ref must not touch the page for this ref")
+
+
+def _entry(issued: int) -> PageEntry:
+    entry = PageEntry(session_id="sess", pages=[])
+    entry.issued = issued
+    entry.generation = 3
+    return entry
+
+
+@pytest.mark.parametrize("ref", ["", "e0", "e01", "abc", "12", "e", "e-1"])
+async def test_malformed_refs_are_no_such_ref(ref: str) -> None:
+    with pytest.raises(ActionError) as info:
+        await resolve_ref(_ExplodingPage(), _entry(50), ref)  # type: ignore[arg-type]
+    assert info.value.code == "no_such_ref"
+
+
+async def test_ref_above_the_watermark_is_no_such_ref_without_a_round_trip() -> None:
+    with pytest.raises(ActionError) as info:
+        await resolve_ref(_ExplodingPage(), _entry(issued=10), "e11")  # type: ignore[arg-type]
+    assert info.value.code == "no_such_ref"
+    assert "never issued" in info.value.message

--- a/packages/aios-browser-driver/tests/test_snapshot_render.py
+++ b/packages/aios-browser-driver/tests/test_snapshot_render.py
@@ -1,0 +1,87 @@
+"""Snapshot rendering: line shapes, budget markers, dialog notes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios_browser_driver.browser_protocol import SNAPSHOT_MAX_CHARS
+from aios_browser_driver.snapshot.snapshot import render
+
+
+def _item(**fields: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {"role": "button", "name": "Go", "tag": "button", "ref": "e1"}
+    base.update(fields)
+    return base
+
+
+def test_basic_line_shapes() -> None:
+    text, truncated = render(
+        [
+            _item(),
+            _item(role="link", name="Docs", tag="a", ref="e2"),
+            _item(role="textbox", name="Email", tag="input", ref="e3", value="a@b.c"),
+            _item(role="checkbox", name="Keep me", tag="input", ref="e4", checked=True),
+            _item(role="heading", name="Pricing", tag="h2", ref="e5", level=2),
+            _item(role="button", name="Buy", ref="e6", disabled=True),
+            _item(role="iframe", name="checkout", tag="iframe", ref=None),
+        ],
+        omitted=0,
+        dialogs=[],
+    )
+    assert not truncated
+    lines = text.splitlines()
+    assert lines[0] == '- button "Go" [ref=e1]'
+    assert lines[1] == '- link "Docs" [ref=e2]'
+    assert lines[2] == '- textbox "Email": "a@b.c" [ref=e3]'
+    assert lines[3] == '- checkbox "Keep me" (checked) [ref=e4]'
+    assert lines[4] == '- heading (h2) "Pricing" [ref=e5]'
+    assert lines[5] == '- button "Buy" (disabled) [ref=e6]'
+    assert lines[6] == '- iframe "checkout"'  # unref'd: content not walked in v1
+
+
+def test_select_options_render_inline() -> None:
+    text, _ = render(
+        [
+            _item(
+                role="combobox",
+                name="Country",
+                tag="select",
+                ref="e1",
+                options=[
+                    {"value": "se", "label": "Sweden", "selected": True},
+                    {"value": "no", "label": "Norway", "selected": False},
+                ],
+                optionsOmitted=3,
+            )
+        ],
+        omitted=0,
+        dialogs=[],
+    )
+    assert "Sweden* [value=se]" in text
+    assert "Norway [value=no]" in text
+    assert "… 3 more" in text
+
+
+def test_element_budget_marker_sets_truncated() -> None:
+    text, truncated = render([_item()], omitted=17, dialogs=[])
+    assert truncated
+    assert "[17 more elements omitted" in text
+
+
+def test_char_budget_truncates_at_a_line_boundary() -> None:
+    items = [_item(name="x" * 70, ref=f"e{i}") for i in range(1, 400)]
+    text, truncated = render(items, omitted=0, dialogs=[])
+    assert truncated
+    assert len(text) <= SNAPSHOT_MAX_CHARS
+    assert text.endswith("[snapshot truncated — the page exceeds the snapshot budget]")
+    # No half-rendered item line before the marker.
+    assert text.splitlines()[-2].endswith("]")
+
+
+def test_dialog_notes_lead_the_snapshot() -> None:
+    text, _ = render(
+        [_item()],
+        omitted=0,
+        dialogs=['alert — "Session expired"'],
+    )
+    assert text.splitlines()[0] == '[dialog auto-dismissed: alert — "Session expired"]'

--- a/packages/aios-browser-driver/tests/test_walker_browser.py
+++ b/packages/aios-browser-driver/tests/test_walker_browser.py
@@ -1,0 +1,227 @@
+"""The walker/refs/actions against a real Chromium (opt-in: ``pytest -m browser``).
+
+Skips (not fails) when playwright's chromium build is absent — the default
+unit lane never launches a browser.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from aios_browser_driver import actions
+from aios_browser_driver.errors import ActionError
+from aios_browser_driver.host import PageEntry
+from aios_browser_driver.snapshot.refs import resolve_ref
+from aios_browser_driver.snapshot.snapshot import take_snapshot
+
+if TYPE_CHECKING:
+    from playwright.async_api import Page
+
+pytestmark = pytest.mark.browser
+
+_PAGE_HTML = """
+<!doctype html>
+<html><body>
+  <h2>Welcome</h2>
+  <button id="go" onclick="this.textContent='Clicked'">Go</button>
+  <a href="/docs">Docs</a>
+  <input aria-label="Email" value="a@b.c">
+  <input type="password" aria-label="Password" value="hunter2secret">
+  <input type="checkbox" aria-label="Keep me" checked>
+  <select aria-label="Country">
+    <option value="se" selected>Sweden</option>
+    <option value="no">Norway</option>
+  </select>
+  <button style="display:none">Hidden</button>
+  <div id="shadow-host"></div>
+  <iframe title="checkout" srcdoc="<button>Inner</button>"></iframe>
+  <script>
+    document.getElementById("shadow-host")
+      .attachShadow({mode: "open"})
+      .innerHTML = '<button id="shadow-btn">Shadow</button>';
+  </script>
+</body></html>
+"""
+
+
+@pytest.fixture
+async def page() -> AsyncIterator[Page]:
+    from playwright.async_api import Error, async_playwright
+
+    pw = await async_playwright().start()
+    try:
+        try:
+            browser = await pw.chromium.launch(channel="chromium", headless=True)
+        except Error as exc:
+            pytest.skip(f"playwright chromium not installed: {exc}")
+        page = await browser.new_page(viewport={"width": 1280, "height": 800})
+        yield page
+        await browser.close()
+    finally:
+        await pw.stop()
+
+
+def _entry(page: Page) -> PageEntry:
+    return PageEntry(session_id="sess_test", pages=[page])
+
+
+def _deadline() -> float:
+    return time.monotonic() + 20.0
+
+
+async def test_walker_collects_refs_and_masks_passwords(page: Page) -> None:
+    await page.set_content(_PAGE_HTML)
+    entry = _entry(page)
+    text, truncated = await take_snapshot(page, entry)
+
+    assert not truncated
+    assert entry.generation == 1
+    assert entry.issued > 0
+    assert '- heading (h2) "Welcome"' in text
+    assert '- button "Go" [ref=' in text
+    assert '- link "Docs" [ref=' in text
+    assert '- textbox "Email": "a@b.c"' in text
+    assert '- checkbox "Keep me" (checked)' in text
+    assert "Sweden* [value=se]" in text
+    assert '- button "Shadow"' in text  # open shadow roots are walked
+    assert '- iframe "checkout"' in text
+    assert "Inner" not in text  # iframe content is not walked (v1)
+    assert "Hidden" not in text  # display:none excluded
+    # The password FIELD is listed (the model must know it exists to route
+    # around it) but its value never is.
+    assert '- textbox "Password"' in text
+    assert "hunter2secret" not in text
+
+
+async def test_ref_resolution_and_staleness(page: Page) -> None:
+    await page.set_content(_PAGE_HTML)
+    entry = _entry(page)
+    text, _ = await take_snapshot(page, entry)
+    ref = text.split('- button "Go" [ref=')[1].split("]")[0]
+
+    handle = await resolve_ref(page, entry, ref)
+    assert await handle.evaluate("el => el.id") == "go"
+
+    with pytest.raises(ActionError) as info:
+        await resolve_ref(page, entry, "e99999")
+    assert info.value.code == "no_such_ref"
+
+    # A newer snapshot supersedes the generation the ref was minted in.
+    await take_snapshot(page, entry)
+    with pytest.raises(ActionError) as info:
+        await resolve_ref(page, entry, ref)
+    assert info.value.code == "stale_snapshot"
+    assert "superseded" in info.value.message
+
+    # Navigation replaces the document — the registry goes with it.
+    await page.set_content("<button>fresh</button>")
+    with pytest.raises(ActionError) as info:
+        await resolve_ref(page, entry, ref)
+    assert info.value.code == "stale_snapshot"
+
+
+async def test_a_ref_below_the_watermark_that_no_longer_resolves_is_stale(page: Page) -> None:
+    # The flat store holds only the current generation, so any superseding
+    # snapshot invalidates an older ref — but its number is ≤ issued, so it is
+    # stale_snapshot (was issued), never no_such_ref.
+    await page.set_content(_PAGE_HTML)
+    entry = _entry(page)
+    text, _ = await take_snapshot(page, entry)
+    ref = text.split('- button "Go" [ref=')[1].split("]")[0]
+    for _i in range(5):
+        await take_snapshot(page, entry)
+    with pytest.raises(ActionError) as info:
+        await resolve_ref(page, entry, ref)
+    assert info.value.code == "stale_snapshot"
+
+
+async def test_click_round_trip(page: Page, tmp_path: Path) -> None:
+    await page.set_content(_PAGE_HTML)
+    entry = _entry(page)
+    text, _ = await take_snapshot(page, entry)
+    ref = text.split('- button "Go" [ref=')[1].split("]")[0]
+
+    await actions.run(
+        entry,
+        page,
+        "click",
+        {"ref": ref, "description": "click the Go button"},
+        deadline=_deadline(),
+        allow_private_nav=True,
+        workspace=tmp_path,
+    )
+    text, _ = await take_snapshot(page, entry)
+    assert '- button "Clicked"' in text
+
+
+async def test_type_empty_string_clears_a_field(page: Page, tmp_path: Path) -> None:
+    # The tool schema has no minLength on `text`, so "" (clear the field) must
+    # be accepted, not bounced as invalid_request.
+    await page.set_content(_PAGE_HTML)
+    entry = _entry(page)
+    text, _ = await take_snapshot(page, entry)
+    ref = text.split('- textbox "Email"')[1].split("[ref=")[1].split("]")[0]
+    await actions.run(
+        entry,
+        page,
+        "type",
+        {"ref": ref, "text": "", "description": "clear the email field"},
+        deadline=_deadline(),
+        allow_private_nav=True,
+        workspace=tmp_path,
+    )
+    assert await page.eval_on_selector("input[aria-label=Email]", "el => el.value") == ""
+
+
+async def test_password_guardrails(page: Page, tmp_path: Path) -> None:
+    await page.set_content(_PAGE_HTML)
+    entry = _entry(page)
+    text, _ = await take_snapshot(page, entry)
+    ref = text.split('- textbox "Password"')[1].split("[ref=")[1].split("]")[0]
+
+    with pytest.raises(ActionError) as info:
+        await actions.run(
+            entry,
+            page,
+            "type",
+            {"ref": ref, "text": "s3cret", "description": "fill the password"},
+            deadline=_deadline(),
+            allow_private_nav=True,
+            workspace=tmp_path,
+        )
+    assert info.value.code == "not_interactable"
+    assert info.value.guardrail
+
+    await page.focus("input[type=password]")
+    with pytest.raises(ActionError) as info:
+        await actions.run(
+            entry,
+            page,
+            "press_key",
+            {"key": "a"},
+            deadline=_deadline(),
+            allow_private_nav=True,
+            workspace=tmp_path,
+        )
+    assert info.value.code == "not_interactable"
+    assert info.value.guardrail
+
+
+async def test_screenshot_writes_under_shots(page: Page, tmp_path: Path) -> None:
+    await page.set_content(_PAGE_HTML)
+    entry = _entry(page)
+    shot = await actions.run(
+        entry,
+        page,
+        "screenshot",
+        {},
+        deadline=_deadline(),
+        allow_private_nav=True,
+        workspace=tmp_path,
+    )
+    assert shot is not None and shot.startswith("shots/") and shot.endswith(".png")
+    assert (tmp_path / shot).stat().st_size > 0

--- a/src/aios/sandbox/browser_protocol.py
+++ b/src/aios/sandbox/browser_protocol.py
@@ -228,8 +228,8 @@ class BrowserResponse(BaseModel):
     snapshot: str | None = None
     snapshot_truncated: bool = False
     duration_ms: int = 0
-    # Plane-relative path (e.g. "shots/....png") for ``screenshot`` and
-    # on-error captures; the worker resolves it against the plane dir.
+    # Plane-relative path (e.g. "shots/....png") from ``screenshot``; the
+    # worker resolves it against the plane dir.
     shot_path: str | None = None
     # True when the calling session's page had to be recreated because the
     # driver (re)booted since the page last existed — the per-call

--- a/src/aios/tools/browser.py
+++ b/src/aios/tools/browser.py
@@ -11,8 +11,7 @@ Perception is text-first: every action returns a budgeted accessibility
 snapshot with ``[ref=eN]`` handles — the fast path for targeting — while the
 pointer arms also take viewport coordinates for surfaces the accessibility
 tree cannot express (canvas, sliders, maps, drag-and-drop). Screenshots are
-explicit (``browser_screenshot``) or attached by the driver on errors, never
-per-action.
+explicit (``browser_screenshot``), never per-action.
 
 Failure currency: driver action failures and transport faults surface as
 ``ToolBail`` — model-visible, self-correctable, and NEVER the calling


### PR DESCRIPTION
## Phase 2, PR2 of 5 — the Chromium-backed driver core

Second PR of the jarbot#106 **Phase 2** stack. Swaps PR1's status-only `SkeletonHost` for the real browser host on the same `Host` protocol: a persistent Chromium context over the plane profile, one page per agent session, and the eleven action ops. **Ships dark** — no image is configured, no `browser_*` arm is granted anywhere until `tests/e2e/test_browser_network_isolation.py` is green there.

> **Stacked on #2281** (`feat/browser-driver-skeleton`). Review the [PR1↔PR2 diff](https://github.com/eumemic/aios/compare/feat/browser-driver-skeleton...feat/browser-driver-core); merges after PR1.

Takeover machinery (admission gate, epoch state machine, screencast, spool) is **PR3** — the two takeover ops answer `unknown_op` here.

### What's here

- **`host.py` — `BrowserHost`**: `boot` = the Chromium-context generation (rotates on daemon start *and* in-container relaunch); a per-session restart ledger at the plane root that advances only when an `ok` response actually carries `driver_restarted` (a cancelled/`ok:false` first touch never spends the once-per-restart signal); a per-session lock keyed on the host so mutual exclusion survives entry recreation; unified death handling — Chromium death relaunches, **driver-subprocess death** (which fires no context event) is caught reactively and crashes the daemon visibly; downloads persisted with real names (playwright otherwise GUID-names and deletes them on close); page-blind `status`/`revoke_site`.
- **`snapshot/`** — an authored-fresh, depth-bounded walker building a **flat** page-scoped `[ref=eN]` registry (current generation only); the driver-side `issued` watermark is the sole owner of *was-issued* vs *never-issued*, so `stale_snapshot`/`no_such_ref` need no page-side history and resolution costs one round trip. Password values are masked against page-realm `type` shadowing (type attribute + autocomplete, on both the value and accessible-name paths).
- **`actions.py`** — the eleven ops on playwright, tolerant of what the worker's schema permits (`text:""` clears a field, integral floats pass as ints); the credential guardrail; modifier presses inside `try` and drag's `mouse.up` in a `finally`; a blocked redirect the driver can't blank is closed so nothing downstream observes it.
- **`guards.py` / `hosts.py` / `errors.py`** — the navigate guard (public-http(s), v4-mapped internals blocked; L3 egress is the real backstop), the signed-in-hosts heuristic, and the shared `ActionError` currency + `first_line`/envelope/arg helpers.

### Review

Built after a 5-agent plan red-team, then closed with an **8-agent uncorrelated review** (reuse / simplification / efficiency / altitude + contract-conformance, concurrency, playwright-API, security). Folded here: the per-session-lock, `driver_restarted`-deferral, boot-stamping and modifier-release **concurrency** fixes; the page-realm password-mask and blocked-redirect **security** fixes; the driver-death watchdog and download-lifecycle **playwright** fixes; the `text:""`/integral-float **conformance** fixes; and the **/simplify** pass (flat ref registry replacing the 4-generation machinery, shared `first_line`/envelope/arg helpers, derived constants, dead walker checks + write-only counter removed). Deferred with note: the op-kind `Literal` split (PR3); the worker-side `ok:false` restart render + tool-schema tightening (aios hardening set).

### Checks

`ruff` / `mypy` clean; 5386 unit + 81 package tests pass. An opt-in `-m browser` lane (deselected by default, self-skipping without browsers) exercises the walker, ref staleness/supersession, click, type-empty-clear, both password guardrails, and screenshot against real Chromium — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
