### PR TITLE
feat(browser): Phase 2 PR3 — the human-takeover state machine

### DIFF
--- a/packages/aios-browser-driver/aios_browser_driver/actions.py
+++ b/packages/aios-browser-driver/aios_browser_driver/actions.py
@@ -315,13 +315,30 @@ async def _select_option(
     await handle.select_option(cast(list[str], values), timeout=_remaining_ms(deadline))
 
 
-async def _screenshot(page: Page, args: dict[str, Any], *, deadline: float, workspace: Path) -> str:
-    name = f"shot-{ULID()!s}.png"
+async def capture_shot(
+    page: Page,
+    workspace: Path,
+    *,
+    prefix: str,
+    full_page: bool = False,
+    timeout_ms: float | None = None,
+) -> str:
+    """Write a PNG to the plane's shots/ dir and return its plane-relative
+    basename. The one owner of the "shots land under shots/, returned
+    plane-relative" contract — shared by browser_screenshot and the takeover
+    handback."""
+    name = f"{prefix}-{ULID()!s}.png"
     shots_dir = workspace / _SHOTS_SUBDIR
     shots_dir.mkdir(parents=True, exist_ok=True)
-    await page.screenshot(
-        path=shots_dir / name,
-        full_page=bool(args.get("full_page")),
-        timeout=_remaining_ms(deadline),
-    )
+    await page.screenshot(path=shots_dir / name, full_page=full_page, timeout=timeout_ms)
     return f"{_SHOTS_SUBDIR}/{name}"
+
+
+async def _screenshot(page: Page, args: dict[str, Any], *, deadline: float, workspace: Path) -> str:
+    return await capture_shot(
+        page,
+        workspace,
+        prefix="shot",
+        full_page=bool(args.get("full_page")),
+        timeout_ms=_remaining_ms(deadline),
+    )

--- a/packages/aios-browser-driver/aios_browser_driver/host.py
+++ b/packages/aios-browser-driver/aios_browser_driver/host.py
@@ -41,7 +41,12 @@ from ulid import ULID
 from aios_browser_driver import actions
 from aios_browser_driver.browser_protocol import (
     DOWNLOADS_DIR,
+    DRIVER_TAKEOVER_IDLE_TIMEOUT_S,
+    DRIVER_TAKEOVER_UNCLAIMED_TIMEOUT_S,
+    FRAMES_DIR,
+    INPUT_SPOOL,
     PROFILE_DIR,
+    TAKEOVER_HEARTBEAT_MARKER,
     BrowserError,
     BrowserRequest,
     BrowserResponse,
@@ -50,6 +55,10 @@ from aios_browser_driver.browser_protocol import (
 from aios_browser_driver.errors import ActionError, error_response, first_line, require_str
 from aios_browser_driver.hosts import normalize_host, signed_in_hosts
 from aios_browser_driver.snapshot.snapshot import take_snapshot
+from aios_browser_driver.takeover.injector import InputInjector
+from aios_browser_driver.takeover.screencast import Screencast
+from aios_browser_driver.takeover.spool import SpoolTailer
+from aios_browser_driver.takeover.state import AdmissionGate, ReplayCache, Takeover, now
 
 if TYPE_CHECKING:
     from playwright.async_api import (
@@ -68,6 +77,20 @@ WORKSPACE = Path("/workspace")
 _LEDGER_RELPATH = Path(".aios/sessions.json")
 _PROFILE_SUBDIR = PurePosixPath(PROFILE_DIR).name
 _DOWNLOADS_SUBDIR = PurePosixPath(DOWNLOADS_DIR).name
+_FRAMES_SUBDIR = PurePosixPath(FRAMES_DIR).name
+_SPOOL_REL = PurePosixPath(INPUT_SPOOL).relative_to("/workspace")
+_HEARTBEAT_REL = PurePosixPath(TAKEOVER_HEARTBEAT_MARKER)
+
+# Takeover watchdog cadence and the absolute lifetime cap (a backstop above the
+# TTL/idle timeouts — a takeover cannot hold the browser forever).
+_WATCHDOG_TICK_S = 15.0
+_ABSOLUTE_CAP_S = 3600.0
+_INPUT_POLL_S = 0.05
+# Keep the admission drain strictly inside the exec/dispatch deadline.
+_DRAIN_MARGIN_S = 2.0
+# Cap the handback screenshot so the whole capture stays inside dispatch's
+# deadline (a hung page degrades to a partial handback, never a cancel).
+_HANDBACK_SHOT_TIMEOUT_MS = 8000.0
 # Background pages must keep rendering (a session's page is "backgrounded"
 # whenever another session's is frontmost); the disk cache is capped and
 # /dev/shm avoided for container-friendliness. NO --no-sandbox — Chromium's
@@ -135,10 +158,31 @@ class BrowserHost:
         self._closing = False
         self._failure: asyncio.Future[None] | None = None
         self._relaunch_task: asyncio.Task[None] | None = None
+        # Takeover machinery (jarbot#106 §5.6): the gate serializes agent
+        # actions against the human's control; one takeover stands at a time,
+        # serialized by the transition lock; frame seq is per-boot.
+        self._gate = AdmissionGate()
+        self._transition_lock = asyncio.Lock()
+        self._standing: Takeover | None = None
+        self._replay = ReplayCache()
+        self._frame_seq = 0
+        self._watchdog_task: asyncio.Task[None] | None = None
 
     @property
     def _ledger_path(self) -> Path:
         return self.workspace / _LEDGER_RELPATH
+
+    @property
+    def _frames_dir(self) -> Path:
+        return self.workspace / _FRAMES_SUBDIR
+
+    @property
+    def _spool_path(self) -> Path:
+        return self.workspace / _SPOOL_REL
+
+    @property
+    def _heartbeat_marker(self) -> Path:
+        return self.workspace / _HEARTBEAT_REL
 
     # ── lifecycle ─────────────────────────────────────────────────────────
 
@@ -161,6 +205,20 @@ class BrowserHost:
         self._closing = True
         if self._relaunch_task is not None:
             self._relaunch_task.cancel()
+        if self._watchdog_task is not None:
+            self._watchdog_task.cancel()
+        # Tear a standing takeover down FIRST — its screencast/input tasks must
+        # be joined before the context closes, or they run against a dying
+        # context and can wedge the shutdown.
+        standing = self._standing
+        if standing is not None:
+            if standing.input_task is not None:
+                standing.input_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await standing.input_task
+            with contextlib.suppress(Exception):
+                await standing.screencast.stop()
+            self._standing = None
         if self._context is not None:
             with contextlib.suppress(Exception):
                 await self._context.close()
@@ -208,6 +266,13 @@ class BrowserHost:
     async def _relaunch(self) -> None:
         log.warning("browser died (boot=%s); relaunching", self.boot)
         self.boot = str(ULID())
+        self._frame_seq = 0  # seq is per-boot
+        # A standing takeover is defunct (its page and CDP died with Chromium):
+        # force-close it so the worker's later close replays an honest
+        # browser_crashed handback rather than hanging on a dead grant.
+        async with self._transition_lock:
+            if self._standing is not None:
+                await self._finalize(self._standing, "browser_crashed")
         async with self._registry_lock:
             self._entries.clear()
         self._last_session = None
@@ -225,23 +290,41 @@ class BrowserHost:
     async def handle(self, request: BrowserRequest, *, deadline: float) -> BrowserResponse:
         from playwright._impl._errors import TargetClosedError
 
-        if request.op in ("takeover_open", "takeover_close"):
-            raise NotImplementedError(request.op)  # the takeover PR lands these
         await self._ready.wait()
         # Stamp the envelope from boot/epoch read at entry, so a relaunch
         # racing this request can't pair a new boot with old page data.
         boot, epoch = self.boot, self.epoch
         try:
+            if request.op == "takeover_open":
+                return await self._takeover_open(request, deadline, boot)
+            if request.op == "takeover_close":
+                return await self._takeover_close(request, boot, epoch)
             if request.op == "status":
                 return await self._status(boot, epoch)
             if request.op == "revoke_site":
+                if self._standing is not None:
+                    # Never clear cookies under the human — the product polls
+                    # status during takeovers, but revoke waits for handback.
+                    return error_response(
+                        boot, epoch, "takeover_active", "cannot revoke a site during a takeover"
+                    )
                 return await self._revoke_site(request.args, boot, epoch)
             if not request.session_id:
                 raise ActionError("invalid_request", f"{request.op} requires a session_id")
             async with self._session_lock(request.session_id):
-                entry, restarted = await self._ensure_entry(request.session_id)
-                self._last_session = request.session_id
-                return await self._run_action(entry, request, restarted, deadline, boot, epoch)
+                if not self._gate.admit():
+                    # A human holds the browser. Page-blind by construction
+                    # (error_response carries no snapshot/url/title/tabs) so the
+                    # human's live page never leaks into agent context.
+                    return error_response(
+                        boot, epoch, "takeover_active", "a human has taken over the computer"
+                    )
+                try:
+                    entry, restarted = await self._ensure_entry(request.session_id)
+                    self._last_session = request.session_id
+                    return await self._run_action(entry, request, restarted, deadline, boot, epoch)
+                finally:
+                    self._gate.release()
         except ActionError as exc:
             # The currency's total sink for the control path + pre-action
             # checks; an action's own ActionError is enveloped WITH the
@@ -342,6 +425,15 @@ class BrowserHost:
             oldest = open_pages.pop(0)
             task = asyncio.get_running_loop().create_task(oldest.close())
             task.add_done_callback(lambda t: t.exception())  # close is best-effort
+        # If a takeover stands for this session, the human just opened a popup —
+        # move the screencast AND injector to it together (they must always
+        # target the same page).
+        standing = self._standing
+        if standing is not None and standing.session_id == entry.session_id:
+            retarget = asyncio.get_running_loop().create_task(
+                self._retarget_takeover(entry.session_id)
+            )
+            retarget.add_done_callback(lambda t: t.exception())
 
     # ── the action envelope ───────────────────────────────────────────────
 
@@ -516,8 +608,297 @@ class BrowserHost:
             with contextlib.suppress(Exception):
                 await page.close()
 
+    # ── takeover ──────────────────────────────────────────────────────────
+
+    def _next_frame_seq(self) -> int:
+        self._frame_seq += 1
+        return self._frame_seq
+
+    async def _takeover_open(
+        self, request: BrowserRequest, deadline: float, boot: str
+    ) -> BrowserResponse:
+        grant_id = str(request.args.get("grant_id") or "")
+        session_id = request.session_id or ""
+        if not grant_id or not session_id:
+            return error_response(
+                boot, self.epoch, "invalid_request", "takeover_open needs grant_id and a session_id"
+            )
+        async with self._transition_lock:
+            standing = self._standing
+            if standing is not None:
+                if standing.grant_id == grant_id:
+                    # Idempotent redrive: a pure echo of the ORIGINAL epoch —
+                    # no drain, no rotate, no tailer re-arm. Page-blind.
+                    return self._open_result(standing.target, boot, standing.epoch)
+                return error_response(
+                    boot, self.epoch, "takeover_active", "a takeover is already in progress"
+                )
+            return await self._open_fresh(grant_id, session_id, deadline, boot)
+
+    async def _open_fresh(
+        self, grant_id: str, session_id: str, deadline: float, boot: str
+    ) -> BrowserResponse:
+        from playwright._impl._errors import TargetClosedError
+
+        assert self._transition_lock.locked(), "_open_fresh must hold the transition lock"
+        # Ensure a page exists to take over (a fresh session gets about:blank).
+        entry, _ = await self._ensure_entry(session_id)
+        _unlink_manifest(self._frames_dir)  # kill the stale-frame flash / cross-takeover leak
+        drain_s = max(1.0, (deadline - time.monotonic()) - _DRAIN_MARGIN_S)
+        # From close_and_drain onward the gate is CLOSED. Every exit that does
+        # not leave a takeover standing MUST reopen it — including a
+        # CancelledError from dispatch's deadline (a BaseException the
+        # `except Exception` below never sees). The `stood` flag + finally is
+        # the single reopen point; the reopen is synchronous so it runs during
+        # cancellation unwinding.
+        stood = False
+        screencast: Screencast | None = None
+        try:
+            if not await self._gate.close_and_drain(drain_s):
+                return error_response(
+                    boot, self.epoch, "action_timeout", "timed out draining in-flight actions"
+                )
+            # Re-read the active page AFTER the drain — it is stable now (no
+            # agent action can be mid-navigation), and a drained action may have
+            # left a popup frontmost.
+            page = entry.active_page
+            if page is None:
+                return error_response(boot, self.epoch, "browser_crashed", "no page to take over")
+            target = {"url": page.url, "title": await _safe_title(page)}
+            signed_open = await self._signed_in_hosts()
+            self.epoch += 1
+            new_epoch = self.epoch
+            screencast = Screencast(
+                self._require_context(),
+                self._frames_dir,
+                boot=boot,
+                epoch=new_epoch,
+                next_seq=self._next_frame_seq,
+            )
+            await screencast.start(page)
+            takeover = Takeover(
+                grant_id=grant_id,
+                session_id=session_id,
+                epoch=new_epoch,
+                opened_at=now(),
+                screencast=screencast,
+                injector=InputInjector(page),
+                target=target,
+                signed_in_at_open=signed_open,
+            )
+            takeover.input_task = asyncio.get_running_loop().create_task(self._input_pump(takeover))
+            self._standing = takeover
+            stood = True  # no await between here and return — the flag is exact
+            self._ensure_watchdog()
+            log.info(
+                "takeover open (grant=%s session=%s epoch=%d)", grant_id, session_id, new_epoch
+            )
+            return self._open_result(target, boot, new_epoch)
+        except Exception as exc:
+            # A non-cancellation failure: stop a partially-started screencast and
+            # rotate again to drop any raced input. The finally reopens the gate.
+            if screencast is not None:
+                with contextlib.suppress(Exception):
+                    await screencast.stop()
+            self.epoch += 1
+            if isinstance(exc, TargetClosedError):
+                self._trigger_relaunch()
+                return error_response(
+                    boot, self.epoch, "browser_crashed", "the browser went away during open"
+                )
+            log.exception("takeover open failed")
+            return error_response(boot, self.epoch, "internal", first_line(exc))
+        finally:
+            if not stood:
+                self._gate.reopen()
+
+    async def _takeover_close(
+        self, request: BrowserRequest, boot: str, epoch: int
+    ) -> BrowserResponse:
+        grant_id = str(request.args.get("grant_id") or "")
+        # outcome is OPAQUE: recorded for the log, never validated (the reaper
+        # mints "expired"; a validating driver would reject reaper handbacks).
+        outcome = str(request.args.get("outcome") or "done")
+        async with self._transition_lock:
+            standing = self._standing
+            if standing is not None and standing.grant_id == grant_id:
+                handback = await self._finalize(standing, outcome)
+                return self._close_result(handback, boot, self.epoch)
+            if standing is not None:
+                return error_response(
+                    boot, epoch, "grant_mismatch", "a different takeover is in progress"
+                )
+            cached = self._replay.get(grant_id)
+            if cached is not None:
+                return self._close_result(cached, boot, epoch)
+            return error_response(boot, epoch, "no_takeover", f"no open takeover {grant_id}")
+
+    async def _finalize(self, takeover: Takeover, outcome: str) -> dict[str, Any]:
+        """Terminal-move a takeover: stop input+screencast (both JOINED), rotate
+        the epoch, capture the handback, reopen admission, cache for replay.
+        Called only under the transition lock (close, watchdog, relaunch).
+
+        The gate reopen + standing-clear run in a finally, so a dispatch-deadline
+        cancellation mid-handback (a BaseException) cannot leave the agent locked
+        out with a takeover that no longer stands. A cancelled close caches no
+        handback (the redrive then gets no_takeover) — but the agent is freed
+        immediately rather than waiting out the idle watchdog."""
+        assert self._transition_lock.locked(), "_finalize must hold the transition lock"
+        try:
+            if takeover.input_task is not None:
+                takeover.input_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await takeover.input_task
+            await takeover.screencast.stop()  # joins the pump — no frame lands after
+            self.epoch += 1  # close-side rotation drops input that raced the close
+            handback = await self._capture_handback(takeover)
+            self._replay.put(takeover.grant_id, handback)
+            log.info(
+                "takeover closed (grant=%s outcome=%s epoch=%d)",
+                takeover.grant_id,
+                outcome,
+                self.epoch,
+            )
+            return handback
+        finally:
+            self._gate.reopen()
+            if self._standing is takeover:
+                self._standing = None
+
+    async def _capture_handback(self, takeover: Takeover) -> dict[str, Any]:
+        entry = self._entries.get(takeover.session_id)
+        page = entry.active_page if entry else None
+        if entry is None or page is None:
+            return {"snapshot": None, "shot_path": None, "signed_in_hosts": [], "url": None}
+        shot_path: str | None = None
+        with contextlib.suppress(Exception):
+            # Bounded so the whole handback capture stays well inside dispatch's
+            # deadline — a hung page yields a partial handback, not a cancel.
+            shot_path = await actions.capture_shot(
+                page, self.workspace, prefix="handback", timeout_ms=_HANDBACK_SHOT_TIMEOUT_MS
+            )
+        snapshot: str | None = None
+        with contextlib.suppress(Exception):
+            snapshot, _ = await take_snapshot(page, entry)
+        url: str | None = None
+        with contextlib.suppress(Exception):
+            url = page.url
+        signed_now = await self._signed_in_hosts()
+        delta = sorted(set(signed_now) - set(takeover.signed_in_at_open))
+        return {"snapshot": snapshot, "shot_path": shot_path, "signed_in_hosts": delta, "url": url}
+
+    async def _input_pump(self, takeover: Takeover) -> None:
+        tailer = SpoolTailer(self._spool_path)
+        tailer.arm()  # from EOF — input written before the open is never replayed
+        try:
+            while True:
+                for batch in tailer.poll():
+                    if not self._accept_batch(takeover, batch):
+                        continue
+                    at = (batch.get("ts_ms") or 0) / 1000.0 or now()
+                    for event in batch.get("events") or []:
+                        if isinstance(event, dict):
+                            with contextlib.suppress(Exception):
+                                await takeover.injector.apply(event, at=at)
+                    takeover.last_input = now()
+                    takeover.last_seq = batch["seq"]  # _accept_batch verified int
+                await asyncio.sleep(_INPUT_POLL_S)
+        finally:
+            tailer.close()
+
+    def _accept_batch(self, takeover: Takeover, batch: dict[str, Any]) -> bool:
+        # The driver is the enforcement authority — drop anything not for the
+        # standing takeover at the current epoch beyond the last-applied seq.
+        # (The isinstance guard tolerates a malformed spool line the JSON parse
+        # let through — a non-int seq would else raise on the comparison.)
+        if batch.get("grant_id") != takeover.grant_id or batch.get("epoch") != takeover.epoch:
+            return False
+        seq = batch.get("seq")
+        return isinstance(seq, int) and seq > takeover.last_seq
+
+    def _ensure_watchdog(self) -> None:
+        if self._watchdog_task is None or self._watchdog_task.done():
+            self._watchdog_task = asyncio.get_running_loop().create_task(self._watchdog())
+
+    async def _watchdog(self) -> None:
+        """Idle/unclaimed/absolute-cap auto-close. Ticks while a takeover
+        stands, then exits (a later open restarts it)."""
+        while not self._closing:
+            await asyncio.sleep(_WATCHDOG_TICK_S)
+            async with self._transition_lock:
+                standing = self._standing
+                if standing is None:
+                    return
+                marker_mtime = _mtime(self._heartbeat_marker)
+                elapsed = now() - standing.opened_at
+                idle = now() - standing.liveness(marker_mtime)
+                unclaimed = (
+                    standing.is_unclaimed(marker_mtime)
+                    and elapsed >= DRIVER_TAKEOVER_UNCLAIMED_TIMEOUT_S
+                )
+                if (
+                    unclaimed
+                    or idle >= DRIVER_TAKEOVER_IDLE_TIMEOUT_S
+                    or elapsed >= _ABSOLUTE_CAP_S
+                ):
+                    await self._finalize(standing, "expired")
+
+    async def _retarget_takeover(self, session_id: str) -> None:
+        # The input pump is not serialized against this swap, so a single human
+        # gesture straddling the popup-adoption instant can split across the old
+        # and new page. Bounded and self-correcting (the swap is one assignment;
+        # click state resets) — a cosmetic input glitch for one gesture, not
+        # worth coordinating the pump around.
+        async with self._transition_lock:
+            standing = self._standing
+            if standing is None or standing.session_id != session_id:
+                return
+            entry = self._entries.get(session_id)
+            page = entry.active_page if entry else None
+            if page is None:
+                return
+            with contextlib.suppress(Exception):
+                await standing.screencast.retarget(page)
+            standing.injector.retarget(page)
+
+    def _open_result(self, target: dict[str, Any], boot: str, epoch: int) -> BrowserResponse:
+        # Page-blind top-level; the viewer reads and pins data.target.
+        return BrowserResponse(ok=True, boot=boot, epoch=epoch, data={"target": target})
+
+    def _close_result(self, handback: dict[str, Any], boot: str, epoch: int) -> BrowserResponse:
+        # The handback IS the observation — the takeover is over, so this is not
+        # page-blind; the worker reads url/snapshot/shot_path + signed_in_hosts.
+        return BrowserResponse(
+            ok=True,
+            boot=boot,
+            epoch=epoch,
+            url=handback.get("url"),
+            snapshot=handback.get("snapshot"),
+            shot_path=handback.get("shot_path"),
+            data={"signed_in_hosts": handback.get("signed_in_hosts") or []},
+        )
+
 
 # ── the restart ledger ────────────────────────────────────────────────────
+
+
+async def _safe_title(page: Page) -> str:
+    try:
+        return await page.title()
+    except Exception:
+        return ""
+
+
+def _unlink_manifest(frames_dir: Path) -> None:
+    with contextlib.suppress(OSError):
+        (frames_dir / "manifest.json").unlink(missing_ok=True)
+
+
+def _mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
 
 
 def _load_ledger(path: Path) -> dict[str, str]:

--- a/packages/aios-browser-driver/aios_browser_driver/takeover/__init__.py
+++ b/packages/aios-browser-driver/aios_browser_driver/takeover/__init__.py
@@ -1,0 +1,4 @@
+"""Human takeover: the admission gate, epoch state machine, screencast pump,
+input spool tailer, and injector (jarbot#106 §5.6)."""
+
+from __future__ import annotations

--- a/packages/aios-browser-driver/aios_browser_driver/takeover/injector.py
+++ b/packages/aios-browser-driver/aios_browser_driver/takeover/injector.py
@@ -1,0 +1,98 @@
+"""Replays the human's raw input events onto the takeover's active page.
+
+Deliberately built on playwright's ``page.mouse``/``page.keyboard`` rather than
+raw CDP: playwright already owns the key-name → keycode table and the
+modifier/button state machine (a held ``Shift`` from ``keyboard.down`` applies
+to later clicks; ``mouse.down`` then ``mouse.move`` drags), which is the bulk of
+what a hand-rolled CDP injector would re-implement. The driver adds only what
+the raw event stream lacks: multi-click detection (the wire vocabulary carries
+no click-count) and the current pointer position for wheel/press at a point.
+
+No credential guardrail here — a takeover is EXACTLY when the human enters
+their own password; the agent is gate-blocked and page-blind meanwhile.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+if TYPE_CHECKING:
+    from playwright.async_api import Page
+
+_Button = Literal["left", "middle", "right"]
+_MULTICLICK_WINDOW_S = 0.5
+_MULTICLICK_RADIUS_PX = 4.0
+
+
+class InputInjector:
+    def __init__(self, page: Page) -> None:
+        self._page = page
+        self._x = 0.0
+        self._y = 0.0
+        self._last_down_at = 0.0
+        self._last_down_x = 0.0
+        self._last_down_y = 0.0
+        self._click_count = 0
+
+    def retarget(self, page: Page) -> None:
+        """Follow the active page (a popup the human opened). Pointer/click
+        state resets — a gesture never spans two pages."""
+        self._page = page
+        self._click_count = 0
+
+    async def apply(self, event: dict[str, Any], *, at: float) -> None:
+        """Dispatch one input event. ``at`` is the batch's wall-clock time,
+        used for multi-click timing."""
+        etype = event.get("type")
+        if etype == "pointer_move":
+            await self._move(event)
+        elif etype == "pointer_down":
+            await self._move(event)
+            count = self._click_count_for(event, at)
+            await self._page.mouse.down(button=self._button(event), click_count=count)
+        elif etype == "pointer_up":
+            await self._move(event)
+            await self._page.mouse.up(
+                button=self._button(event), click_count=self._click_count or 1
+            )
+        elif etype == "wheel":
+            await self._move(event)
+            await self._page.mouse.wheel(_num(event, "dx"), _num(event, "dy"))
+        elif etype == "key_down":
+            await self._page.keyboard.down(_str(event, "key"))
+        elif etype == "key_up":
+            await self._page.keyboard.up(_str(event, "key"))
+        elif etype == "text":
+            await self._page.keyboard.insert_text(_str(event, "text"))
+        # An unknown type is ignored — the vocabulary is pinned, and a human's
+        # live driving must not stall on one odd line.
+
+    async def _move(self, event: dict[str, Any]) -> None:
+        if event.get("x") is not None and event.get("y") is not None:
+            self._x, self._y = _num(event, "x"), _num(event, "y")
+        await self._page.mouse.move(self._x, self._y)
+
+    def _button(self, event: dict[str, Any]) -> _Button:
+        button = event.get("button")
+        return cast(_Button, button) if button in ("left", "middle", "right") else "left"
+
+    def _click_count_for(self, event: dict[str, Any], at: float) -> int:
+        x, y = self._x, self._y
+        near = math.hypot(x - self._last_down_x, y - self._last_down_y) <= _MULTICLICK_RADIUS_PX
+        if at - self._last_down_at <= _MULTICLICK_WINDOW_S and near and self._click_count:
+            self._click_count = min(3, self._click_count + 1)
+        else:
+            self._click_count = 1
+        self._last_down_at, self._last_down_x, self._last_down_y = at, x, y
+        return self._click_count
+
+
+def _num(event: dict[str, Any], key: str) -> float:
+    value = event.get(key)
+    return float(value) if isinstance(value, int | float) else 0.0
+
+
+def _str(event: dict[str, Any], key: str) -> str:
+    value = event.get(key)
+    return value if isinstance(value, str) else ""

--- a/packages/aios-browser-driver/aios_browser_driver/takeover/screencast.py
+++ b/packages/aios-browser-driver/aios_browser_driver/takeover/screencast.py
@@ -1,0 +1,184 @@
+"""The takeover screencast pump.
+
+Subscribes to CDP ``Page.startScreencast`` and writes each throttled frame to
+``frames/frame-<seq>.jpg`` plus an atomically-renamed ``frames/manifest.json``
+the API tails. The invariants (red-team folds #9/#10/#14):
+
+* Every frame is ACKED (Chromium flow-controls on the ack); throttling skips
+  WRITES, never acks, so frames keep flowing while disk churn stays bounded.
+* The manifest is the publication barrier: it is renamed over its old copy only
+  after ``frame-<seq>.jpg`` is fully written, so a reader (the API) that follows
+  the manifest never sees a partial frame or a manifest pointing at a
+  half-written file. The previous frame is then unlinked, so the frames dir
+  holds ~one frame rather than growing unbounded (a reader mid-open of the
+  just-unlinked frame gets ENOENT, which the API already tolerates).
+* ``manifest["file"]`` is a frames-dir-relative BASENAME.
+* ``seq`` is monotonic per BOOT (the API ends the stream on a boot change and
+  advances on ``seq >``), so the counter is owned by the host and survives
+  across takeovers within one boot.
+* ``origin``/``security`` come from the committed main-frame URL (never pixels):
+  origin is the URL's scheme+host, security is derived from the scheme
+  (``https`` ⇒ secure). Chromium no longer emits ``Security.securityStateChanged``.
+* The reaper can delete the frames dir mid-write; every write recreates it and
+  tolerates ``ENOENT``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import json
+import logging
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from playwright.async_api import BrowserContext, CDPSession, Page
+
+log = logging.getLogger("aios_browser_driver.takeover.screencast")
+
+_PERSIST_INTERVAL_S = 0.2
+_JPEG_QUALITY = 70
+_MAX_W = 1280
+_MAX_H = 800
+
+
+class Screencast:
+    def __init__(
+        self,
+        context: BrowserContext,
+        frames_dir: Path,
+        *,
+        boot: str,
+        epoch: int,
+        next_seq: Callable[[], int],
+    ) -> None:
+        self._context = context
+        self._frames_dir = frames_dir
+        self._boot = boot
+        self._epoch = epoch
+        self._next_seq = next_seq
+        self._cdp: CDPSession | None = None
+        self._queue: asyncio.Queue[tuple[str, dict[str, Any], int]] = asyncio.Queue()
+        self._pump_task: asyncio.Task[None] | None = None
+        self._origin: str | None = None
+        self._security: str | None = None
+        self._last_persist = 0.0
+        self._last_frame: str | None = None
+
+    async def start(self, page: Page) -> None:
+        # A fresh queue and persist clock per (re)start, so a retarget never
+        # persists a stale old-page frame under the new page's origin.
+        self._queue = asyncio.Queue()
+        self._last_persist = 0.0
+        self._origin, self._security = _chrome_of(page.url)
+        cdp = await self._context.new_cdp_session(page)
+        self._cdp = cdp
+        await cdp.send("Page.enable")
+        cdp.on("Page.screencastFrame", self._on_frame)
+        cdp.on("Page.frameNavigated", self._on_nav)
+        await cdp.send(
+            "Page.startScreencast",
+            {"format": "jpeg", "quality": _JPEG_QUALITY, "maxWidth": _MAX_W, "maxHeight": _MAX_H},
+        )
+        self._pump_task = asyncio.get_running_loop().create_task(self._pump())
+
+    async def retarget(self, page: Page) -> None:
+        """Follow the active page — full stop on the old, start on the new; the
+        boot-scoped seq counter continues, so the viewer sees no restart."""
+        await self.stop()
+        await self.start(page)
+
+    async def stop(self) -> None:
+        """Stop the screencast and JOIN the pump before returning — the caller
+        rotates the epoch only once no more frames can be written."""
+        if self._cdp is not None:
+            with contextlib.suppress(Exception):
+                await self._cdp.send("Page.stopScreencast")
+        if self._pump_task is not None:
+            self._pump_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._pump_task
+            self._pump_task = None
+        if self._cdp is not None:
+            with contextlib.suppress(Exception):
+                await self._cdp.detach()
+            self._cdp = None
+
+    # ── CDP event handlers (sync — enqueue / record only) ─────────────────
+
+    def _on_frame(self, params: dict[str, Any]) -> None:
+        data = params.get("data")
+        session_id = params.get("sessionId")  # an int in the CDP wire format
+        if isinstance(data, str) and isinstance(session_id, int):
+            self._queue.put_nowait((data, params.get("metadata") or {}, session_id))
+
+    def _on_nav(self, params: dict[str, Any]) -> None:
+        frame = params.get("frame") or {}
+        if not frame.get("parentId"):  # main frame only
+            self._origin, self._security = _chrome_of(frame.get("url") or "")
+
+    # ── the pump ──────────────────────────────────────────────────────────
+
+    async def _pump(self) -> None:
+        while True:
+            data, metadata, session_id = await self._queue.get()
+            if self._cdp is not None:
+                with contextlib.suppress(Exception):
+                    await self._cdp.send("Page.screencastFrameAck", {"sessionId": session_id})
+            now = time.monotonic()
+            if now - self._last_persist < _PERSIST_INTERVAL_S:
+                continue  # throttle WRITES, never acks
+            self._last_persist = now
+            try:
+                self._persist(data, metadata)
+            except OSError as exc:
+                log.warning("frame persist failed: %s", exc)
+
+    def _persist(self, data_b64: str, metadata: dict[str, Any]) -> None:
+        seq = self._next_seq()
+        jpeg = base64.b64decode(data_b64)
+        self._frames_dir.mkdir(parents=True, exist_ok=True)
+        name = f"frame-{seq}.jpg"
+        # The frame file is written under a unique per-seq name, so it need not
+        # be atomic — the manifest rename below is the publication barrier and
+        # only names this frame once it is complete.
+        (self._frames_dir / name).write_bytes(jpeg)
+        manifest = {
+            "seq": seq,
+            "file": name,  # frames-dir-relative basename
+            "ts_ms": int(time.time() * 1000),
+            "epoch": self._epoch,
+            "boot": self._boot,
+            "origin": self._origin,
+            "security": self._security,
+            "w": int(metadata.get("deviceWidth") or _MAX_W),
+            "h": int(metadata.get("deviceHeight") or _MAX_H),
+        }
+        manifest_tmp = self._frames_dir / ".manifest.json.tmp"
+        manifest_tmp.write_text(json.dumps(manifest), "utf-8")
+        os.replace(manifest_tmp, self._frames_dir / "manifest.json")
+        # The manifest now names the new frame; drop the previous one so the dir
+        # stays O(1) instead of accumulating a frame every 200ms.
+        if self._last_frame is not None and self._last_frame != name:
+            with contextlib.suppress(OSError):
+                (self._frames_dir / self._last_frame).unlink()
+        self._last_frame = name
+
+
+def _chrome_of(url: str) -> tuple[str | None, str | None]:
+    """The trusted-chrome (origin, security) for a URL, both from the committed
+    URL alone — origin is scheme+host, security is ``secure`` for https,
+    ``insecure`` for http, ``None`` for anything else (about:blank, data:)."""
+    parts = urlsplit(url)
+    if not parts.scheme or not parts.netloc:
+        return None, None
+    security = (
+        "secure" if parts.scheme == "https" else "insecure" if parts.scheme == "http" else None
+    )
+    return f"{parts.scheme}://{parts.netloc}", security

--- a/packages/aios-browser-driver/aios_browser_driver/takeover/spool.py
+++ b/packages/aios-browser-driver/aios_browser_driver/takeover/spool.py
@@ -1,0 +1,102 @@
+"""The input-spool tailer.
+
+Tails ``input/spool.jsonl`` — the append-only JSONL the API writes the human's
+input to. Two hazards drive the design (red-team fold #13):
+
+* The reaper UNLINKS and recreates the spool, so the tailer is inode-aware:
+  it adopts a new file by ``open``-then-``fstat`` (never ``stat``-then-``open``,
+  which could adopt a different inode than it checked), and drains the old fd
+  to EOF before switching so no line is lost across the swap.
+* A partial line (the API's append and our read interleave) is buffered until
+  its newline arrives; a line that will not parse is skipped and logged, never
+  fatal to the tailer.
+
+The tailer returns parsed batch dicts; the caller (the controller) owns the
+grant/epoch/seq filtering, since only it knows the standing takeover.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("aios_browser_driver.takeover.spool")
+
+_READ_CHUNK = 65536
+
+
+class SpoolTailer:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fd: int | None = None
+        self._ino: int | None = None
+        self._buf = b""
+
+    def arm(self) -> None:
+        """Open the spool at its CURRENT end, so input written before the
+        takeover opened is never replayed. Absent spool → armed empty; the
+        first :meth:`poll` adopts it when it appears."""
+        try:
+            fd = os.open(self._path, os.O_RDONLY)
+        except FileNotFoundError:
+            return
+        os.lseek(fd, 0, os.SEEK_END)
+        self._fd, self._ino = fd, os.fstat(fd).st_ino
+
+    def close(self) -> None:
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd, self._ino = None, None
+        self._buf = b""
+
+    def poll(self) -> list[dict[str, Any]]:
+        """Return every complete batch appended since the last poll, following
+        an inode rotation if the reaper recreated the spool."""
+        lines: list[bytes] = []
+        if self._fd is not None:
+            lines += self._drain(self._fd)
+        lines += self._follow_rotation()
+        return [b for b in (self._parse(raw) for raw in lines) if b is not None]
+
+    def _follow_rotation(self) -> list[bytes]:
+        try:
+            new_fd = os.open(self._path, os.O_RDONLY)
+        except FileNotFoundError:
+            return []  # unlinked and not yet recreated — retry next poll
+        new_ino = os.fstat(new_fd).st_ino
+        if self._ino == new_ino:
+            os.close(new_fd)  # same file, already drained above
+            return []
+        # A fresh inode: the old fd was drained to EOF above; adopt the new
+        # file from its start (a recreated spool begins empty). Drop any
+        # buffered partial — its completion lived on the old inode, now gone.
+        if self._fd is not None:
+            os.close(self._fd)
+        self._fd, self._ino, self._buf = new_fd, new_ino, b""
+        return self._drain(new_fd)
+
+    def _drain(self, fd: int) -> list[bytes]:
+        while True:
+            chunk = os.read(fd, _READ_CHUNK)
+            if not chunk:
+                break
+            self._buf += chunk
+        if b"\n" not in self._buf:
+            return []
+        *complete, self._buf = self._buf.split(b"\n")
+        return complete
+
+    def _parse(self, raw: bytes) -> dict[str, Any] | None:
+        if not raw.strip():
+            return None
+        try:
+            doc = json.loads(raw)
+        except ValueError:
+            log.warning("dropping malformed spool line (%d bytes)", len(raw))
+            return None
+        if not isinstance(doc, dict):
+            return None
+        return doc

--- a/packages/aios-browser-driver/aios_browser_driver/takeover/state.py
+++ b/packages/aios-browser-driver/aios_browser_driver/takeover/state.py
@@ -1,0 +1,128 @@
+"""The takeover admission gate and the standing-takeover record.
+
+The gate is the barrier between agent actions and a human takeover. Its
+contract is the delicate part (jarbot#106 §5.6, red-team folds):
+
+* ``admit`` is SYNCHRONOUS — a closed-check and a count-increment with no
+  await between — so an action either fully enters before the gate closes or
+  is refused. ``close_and_drain`` sets ``closed`` (synchronously) BEFORE
+  awaiting the in-flight count to reach zero, so no action can slip in after
+  the drain begins. Together these mean the epoch rotates only once every
+  admitted action has finished — a human's input can never land under agent
+  control, nor an agent action under the human's.
+* On a drain that times out, the caller reopens the gate and FAILS the open;
+  the epoch never rotates while actions are in flight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aios_browser_driver.takeover.injector import InputInjector
+    from aios_browser_driver.takeover.screencast import Screencast
+
+# LRU depth of the closed-takeover handback cache — a redriven ``takeover_close``
+# for an already-closed grant replays its cached handback instead of erroring.
+_REPLAY_CACHE_MAX = 8
+
+
+class AdmissionGate:
+    """Serializes agent actions against a takeover. Open: actions ``admit``.
+    Closing: new actions are refused and the in-flight ones drain to zero
+    before the caller rotates the epoch."""
+
+    def __init__(self) -> None:
+        self._closed = False
+        self._active = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def admit(self) -> bool:
+        """Synchronously admit one action, or refuse if the gate is closed.
+        No await between the check and the increment — the drain cannot race
+        an admission in."""
+        if self._closed:
+            return False
+        self._active += 1
+        self._idle.clear()
+        return True
+
+    def release(self) -> None:
+        # Paired one-to-one with a successful admit() in the caller's finally,
+        # so _active never goes negative.
+        self._active -= 1
+        if self._active == 0:
+            self._idle.set()
+
+    async def close_and_drain(self, drain_timeout_s: float) -> bool:
+        """Close the gate and wait for in-flight actions to finish. Returns
+        True if drained within ``drain_timeout_s``, False otherwise (the caller
+        then reopens and fails the open)."""
+        self._closed = True
+        if self._active == 0:
+            return True
+        try:
+            await asyncio.wait_for(self._idle.wait(), drain_timeout_s)
+            return True
+        except TimeoutError:
+            return False
+
+    def reopen(self) -> None:
+        self._closed = False
+
+
+@dataclass
+class Takeover:
+    """The one standing takeover. ``opened_at``/``last_input`` are wall-clock
+    seconds; the watchdog folds in the heartbeat marker's mtime for liveness."""
+
+    grant_id: str
+    session_id: str
+    epoch: int
+    opened_at: float
+    screencast: Screencast
+    injector: InputInjector
+    target: dict[str, Any]
+    signed_in_at_open: list[str] = field(default_factory=list)
+    input_task: asyncio.Task[None] | None = None
+    last_input: float = 0.0
+    last_seq: int = 0  # highest input-spool seq applied (per this takeover)
+
+    def liveness(self, marker_mtime: float) -> float:
+        return max(self.opened_at, self.last_input, marker_mtime)
+
+    def is_unclaimed(self, marker_mtime: float) -> bool:
+        """No input line AND no heartbeat-marker touch since it opened — the
+        ack was produced but no viewer ever attached."""
+        return self.last_input == 0.0 and marker_mtime <= self.opened_at
+
+
+class ReplayCache:
+    """Closed-grant → handback, bounded FIFO. Lets a redriven close of an
+    already-finalized grant replay the real handback. Grant ids are single-use
+    and a redrive lands right after its own close — well inside the window — so
+    insertion order suffices; no access-recency bookkeeping is needed."""
+
+    def __init__(self, maxlen: int = _REPLAY_CACHE_MAX) -> None:
+        self._store: dict[str, dict[str, Any]] = {}
+        self._maxlen = maxlen
+
+    def put(self, grant_id: str, handback: dict[str, Any]) -> None:
+        self._store[grant_id] = handback
+        while len(self._store) > self._maxlen:
+            del self._store[next(iter(self._store))]  # evict oldest insertion
+
+    def get(self, grant_id: str) -> dict[str, Any] | None:
+        return self._store.get(grant_id)
+
+
+def now() -> float:
+    return time.time()

--- a/packages/aios-browser-driver/tests/test_admission_gate.py
+++ b/packages/aios-browser-driver/tests/test_admission_gate.py
@@ -1,0 +1,59 @@
+"""The admission gate: synchronous admit, drain-to-zero, timeout, reopen."""
+
+from __future__ import annotations
+
+import asyncio
+
+from aios_browser_driver.takeover.state import AdmissionGate
+
+
+async def test_admit_release_and_idle() -> None:
+    gate = AdmissionGate()
+    assert gate.admit() is True
+    assert gate.admit() is True  # two in flight
+    gate.release()
+    gate.release()
+    # Idle again → a fresh close drains instantly.
+    assert await gate.close_and_drain(0.01) is True
+
+
+async def test_closed_gate_refuses_admission() -> None:
+    gate = AdmissionGate()
+    assert await gate.close_and_drain(0.01) is True
+    assert gate.closed is True
+    assert gate.admit() is False
+
+
+async def test_close_waits_for_in_flight_then_drains() -> None:
+    gate = AdmissionGate()
+    assert gate.admit() is True  # one action in flight
+    drain = asyncio.create_task(gate.close_and_drain(1.0))
+    await asyncio.sleep(0.01)
+    assert not drain.done()  # blocked on the in-flight action
+    assert gate.admit() is False  # closed the instant close_and_drain began
+    gate.release()
+    assert await drain is True
+
+
+async def test_drain_timeout_returns_false() -> None:
+    gate = AdmissionGate()
+    assert gate.admit() is True
+    assert await gate.close_and_drain(0.02) is False  # never released
+    # The caller reopens and the gate admits again.
+    gate.reopen()
+    assert gate.admit() is True
+
+
+async def test_admit_is_synchronous_no_await_window() -> None:
+    # admit() must not await between the closed-check and the increment, or a
+    # concurrent close could slip a drain in. Exercised by racing many admits
+    # against a close on one event-loop tick.
+    gate = AdmissionGate()
+    admitted = [gate.admit() for _ in range(5)]
+    assert all(admitted)
+    drain = asyncio.create_task(gate.close_and_drain(1.0))
+    await asyncio.sleep(0)
+    assert gate.admit() is False
+    for _ in range(5):
+        gate.release()
+    assert await drain is True

--- a/packages/aios-browser-driver/tests/test_injector.py
+++ b/packages/aios-browser-driver/tests/test_injector.py
@@ -1,0 +1,106 @@
+"""The input injector maps the raw event vocabulary onto playwright's page
+API and detects multi-clicks (the wire carries no click count)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios_browser_driver.takeover.injector import InputInjector
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def _record(self, name: str) -> Any:
+        async def method(*args: Any, **kwargs: Any) -> None:
+            self.calls.append((name, args, kwargs))
+
+        return method
+
+
+class _FakeMouse(_Recorder):
+    def __init__(self) -> None:
+        super().__init__()
+        self.move = self._record("move")
+        self.down = self._record("down")
+        self.up = self._record("up")
+        self.wheel = self._record("wheel")
+
+
+class _FakeKeyboard(_Recorder):
+    def __init__(self) -> None:
+        super().__init__()
+        self.down = self._record("down")
+        self.up = self._record("up")
+        self.insert_text = self._record("insert_text")
+
+
+class _FakePage:
+    def __init__(self) -> None:
+        self.mouse = _FakeMouse()
+        self.keyboard = _FakeKeyboard()
+
+
+async def test_pointer_and_wheel_map_to_mouse() -> None:
+    page = _FakePage()
+    inj = InputInjector(page)  # type: ignore[arg-type]
+    await inj.apply({"type": "pointer_move", "x": 5, "y": 6}, at=0.0)
+    await inj.apply({"type": "pointer_down", "x": 5, "y": 6, "button": "right"}, at=0.0)
+    await inj.apply({"type": "pointer_up", "x": 5, "y": 6, "button": "right"}, at=0.0)
+    await inj.apply({"type": "wheel", "x": 5, "y": 6, "dx": 0, "dy": 120}, at=0.0)
+
+    assert ("move", (5.0, 6.0), {}) in page.mouse.calls
+    down = next(c for c in page.mouse.calls if c[0] == "down")
+    assert down[2]["button"] == "right" and down[2]["click_count"] == 1
+    assert ("wheel", (0.0, 120.0), {}) in page.mouse.calls
+
+
+async def test_keys_and_text_map_to_keyboard() -> None:
+    page = _FakePage()
+    inj = InputInjector(page)  # type: ignore[arg-type]
+    await inj.apply({"type": "key_down", "key": "Enter"}, at=0.0)
+    await inj.apply({"type": "key_up", "key": "Enter"}, at=0.0)
+    await inj.apply({"type": "text", "text": "hi"}, at=0.0)
+
+    assert ("down", ("Enter",), {}) in page.keyboard.calls
+    assert ("up", ("Enter",), {}) in page.keyboard.calls
+    assert ("insert_text", ("hi",), {}) in page.keyboard.calls
+
+
+async def test_double_click_detected_from_two_rapid_downs() -> None:
+    page = _FakePage()
+    inj = InputInjector(page)  # type: ignore[arg-type]
+    await inj.apply({"type": "pointer_down", "x": 10, "y": 10, "button": "left"}, at=0.0)
+    await inj.apply({"type": "pointer_up", "x": 10, "y": 10, "button": "left"}, at=0.05)
+    await inj.apply({"type": "pointer_down", "x": 10, "y": 10, "button": "left"}, at=0.1)
+
+    downs = [c for c in page.mouse.calls if c[0] == "down"]
+    assert downs[0][2]["click_count"] == 1
+    assert downs[1][2]["click_count"] == 2
+
+
+async def test_far_apart_downs_are_single_clicks() -> None:
+    page = _FakePage()
+    inj = InputInjector(page)  # type: ignore[arg-type]
+    await inj.apply({"type": "pointer_down", "x": 10, "y": 10, "button": "left"}, at=0.0)
+    await inj.apply({"type": "pointer_down", "x": 200, "y": 200, "button": "left"}, at=0.1)
+    downs = [c for c in page.mouse.calls if c[0] == "down"]
+    assert downs[0][2]["click_count"] == 1
+    assert downs[1][2]["click_count"] == 1  # moved too far to be a double-click
+
+
+async def test_unknown_event_type_is_ignored() -> None:
+    page = _FakePage()
+    inj = InputInjector(page)  # type: ignore[arg-type]
+    await inj.apply({"type": "teleport"}, at=0.0)
+    assert page.mouse.calls == [] and page.keyboard.calls == []
+
+
+async def test_wheel_uses_last_pointer_position_when_absent() -> None:
+    page = _FakePage()
+    inj = InputInjector(page)  # type: ignore[arg-type]
+    await inj.apply({"type": "pointer_move", "x": 30, "y": 40}, at=0.0)
+    await inj.apply({"type": "wheel", "dx": 0, "dy": 10}, at=0.0)
+    moves = [c for c in page.mouse.calls if c[0] == "move"]
+    assert moves[-1] == ("move", (30.0, 40.0), {})  # wheel re-moved to last xy

--- a/packages/aios-browser-driver/tests/test_replay_cache.py
+++ b/packages/aios-browser-driver/tests/test_replay_cache.py
@@ -1,0 +1,35 @@
+"""The closed-grant replay cache: bounded LRU with recency on get and put."""
+
+from __future__ import annotations
+
+from aios_browser_driver.takeover.state import ReplayCache
+
+
+def test_get_returns_the_stored_handback() -> None:
+    cache = ReplayCache(maxlen=3)
+    cache.put("g1", {"url": "https://a.test"})
+    assert cache.get("g1") == {"url": "https://a.test"}
+    assert cache.get("absent") is None
+
+
+def test_evicts_the_least_recently_used_beyond_maxlen() -> None:
+    cache = ReplayCache(maxlen=2)
+    cache.put("g1", {"n": 1})
+    cache.put("g2", {"n": 2})
+    cache.put("g3", {"n": 3})  # evicts g1
+    assert cache.get("g1") is None
+    assert cache.get("g2") == {"n": 2}
+    assert cache.get("g3") == {"n": 3}
+
+
+def test_eviction_is_insertion_order_not_access_order() -> None:
+    # FIFO: a get does NOT refresh recency (grant ids are single-use, so
+    # access-recency would be dead bookkeeping).
+    cache = ReplayCache(maxlen=2)
+    cache.put("g1", {"n": 1})
+    cache.put("g2", {"n": 2})
+    assert cache.get("g1") == {"n": 1}  # reading g1 does not save it
+    cache.put("g3", {"n": 3})  # evicts g1 (oldest insertion), regardless of the read
+    assert cache.get("g1") is None
+    assert cache.get("g2") == {"n": 2}
+    assert cache.get("g3") == {"n": 3}

--- a/packages/aios-browser-driver/tests/test_screencast_writer.py
+++ b/packages/aios-browser-driver/tests/test_screencast_writer.py
@@ -1,0 +1,99 @@
+"""The screencast frame writer: basename manifest, per-boot seq, atomic
+writes, and ENOENT tolerance when the reaper deletes the frames dir."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from aios_browser_driver.takeover.screencast import Screencast, _chrome_of
+
+_JPEG = base64.b64encode(b"\xff\xd8\xff\xe0jpegbytes\xff\xd9").decode("ascii")
+
+
+def _screencast(frames_dir: Path) -> Screencast:
+    seq = iter(range(1, 1000))
+    return Screencast(
+        cast(Any, None),  # the context is unused by _persist
+        frames_dir,
+        boot="01BOOT",
+        epoch=7,
+        next_seq=lambda: next(seq),
+    )
+
+
+def test_persist_writes_a_basename_manifest_and_a_complete_frame(tmp_path: Path) -> None:
+    frames = tmp_path / "frames"
+    sc = _screencast(frames)
+    sc._persist(_JPEG, {"deviceWidth": 1280, "deviceHeight": 800})
+
+    manifest = json.loads((frames / "manifest.json").read_text())
+    assert manifest["seq"] == 1
+    assert manifest["file"] == "frame-1.jpg"  # frames-dir-relative BASENAME
+    assert "/" not in manifest["file"]
+    assert manifest["epoch"] == 7 and manifest["boot"] == "01BOOT"
+    assert manifest["w"] == 1280 and manifest["h"] == 800
+    # The frame the manifest points at exists and holds the whole JPEG.
+    assert (frames / manifest["file"]).read_bytes() == base64.b64decode(_JPEG)
+
+
+def test_no_temp_files_survive_a_write(tmp_path: Path) -> None:
+    frames = tmp_path / "frames"
+    sc = _screencast(frames)
+    sc._persist(_JPEG, {})
+    # tmp+rename leaves no partial artifacts a reader could trip over.
+    leftovers = [p.name for p in frames.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_seq_advances_and_the_previous_frame_is_unlinked(tmp_path: Path) -> None:
+    frames = tmp_path / "frames"
+    sc = _screencast(frames)
+    sc._persist(_JPEG, {})
+    sc._persist(_JPEG, {})
+    manifest = json.loads((frames / "manifest.json").read_text())
+    assert manifest["seq"] == 2
+    # The dir stays O(1): only the current frame survives, the previous is gone.
+    assert (frames / "frame-2.jpg").exists()
+    assert not (frames / "frame-1.jpg").exists()
+
+
+def test_persist_recreates_a_deleted_frames_dir(tmp_path: Path) -> None:
+    frames = tmp_path / "frames"
+    sc = _screencast(frames)
+    sc._persist(_JPEG, {})
+    # The reaper deletes the dir between frames; the next persist recreates it.
+    for child in frames.iterdir():
+        child.unlink()
+    frames.rmdir()
+    sc._persist(_JPEG, {})
+    assert (frames / "manifest.json").exists()
+
+
+def test_missing_dimensions_fall_back_to_the_viewport(tmp_path: Path) -> None:
+    frames = tmp_path / "frames"
+    sc = _screencast(frames)
+    sc._persist(_JPEG, {})  # no metadata
+    manifest = json.loads((frames / "manifest.json").read_text())
+    assert manifest["w"] == 1280 and manifest["h"] == 800
+
+
+def test_on_frame_enqueues_int_session_ids(tmp_path: Path) -> None:
+    # CDP delivers screencastFrame.sessionId as an INT — a str-only guard would
+    # silently drop every frame (regression guard).
+    sc = _screencast(tmp_path / "frames")
+    sc._on_frame({"data": _JPEG, "sessionId": 7, "metadata": {}})
+    assert sc._queue.qsize() == 1
+    _data, _meta, session_id = sc._queue.get_nowait()
+    assert session_id == 7
+
+
+def test_chrome_derives_security_from_the_url_scheme() -> None:
+    # Chromium stopped emitting Security.securityStateChanged, so security is
+    # derived from the committed URL's scheme, not a dead CDP event.
+    assert _chrome_of("https://bank.example/login") == ("https://bank.example", "secure")
+    assert _chrome_of("http://shop.example/") == ("http://shop.example", "insecure")
+    assert _chrome_of("about:blank") == (None, None)
+    assert _chrome_of("data:text/html,x") == (None, None)

--- a/packages/aios-browser-driver/tests/test_spool_tailer.py
+++ b/packages/aios-browser-driver/tests/test_spool_tailer.py
@@ -1,0 +1,88 @@
+"""The input-spool tailer: EOF arming, partial-line buffering, malformed-skip,
+and inode rotation (the reaper unlinks and recreates the spool)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aios_browser_driver.takeover.spool import SpoolTailer
+
+
+def _batch(seq: int) -> str:
+    return json.dumps({"grant_id": "g", "epoch": 1, "seq": seq, "events": []}) + "\n"
+
+
+def test_arms_from_eof_so_pre_takeover_input_is_not_replayed(tmp_path: Path) -> None:
+    spool = tmp_path / "spool.jsonl"
+    spool.write_text(_batch(1) + _batch(2), "utf-8")  # written before the open
+    tailer = SpoolTailer(spool)
+    tailer.arm()
+    assert tailer.poll() == []  # nothing after EOF
+    spool.write_text(spool.read_text() + _batch(3), "utf-8")
+    assert [b["seq"] for b in tailer.poll()] == [3]
+    tailer.close()
+
+
+def test_absent_spool_is_adopted_on_first_appearance(tmp_path: Path) -> None:
+    spool = tmp_path / "spool.jsonl"
+    tailer = SpoolTailer(spool)
+    tailer.arm()  # file does not exist yet
+    assert tailer.poll() == []
+    spool.write_text(_batch(1), "utf-8")
+    assert [b["seq"] for b in tailer.poll()] == [1]
+    tailer.close()
+
+
+def test_partial_line_is_buffered_until_its_newline(tmp_path: Path) -> None:
+    spool = tmp_path / "spool.jsonl"
+    spool.write_text("", "utf-8")
+    tailer = SpoolTailer(spool)
+    tailer.arm()
+    with spool.open("a") as fh:
+        fh.write('{"grant_id": "g", "epoch": 1, "seq": 5, "eve')
+    assert tailer.poll() == []  # incomplete — no newline yet
+    with spool.open("a") as fh:
+        fh.write('nts": []}\n')
+    assert [b["seq"] for b in tailer.poll()] == [5]
+    tailer.close()
+
+
+def test_malformed_line_is_skipped_not_fatal(tmp_path: Path) -> None:
+    spool = tmp_path / "spool.jsonl"
+    spool.write_text("", "utf-8")
+    tailer = SpoolTailer(spool)
+    tailer.arm()
+    spool.write_text("not json at all\n" + _batch(7), "utf-8")
+    assert [b["seq"] for b in tailer.poll()] == [7]  # bad line dropped, good one kept
+    tailer.close()
+
+
+def test_inode_rotation_drains_old_then_follows_new(tmp_path: Path) -> None:
+    spool = tmp_path / "spool.jsonl"
+    spool.write_text("", "utf-8")
+    tailer = SpoolTailer(spool)
+    tailer.arm()
+    spool.write_text(_batch(1), "utf-8")
+    assert [b["seq"] for b in tailer.poll()] == [1]
+
+    # The reaper unlinks and recreates the spool with a fresh inode.
+    spool.unlink()
+    spool.write_text(_batch(2), "utf-8")
+    assert [b["seq"] for b in tailer.poll()] == [2]  # adopted the new file from its start
+    tailer.close()
+
+
+def test_rotation_does_not_lose_the_tail_of_the_old_file(tmp_path: Path) -> None:
+    spool = tmp_path / "spool.jsonl"
+    spool.write_text("", "utf-8")
+    tailer = SpoolTailer(spool)
+    tailer.arm()
+    # Old file gains a line we never polled; then it rotates. The unpolled tail
+    # must still be drained before switching.
+    spool.write_text(_batch(1), "utf-8")
+    spool.rename(tmp_path / "old.jsonl")
+    spool.write_text(_batch(2), "utf-8")
+    seqs = [b["seq"] for b in tailer.poll()]
+    assert seqs == [1, 2]
+    tailer.close()

--- a/packages/aios-browser-driver/tests/test_takeover_host_browser.py
+++ b/packages/aios-browser-driver/tests/test_takeover_host_browser.py
@@ -1,0 +1,224 @@
+"""The takeover lifecycle against a real BrowserHost + Chromium (opt-in:
+``pytest -m browser``). Exercises the epoch state machine, gate blocking,
+idempotency, replay, and the screencast plumbing end to end over a loopback
+fixture page."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import http.server
+import json
+import socketserver
+import threading
+import time
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aios_browser_driver import host as host_mod
+from aios_browser_driver.browser_protocol import BrowserRequest
+from aios_browser_driver.host import BrowserHost
+
+pytestmark = pytest.mark.browser
+
+_HTML = b"<!doctype html><html><body><h1>Takeover fixture</h1><button>Go</button></body></html>"
+
+
+@pytest.fixture
+def server() -> Iterator[str]:
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(_HTML)))
+            self.end_headers()
+            self.wfile.write(_HTML)
+
+        def log_message(self, *args: Any) -> None:
+            pass
+
+    srv = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}/"
+    finally:
+        srv.shutdown()
+
+
+@pytest.fixture
+async def host(tmp_path: Path) -> AsyncIterator[BrowserHost]:
+    from playwright.async_api import Error
+
+    for sub in ("profile", "frames", "shots", "downloads", "input"):
+        (tmp_path / sub).mkdir()
+    h = BrowserHost(workspace=tmp_path, allow_private_nav=True)
+    try:
+        await h.start()
+    except Error as exc:
+        pytest.skip(f"playwright chromium not installed: {exc}")
+    yield h
+    await h.close()
+
+
+async def _handle(h: BrowserHost, op: str, **kw: Any) -> Any:
+    session_id = kw.pop("session_id", None)
+    request = BrowserRequest(op=op, session_id=session_id, args=dict(kw))
+    return await h.handle(request, deadline=time.monotonic() + 30)
+
+
+async def _land_on_fixture(h: BrowserHost, server: str, session_id: str) -> None:
+    resp = await _handle(h, "navigate", session_id=session_id, url=server, description="open")
+    assert resp.ok, resp.error
+
+
+async def test_open_close_lifecycle(host: BrowserHost, server: str) -> None:
+    await _land_on_fixture(host, server, "s1")
+
+    opened = await _handle(host, "takeover_open", session_id="s1", grant_id="g1", reason="login")
+    assert opened.ok
+    assert opened.data["target"]["url"] == server
+    assert opened.snapshot is None and opened.url is None  # page-blind top level
+    open_epoch = opened.epoch
+    assert open_epoch > 0
+
+    # An agent action is refused, page-blind, while the human holds the browser.
+    blocked = await _handle(host, "snapshot", session_id="s1")
+    assert not blocked.ok and blocked.error.code == "takeover_active"
+    assert blocked.snapshot is None and blocked.tabs == []
+
+    # A competing open for a different grant is refused without disturbing g1.
+    competing = await _handle(host, "takeover_open", session_id="s1", grant_id="g2")
+    assert competing.error.code == "takeover_active"
+
+    # Idempotent re-open of the SAME grant echoes the original epoch.
+    echo = await _handle(host, "takeover_open", session_id="s1", grant_id="g1")
+    assert echo.ok and echo.epoch == open_epoch
+
+    # Close hands back — url populated, epoch rotates again.
+    closed = await _handle(host, "takeover_close", grant_id="g1", outcome="done")
+    assert closed.ok and closed.epoch > open_epoch
+    assert closed.url is not None  # A2 fold: close must populate url
+
+    # After close, the agent can act again.
+    acted = await _handle(host, "snapshot", session_id="s1")
+    assert acted.ok
+
+
+async def test_close_replays_from_cache_and_unknown_is_no_takeover(
+    host: BrowserHost, server: str
+) -> None:
+    await _land_on_fixture(host, server, "s1")
+    await _handle(host, "takeover_open", session_id="s1", grant_id="g1")
+    first = await _handle(host, "takeover_close", grant_id="g1")
+    replay = await _handle(host, "takeover_close", grant_id="g1")
+    assert replay.ok and replay.url == first.url
+
+    unknown = await _handle(host, "takeover_close", grant_id="gX")
+    assert unknown.error.code == "no_takeover"
+
+
+async def test_grant_mismatch_close(host: BrowserHost, server: str) -> None:
+    await _land_on_fixture(host, server, "s1")
+    await _handle(host, "takeover_open", session_id="s1", grant_id="g1")
+    mismatch = await _handle(host, "takeover_close", grant_id="other")
+    assert mismatch.error.code == "grant_mismatch"
+
+
+async def test_screencast_writes_a_frame_manifest(
+    host: BrowserHost, server: str, tmp_path: Path
+) -> None:
+    await _land_on_fixture(host, server, "s1")
+    await _handle(host, "takeover_open", session_id="s1", grant_id="g1")
+
+    manifest_path = tmp_path / "frames" / "manifest.json"
+    for _ in range(50):
+        if manifest_path.exists():
+            break
+        await asyncio.sleep(0.1)
+    assert manifest_path.exists(), "screencast never wrote a manifest"
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["boot"] == host.boot
+    assert manifest["file"] == f"frame-{manifest['seq']}.jpg"
+    assert "/" not in manifest["file"]
+    assert manifest["security"] == "insecure"  # http fixture, derived from scheme
+    assert manifest["origin"] == server.rstrip("/")
+    assert (tmp_path / "frames" / manifest["file"]).exists()
+    await _handle(host, "takeover_close", grant_id="g1")
+
+
+async def test_cancelled_open_reopens_the_gate(
+    host: BrowserHost, server: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # THE critical regression: a dispatch-deadline cancellation lands inside
+    # takeover_open AFTER the gate has closed. If the rollback only caught
+    # Exception (not the BaseException CancelledError), the gate would wedge
+    # closed forever and every agent action would return takeover_active.
+    await _land_on_fixture(host, server, "s1")
+    started = asyncio.Event()
+
+    class _HangingScreencast:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def start(self, page: Any) -> None:
+            started.set()
+            await asyncio.Event().wait()  # never returns — the open parks here
+
+        async def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(host_mod, "Screencast", _HangingScreencast)
+    task = asyncio.create_task(_handle(host, "takeover_open", session_id="s1", grant_id="g1"))
+    await asyncio.wait_for(started.wait(), timeout=10)  # gate is now closed, parked in start()
+    assert host._gate.closed is True
+
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    # The finally must have reopened the gate and left no standing takeover.
+    assert host._gate.closed is False
+    assert host._standing is None
+    # And an agent action is admitted again — not wedged at takeover_active.
+    acted = await _handle(host, "snapshot", session_id="s1")
+    assert acted.ok
+
+
+async def test_input_spool_drives_the_page(host: BrowserHost, server: str, tmp_path: Path) -> None:
+    await _land_on_fixture(host, server, "s1")
+    opened = await _handle(host, "takeover_open", session_id="s1", grant_id="g1")
+    epoch = opened.epoch
+
+    # A current-epoch batch is applied; a stale-epoch batch is dropped. We prove
+    # application by observing that no exception tears down the takeover and the
+    # close still succeeds after replaying input.
+    spool = tmp_path / "input" / "spool.jsonl"
+    batches = [
+        {
+            "grant_id": "g1",
+            "epoch": epoch,
+            "seq": 1,
+            "events": [{"type": "pointer_move", "x": 5, "y": 5}],
+        },
+        {"grant_id": "g1", "epoch": epoch - 1, "seq": 2, "events": [{"type": "text", "text": "x"}]},
+        {"grant_id": "other", "epoch": epoch, "seq": 3, "events": [{"type": "text", "text": "y"}]},
+    ]
+    spool.write_text("".join(json.dumps(b) + "\n" for b in batches), "utf-8")
+    await asyncio.sleep(0.3)  # let the input pump drain a couple of polls
+
+    closed = await _handle(host, "takeover_close", grant_id="g1")
+    assert closed.ok
+    assert host._standing is None
+
+
+async def test_status_answers_during_a_takeover(host: BrowserHost, server: str) -> None:
+    await _land_on_fixture(host, server, "s1")
+    await _handle(host, "takeover_open", session_id="s1", grant_id="g1")
+    status = await _handle(host, "status")
+    assert status.ok and "signed_in_hosts" in status.data
+    # revoke_site, by contrast, refuses during a takeover.
+    revoke = await _handle(host, "revoke_site", host="example.com")
+    assert revoke.error.code == "takeover_active"


### PR DESCRIPTION
## Phase 2, PR3 of 5 — the human-takeover state machine

Third PR of the jarbot#106 **Phase 2** stack. Lands the takeover machinery the two `NotImplemented` ops stood in for: a human drives the account's browser directly while the agent is **gate-blocked and page-blind**, with a live screencast streaming out and an input spool coming in. **Ships dark** — the rollout gate is unchanged.

> **Stacked on #2284** (`feat/browser-driver-core`). Review the [PR2↔PR3 diff](https://github.com/eumemic/aios/compare/feat/browser-driver-core...feat/browser-driver-takeover); merges after PR2.

Image + seccomp + CI is **PR4**; worker wiring is **PR5**.

### What's here — `aios_browser_driver/takeover/`

- **`state.py`** — the `AdmissionGate` (synchronous `admit`; `close_and_drain` sets closed before draining the in-flight count to zero, so the epoch rotates only once every admitted action has finished — a human's input can never land under agent control, nor vice versa) and a bounded-FIFO replay cache for redriven closes.
- **`spool.py`** — the input tailer: arms from EOF, buffers partial lines, skips malformed ones, and is inode-aware (adopts a reaper-recreated spool by open-then-fstat, draining the old fd first).
- **`injector.py`** — replays the raw event vocabulary onto playwright's `page.mouse`/`keyboard` (which own the keycode/modifier machinery); adds only multi-click detection. No credential guardrail — a takeover is exactly when the human types their own password.
- **`screencast.py`** — CDP `Page.startScreencast` → `frames/frame-<seq>.jpg` + an atomically-renamed manifest the API tails; every frame acked, writes throttled, the previous frame unlinked so the dir stays O(1); origin/security derived from the committed main-frame URL.
- **`host.py`** — orchestration: `takeover_open`/`takeover_close` (idempotent-per-grant, competing→`takeover_active`, mismatch→`grant_mismatch`, replay→cached, else `no_takeover`); close joins the input+screencast tasks before rotating the epoch; the idle/unclaimed/absolute-cap watchdog; popup retarget; Chromium-death force-close with an honest handback.

### Review

Built after a 5-agent plan red-team, then closed with an **8-agent uncorrelated review** (reuse / simplification / efficiency / altitude + contract-conformance, concurrency, playwright-API, security). The review caught a **CRITICAL** bug — a dispatch-deadline `CancelledError` inside `takeover_open` (a `BaseException` the `except Exception` rollback never saw) would have wedged the admission gate closed **forever**, locking every session out of the browser with the worker seeing only a bland `action_timeout`. Fixed with a cancellation-safe `finally` and a dedicated regression test. Also folded: a HIGH playwright fix (Chromium no longer emits `Security.securityStateChanged` → security now derived from the URL scheme), the retarget queue-reset, bounded frames-on-disk, and several simplifications. Conformance and the two crux security invariants (agent page-blindness, epoch/grant enforcement across handback) verified clean with tests. One LOW finding — a ≤2s same-account frame bleed in the frames-SSE **API router** — is deferred to the aios-hardening set (not driver code).

### Checks

`ruff` / `mypy` clean; 5386 unit + 108 package tests pass. An opt-in `-m browser` lane drives the full open→block→echo→close→replay→mismatch lifecycle, a real screencast over a loopback fixture, and the cancelled-open gate-reopen regression against real Chromium — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
