### PR TITLE
feat(browser): Phase 2 PR4 — the browser image, seccomp profile, and gates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,8 +49,15 @@ spool.sqlite*
 # Claude Code session state — not part of aios source.
 .claude
 
-# Tests don't ship in production images.
+# Tests don't ship in production images. NB: dockerignore patterns are
+# anchored at the context root and bare names / ``*`` do not cross ``/`` —
+# ``tests`` excludes only the repo-root tests dir, and ``*.md`` below strips
+# only root-level markdown. Package-relative paths must be listed explicitly;
+# package READMEs survive by anchoring, and MUST (hatchling's ``readme``
+# field fails the wheel build without them) — do not "tighten" these to
+# ``**/`` forms.
 tests
+packages/aios-browser-driver/tests
 
 # Generated SDK source — not consumed at runtime; FastAPI builds OpenAPI
 # in-memory.

--- a/.github/workflows/build-browser-image.yml
+++ b/.github/workflows/build-browser-image.yml
@@ -1,19 +1,20 @@
-name: Build aios-sandbox image
+name: Build aios-browser image
 
-# Builds and publishes ``ghcr.io/eumemic/aios-sandbox`` whenever the
-# sandbox base image's inputs change.  The worker pulls this image to
-# spawn per-session sandbox containers — see ``docker/Dockerfile.sandbox``
-# for what's in it.
+# Builds and publishes ``ghcr.io/eumemic/aios-browser`` — the per-account
+# browser container (Chromium + driver daemon, jarbot#106 Phase 2) — whenever
+# its inputs change.  See ``docker/Dockerfile.browser`` for what's in it.
 #
 # Triggers:
-# - Push to master that touches the sandbox Dockerfile (or this workflow)
-# - Push to master that touches ``bin/tool`` — the Dockerfile COPYs it in
-#   (line 63: ``COPY bin/tool /usr/local/bin/tool``) so a tool-only push
-#   must rebuild the image
+# - Push to master that touches the browser Dockerfile, the authored seccomp
+#   profile, the driver package, or the wire-contract module the image COPYs
+#   over the package's vendored copy (a protocol-only push must rebuild, or
+#   the image-side byte-equality check goes stale)
 # - Manual ``workflow_dispatch`` for force rebuilds
 #
 # Tags published: ``latest`` (always tracks master) + ``sha-<short>`` for
-# traceable rollbacks.
+# traceable rollbacks.  The smoke job runs BOTH browser e2e suites (image
+# contract + driver behavior) against the immutable sha tag and only then
+# retags ``:smoked`` — the tag deploy targets and the PR e2e shard consume.
 #
 # Security note: this workflow does not interpolate any untrusted input
 # (issue titles, PR bodies, head_ref, etc.) into ``run:`` commands.  Only
@@ -24,9 +25,20 @@ on:
   push:
     branches: [master]
     paths:
-      - docker/Dockerfile.sandbox
-      - .github/workflows/build-sandbox.yml
-      - bin/tool
+      - docker/Dockerfile.browser
+      - docker/seccomp-browser.json
+      # The smoke's NEGATIVE control launches the image under the sandbox
+      # profile — a change there can invalidate its premise, so re-smoke.
+      - docker/seccomp-sandbox.json
+      # The context filter shapes what the Dockerfile's COPYs see.
+      - .dockerignore
+      - packages/aios-browser-driver/**
+      - src/aios/sandbox/browser_protocol.py
+      # The gates themselves: ``:smoked`` means "passed THESE suites".
+      - tests/e2e/test_browser_image_contract.py
+      - tests/e2e/test_browser_driver_behavior.py
+      - tests/e2e/browser_image_common.py
+      - .github/workflows/build-browser-image.yml
   workflow_dispatch:
 
 # One build+smoke pipeline at a time per ref.  A second push while smoke
@@ -38,6 +50,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Generous: the linux/arm64 leg is QEMU-emulated and includes
+    # ``playwright install-deps`` (apt) plus a per-arch Chromium download —
+    # far heavier than the sandbox image's apt-only build.
+    timeout-minutes: 90
     outputs:
       # Immutable sha-tagged reference for the smoke job so it always tests
       # the exact image produced by this build step, regardless of concurrent
@@ -53,9 +69,6 @@ jobs:
 
       # QEMU enables cross-arch emulation so we can build linux/arm64
       # layers on the linux/amd64 GitHub runner without separate runners.
-      # The sandbox Dockerfile only uses apt + the multi-arch
-      # ``python:3.13-slim-bookworm`` base, so cross-build under QEMU is
-      # well within the "trivial enough to emulate" envelope.
       - uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
@@ -73,7 +86,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/eumemic/aios-sandbox
+          images: ghcr.io/eumemic/aios-browser
           tags: |
             type=raw,value=latest
             type=sha,format=short,prefix=sha-
@@ -82,28 +95,31 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           # Build context is the repo root (not ``docker/``) so the
-          # Dockerfile can COPY ``bin/mcp`` — see issue #392.
+          # Dockerfile can COPY the driver package and the ``src/``
+          # protocol original over its vendored copy.
           context: .
-          file: docker/Dockerfile.sandbox
+          file: docker/Dockerfile.browser
           # Multi-arch so developer machines on Apple Silicon (linux/arm64
           # under Docker Desktop) pull a native image without ``no matching
-          # manifest`` errors.  Cross-build is QEMU-emulated; layers are
-          # cached so subsequent builds with unchanged apt set are fast.
+          # manifest`` errors.
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=sandbox-image
-          cache-to: type=gha,mode=max,scope=sandbox-image
+          # Scoped: the default shared scope lets the sandbox/signal image
+          # builds evict this cache — and a cold browser rebuild is the
+          # most expensive build in the repo (QEMU arm64 + Chromium).
+          cache-from: type=gha,scope=browser-image
+          cache-to: type=gha,mode=max,scope=browser-image
 
       - name: Expose sha tag for smoke job
         id: sha_tag
-        run: echo "tag=ghcr.io/eumemic/aios-sandbox:sha-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+        run: echo "tag=ghcr.io/eumemic/aios-browser:sha-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
 
   smoke:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -126,12 +142,18 @@ jobs:
         # Pull by immutable sha tag (set by build job) to avoid a race
         # where a concurrent master push advances :latest before we smoke.
         run: docker pull "${{ needs.build.outputs.sha_tag }}"
-      - name: Run sandbox contract test
-        run: uv run pytest tests/e2e/test_sandbox_image_contract.py -v
+      - name: Run browser contract + behavior suites
+        # Both suites are gated on this env var (they self-skip without it),
+        # aios-import-free, and drive the image through the worker's exact
+        # ``docker exec browser-cli`` transport — including the
+        # Chromium-sandbox-ON probe and its seccomp negative control.
+        run: >
+          uv run pytest tests/e2e/test_browser_image_contract.py
+          tests/e2e/test_browser_driver_behavior.py -v
         env:
-          AIOS_DOCKER_IMAGE: ${{ needs.build.outputs.sha_tag }}
+          AIOS_SANDBOX_BROWSER_IMAGE: ${{ needs.build.outputs.sha_tag }}
       - name: Retag sha → :smoked
         run: |
           docker buildx imagetools create \
-            -t ghcr.io/eumemic/aios-sandbox:smoked \
+            -t ghcr.io/eumemic/aios-browser:smoked \
             "${{ needs.build.outputs.sha_tag }}"

--- a/.github/workflows/build-signal-connector.yml
+++ b/.github/workflows/build-signal-connector.yml
@@ -60,8 +60,8 @@ jobs:
           load: true
           push: false
           tags: aios-signal:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=signal-image
+          cache-to: type=gha,mode=max,scope=signal-image
 
       - name: Smoke test — signal-cli runs and reports a version
         run: docker run --rm --entrypoint signal-cli aios-signal:ci --version | grep -q 'signal-cli'

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -84,7 +84,10 @@ jobs:
           # SDK under ``packages/aios-sdk/aios_sdk/_generated/`` — always
           # run CI.  ``tests/unit/test_detect_filter_sync.py`` enforces that
           # this regex stays in sync with all committed generated artifacts.
-          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^connectors/[^/]+/Dockerfile$|^bin/tool$|^\.github/workflows/|^packages/[^/]+/(pyproject\.toml|CHANGELOG\.md)$|^Dockerfile$|^compose\.yml$|^openapi\.json$'; then
+          # ``aios-browser-driver`` is matched whole: it ships the first
+          # runtime-load-bearing non-Python source in ``packages/``
+          # (``snapshot/walker.js``), which the ``\.py$`` arm would miss.
+          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^connectors/[^/]+/Dockerfile$|^bin/tool$|^\.github/workflows/|^packages/aios-browser-driver/|^packages/[^/]+/(pyproject\.toml|CHANGELOG\.md)$|^Dockerfile$|^compose\.yml$|^openapi\.json$'; then
             echo "Build-affecting changes detected — running checks."
             echo "run_checks=true" >> "$GITHUB_OUTPUT"
           else

--- a/docker/Dockerfile.browser
+++ b/docker/Dockerfile.browser
@@ -1,0 +1,109 @@
+# aios browser image — the per-account "computer" (jarbot#106 Phase 2).
+#
+# Chromium plus the ``aios-browser-driver`` daemon implementing the wire
+# contract in ``src/aios/sandbox/browser_protocol.py``. The worker starts one
+# container per account (``build_spec_from_browser``) with a single bind mount
+# (the account plane at ``/workspace``), no env injection, no published ports,
+# and drives it exclusively via ``docker exec browser-cli invoke '<json>'``.
+#
+# Published as ``ghcr.io/eumemic/aios-browser`` by
+# ``.github/workflows/build-browser-image.yml`` on every change to its inputs
+# (this file, the seccomp profile, the driver package, the protocol module).
+# Deploy targets pull from GHCR via ``AIOS_SANDBOX_BROWSER_IMAGE``.
+#
+# Local dev:
+#   docker build -t aios-browser:dev -f docker/Dockerfile.browser .
+# then point ``AIOS_SANDBOX_BROWSER_IMAGE`` at the tag and run the e2e suites:
+#   AIOS_SANDBOX_BROWSER_IMAGE=aios-browser:dev uv run pytest \
+#     tests/e2e/test_browser_image_contract.py tests/e2e/test_browser_driver_behavior.py
+#
+# Build context is the repo root (NOT ``docker/``): the image COPYs the driver
+# package AND the ``src/`` protocol original over the package's vendored copy,
+# so the installed contract can never fork from the worker's
+# (``test_browser_image_contract.py`` asserts byte equality against a live
+# container).
+#
+# Runtime posture (enforced by the worker's spec/backend, asserted by the
+# contract e2e):
+# - Runs as USER 1000:1000 — ``browser_protocol.PLANE_OWNER_UID`` — so plane
+#   files (frames/shots/downloads, the input spool) are readable/writable by
+#   the API process without any chown dance. The worker passes no ``--user``.
+# - CMD is the daemon (absolute path — PATH-regression defense, #925/#938);
+#   the worker passes no command override.
+# - Chromium's own namespace sandbox stays ON (no ``--no-sandbox`` anywhere).
+#   It needs unprivileged USER/PID/NET namespaces, which
+#   ``docker/seccomp-browser.json`` re-permits. NEVER run this container with
+#   ``--security-opt apparmor=unconfined``: on Ubuntu 24.04 hosts
+#   (``apparmor_restrict_unprivileged_userns=1``) the docker-default AppArmor
+#   profile is exactly what exempts the container from the userns restriction —
+#   unconfined KILLS the sandbox rather than loosening anything.
+
+FROM python:3.13-slim-bookworm
+
+# uv binary (pinned) — same provenance as the worker image's install step.
+COPY --from=ghcr.io/astral-sh/uv:0.5.18 /uv /usr/local/bin/uv
+
+# Named non-root user ``aios`` (uid:gid 1000:1000 = PLANE_OWNER_UID) with a
+# writable home. Chromium refuses to run when $HOME's owner != the running
+# uid, and writes ~/.config / ~/.cache under it.
+RUN groupadd --gid 1000 aios \
+ && useradd --uid 1000 --gid 1000 --create-home --home-dir /home/aios aios
+
+# Browsers land in a shared root-installed path, NOT root's ~/.cache — set
+# BEFORE ``playwright install`` and persisted to runtime so the uid-1000
+# daemon resolves the same path the root build step populated (a bare install
+# would land in /root/.cache, unreadable by uid 1000).
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+
+# Layer order is cache-bust order: the driver package and the protocol module
+# are the frequently-changing inputs, so the expensive layers below key ONLY
+# on the dependency set (this pyproject copy). A driver-code or protocol-only
+# rebuild reuses apt + Chromium — the layers the arm64/QEMU CI leg pays
+# tens of minutes for.
+COPY packages/aios-browser-driver/pyproject.toml /tmp/driver-deps/pyproject.toml
+RUN uv pip install --system --no-cache -r /tmp/driver-deps/pyproject.toml \
+ && rm -rf /tmp/driver-deps
+
+# Chromium's OS dependencies (apt) — split from the browser download below so
+# a Chromium-only bump doesn't re-run the slow apt layer.
+RUN apt-get update \
+ && playwright install-deps chromium \
+ && rm -rf /var/lib/apt/lists/*
+
+# Chromium itself, pinned by the playwright version installed above.
+# ``--no-shell`` skips the headless-shell build — the driver launches full
+# Chromium via ``channel="chromium"`` on every path. World-read the tree so
+# the uid-1000 daemon can execute what root installed.
+RUN playwright install --no-shell chromium \
+ && chmod -R a+rX /opt/ms-playwright
+
+# The driver package itself — last, so the frequent case rebuilds only this
+# cheap wheel layer. ``--no-sources`` = the exact closure its own pyproject
+# declares (playwright, pydantic, python-ulid — deliberately NO aios). The
+# ``src/`` protocol original is COPYed OVER the package's vendored copy first,
+# so the installed module is byte-identical to the worker's — the
+# single-source mechanism that keeps the wire contract from forking
+# (drift-guarded repo-side by tests/test_protocol_drift.py, image-side by the
+# contract e2e).
+COPY packages/aios-browser-driver /tmp/aios-browser-driver
+COPY src/aios/sandbox/browser_protocol.py \
+     /tmp/aios-browser-driver/aios_browser_driver/browser_protocol.py
+RUN uv pip install --system --no-cache --no-sources /tmp/aios-browser-driver \
+ && rm -rf /tmp/aios-browser-driver
+
+# The driver's AF_UNIX request socket lives at /run/aios/driver.sock
+# (aios_browser_driver.sockpath) — the daemon (uid 1000) must be able to bind
+# there.
+RUN mkdir -p /run/aios && chown 1000:1000 /run/aios
+
+ENV HOME=/home/aios
+USER 1000:1000
+
+# The account plane is bind-mounted here at container start
+# (profile/ shots/ frames/ downloads/ input/).
+WORKDIR /workspace
+
+# The daemon IS the container: binds the socket, launches Chromium, crashes
+# visibly on any startup or relaunch failure (a crash-looping container beats
+# a live one that answers nothing). Absolute path — PATH-regression defense.
+CMD ["/usr/local/bin/aios-browser-driver"]

--- a/docker/seccomp-browser.json
+++ b/docker/seccomp-browser.json
@@ -1,0 +1,852 @@
+{
+  "_authored_comment": "AUTHORED seccomp profile for aios BROWSER containers (jarbot#106 Phase 2). This file is a VERBATIM vendored copy of moby's default seccomp profile (profiles/seccomp/default.json, pinned tag v24.0.7 -- the same provenance as docker/seccomp-sandbox.json; defaultAction SCMP_ACT_ERRNO with defaultErrnoRet 1 = EPERM) with ONE authored block PREPENDED to the FRONT of the syscalls array. seccomp is first-match-wins, so the authored block wins over the vendored blocks that follow. The authored block permits clone/unshare when (arg0 & 0x0E020000) == 0: Chromium's namespace sandbox (the primary security boundary of the browser container -- there is deliberately NO --no-sandbox) creates USER, PID, and NET namespaces from an unprivileged process, which moby's default profile denies; the masked-eq allow re-permits exactly those while still refusing MOUNT (CLONE_NEWNS), CGROUP, UTS, and IPC namespaces. 0x0E020000 = NEWNS 0x20000 | NEWCGROUP 0x2000000 | NEWUTS 0x4000000 | NEWIPC 0x8000000. MUST-NOT-REGRESS: the mask MUST include CLONE_NEWNS (0x20000) -- an earlier draft used a mask omitting it, which would have re-enabled mount-namespace creation (tests/unit/test_browser_seccomp_profile.py pins this; the image contract e2e proves unshare(CLONE_NEWNS) -> EPERM against a live container). NAMED RESIDUAL (F4 decision): a compromised BROWSER process (post renderer->Mojo escalation) regains the unprivileged-userns kernel attack surface for container->host escape -- Chromium's seccomp-bpf layer closes it to renderers (namespace-flag clone crashes, unshare/clone3 denied in the baseline policy), so it is reachable only from the trusted browser/zygote/daemon processes. Compensations: runc stays the default with a patched-host-kernel floor as an operator requirement, and gVisor ships as a validated opt-in (sandbox_browser_runtime=\"runsc\"). Unlike seccomp-sandbox.json there is NO flat deny block: ptrace stays allowed (kernel >= 4.8 vendored rule) because Chromium's crashpad handler ptraces its own processes, and no agent code ever runs in this container -- the driver daemon and Chromium are the only workloads. clone3 keeps the vendored ENOSYS (errnoRet 38) so glibc falls back to clone, where the arg0 filter applies. MAINTENANCE: re-vendor default.json from a newer moby tag periodically and re-apply the single authored block at the front. seccomp ignores unknown top-level keys, so this _authored_comment is inert at runtime.",
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "defaultErrnoRet": 1,
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_RISCV64",
+      "subArchitectures": null
+    }
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "clone",
+        "unshare"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 235012096,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "comment": "Allow clone/unshare only when none of CLONE_NEWNS|CLONE_NEWCGROUP|CLONE_NEWUTS|CLONE_NEWIPC is set (mask 0x0E020000 = 235012096). CLONE_NEWUSER|CLONE_NEWPID|CLONE_NEWNET remain PERMITTED -- Chromium's zygote sandbox needs exactly those three. arg0 is the flags word on amd64/arm64; s390* pass clone flags in arg1, so they are excluded rather than silently misread.",
+      "excludes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      }
+    },
+    {
+      "names": [
+        "accept",
+        "accept4",
+        "access",
+        "adjtimex",
+        "alarm",
+        "bind",
+        "brk",
+        "capget",
+        "capset",
+        "chdir",
+        "chmod",
+        "chown",
+        "chown32",
+        "clock_adjtime",
+        "clock_adjtime64",
+        "clock_getres",
+        "clock_getres_time64",
+        "clock_gettime",
+        "clock_gettime64",
+        "clock_nanosleep",
+        "clock_nanosleep_time64",
+        "close",
+        "close_range",
+        "connect",
+        "copy_file_range",
+        "creat",
+        "dup",
+        "dup2",
+        "dup3",
+        "epoll_create",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_ctl_old",
+        "epoll_pwait",
+        "epoll_pwait2",
+        "epoll_wait",
+        "epoll_wait_old",
+        "eventfd",
+        "eventfd2",
+        "execve",
+        "execveat",
+        "exit",
+        "exit_group",
+        "faccessat",
+        "faccessat2",
+        "fadvise64",
+        "fadvise64_64",
+        "fallocate",
+        "fanotify_mark",
+        "fchdir",
+        "fchmod",
+        "fchmodat",
+        "fchown",
+        "fchown32",
+        "fchownat",
+        "fcntl",
+        "fcntl64",
+        "fdatasync",
+        "fgetxattr",
+        "flistxattr",
+        "flock",
+        "fork",
+        "fremovexattr",
+        "fsetxattr",
+        "fstat",
+        "fstat64",
+        "fstatat64",
+        "fstatfs",
+        "fstatfs64",
+        "fsync",
+        "ftruncate",
+        "ftruncate64",
+        "futex",
+        "futex_time64",
+        "futex_waitv",
+        "futimesat",
+        "getcpu",
+        "getcwd",
+        "getdents",
+        "getdents64",
+        "getegid",
+        "getegid32",
+        "geteuid",
+        "geteuid32",
+        "getgid",
+        "getgid32",
+        "getgroups",
+        "getgroups32",
+        "getitimer",
+        "getpeername",
+        "getpgid",
+        "getpgrp",
+        "getpid",
+        "getppid",
+        "getpriority",
+        "getrandom",
+        "getresgid",
+        "getresgid32",
+        "getresuid",
+        "getresuid32",
+        "getrlimit",
+        "get_robust_list",
+        "getrusage",
+        "getsid",
+        "getsockname",
+        "getsockopt",
+        "get_thread_area",
+        "gettid",
+        "gettimeofday",
+        "getuid",
+        "getuid32",
+        "getxattr",
+        "inotify_add_watch",
+        "inotify_init",
+        "inotify_init1",
+        "inotify_rm_watch",
+        "io_cancel",
+        "ioctl",
+        "io_destroy",
+        "io_getevents",
+        "io_pgetevents",
+        "io_pgetevents_time64",
+        "ioprio_get",
+        "ioprio_set",
+        "io_setup",
+        "io_submit",
+        "io_uring_enter",
+        "io_uring_register",
+        "io_uring_setup",
+        "ipc",
+        "kill",
+        "landlock_add_rule",
+        "landlock_create_ruleset",
+        "landlock_restrict_self",
+        "lchown",
+        "lchown32",
+        "lgetxattr",
+        "link",
+        "linkat",
+        "listen",
+        "listxattr",
+        "llistxattr",
+        "_llseek",
+        "lremovexattr",
+        "lseek",
+        "lsetxattr",
+        "lstat",
+        "lstat64",
+        "madvise",
+        "membarrier",
+        "memfd_create",
+        "memfd_secret",
+        "mincore",
+        "mkdir",
+        "mkdirat",
+        "mknod",
+        "mknodat",
+        "mlock",
+        "mlock2",
+        "mlockall",
+        "mmap",
+        "mmap2",
+        "mprotect",
+        "mq_getsetattr",
+        "mq_notify",
+        "mq_open",
+        "mq_timedreceive",
+        "mq_timedreceive_time64",
+        "mq_timedsend",
+        "mq_timedsend_time64",
+        "mq_unlink",
+        "mremap",
+        "msgctl",
+        "msgget",
+        "msgrcv",
+        "msgsnd",
+        "msync",
+        "munlock",
+        "munlockall",
+        "munmap",
+        "name_to_handle_at",
+        "nanosleep",
+        "newfstatat",
+        "_newselect",
+        "open",
+        "openat",
+        "openat2",
+        "pause",
+        "pidfd_open",
+        "pidfd_send_signal",
+        "pipe",
+        "pipe2",
+        "pkey_alloc",
+        "pkey_free",
+        "pkey_mprotect",
+        "poll",
+        "ppoll",
+        "ppoll_time64",
+        "prctl",
+        "pread64",
+        "preadv",
+        "preadv2",
+        "prlimit64",
+        "process_mrelease",
+        "pselect6",
+        "pselect6_time64",
+        "pwrite64",
+        "pwritev",
+        "pwritev2",
+        "read",
+        "readahead",
+        "readlink",
+        "readlinkat",
+        "readv",
+        "recv",
+        "recvfrom",
+        "recvmmsg",
+        "recvmmsg_time64",
+        "recvmsg",
+        "remap_file_pages",
+        "removexattr",
+        "rename",
+        "renameat",
+        "renameat2",
+        "restart_syscall",
+        "rmdir",
+        "rseq",
+        "rt_sigaction",
+        "rt_sigpending",
+        "rt_sigprocmask",
+        "rt_sigqueueinfo",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "rt_sigtimedwait",
+        "rt_sigtimedwait_time64",
+        "rt_tgsigqueueinfo",
+        "sched_getaffinity",
+        "sched_getattr",
+        "sched_getparam",
+        "sched_get_priority_max",
+        "sched_get_priority_min",
+        "sched_getscheduler",
+        "sched_rr_get_interval",
+        "sched_rr_get_interval_time64",
+        "sched_setaffinity",
+        "sched_setattr",
+        "sched_setparam",
+        "sched_setscheduler",
+        "sched_yield",
+        "seccomp",
+        "select",
+        "semctl",
+        "semget",
+        "semop",
+        "semtimedop",
+        "semtimedop_time64",
+        "send",
+        "sendfile",
+        "sendfile64",
+        "sendmmsg",
+        "sendmsg",
+        "sendto",
+        "setfsgid",
+        "setfsgid32",
+        "setfsuid",
+        "setfsuid32",
+        "setgid",
+        "setgid32",
+        "setgroups",
+        "setgroups32",
+        "setitimer",
+        "setpgid",
+        "setpriority",
+        "setregid",
+        "setregid32",
+        "setresgid",
+        "setresgid32",
+        "setresuid",
+        "setresuid32",
+        "setreuid",
+        "setreuid32",
+        "setrlimit",
+        "set_robust_list",
+        "setsid",
+        "setsockopt",
+        "set_thread_area",
+        "set_tid_address",
+        "setuid",
+        "setuid32",
+        "setxattr",
+        "shmat",
+        "shmctl",
+        "shmdt",
+        "shmget",
+        "shutdown",
+        "sigaltstack",
+        "signalfd",
+        "signalfd4",
+        "sigprocmask",
+        "sigreturn",
+        "socketcall",
+        "socketpair",
+        "splice",
+        "stat",
+        "stat64",
+        "statfs",
+        "statfs64",
+        "statx",
+        "symlink",
+        "symlinkat",
+        "sync",
+        "sync_file_range",
+        "syncfs",
+        "sysinfo",
+        "tee",
+        "tgkill",
+        "time",
+        "timer_create",
+        "timer_delete",
+        "timer_getoverrun",
+        "timer_gettime",
+        "timer_gettime64",
+        "timer_settime",
+        "timer_settime64",
+        "timerfd_create",
+        "timerfd_gettime",
+        "timerfd_gettime64",
+        "timerfd_settime",
+        "timerfd_settime64",
+        "times",
+        "tkill",
+        "truncate",
+        "truncate64",
+        "ugetrlimit",
+        "umask",
+        "uname",
+        "unlink",
+        "unlinkat",
+        "utime",
+        "utimensat",
+        "utimensat_time64",
+        "utimes",
+        "vfork",
+        "vmsplice",
+        "wait4",
+        "waitid",
+        "waitpid",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    },
+    {
+      "names": [
+        "process_vm_readv",
+        "process_vm_writev",
+        "ptrace"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "minKernel": "4.8"
+      }
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 40,
+          "op": "SCMP_CMP_NE"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 8,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131072,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131080,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 4294967295,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "sync_file_range2",
+        "swapcontext"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "ppc64le"
+        ]
+      }
+    },
+    {
+      "names": [
+        "arm_fadvise64_64",
+        "arm_sync_file_range",
+        "sync_file_range2",
+        "breakpoint",
+        "cacheflush",
+        "set_tls"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "arm",
+          "arm64"
+        ]
+      }
+    },
+    {
+      "names": [
+        "arch_prctl"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32"
+        ]
+      }
+    },
+    {
+      "names": [
+        "modify_ldt"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32",
+          "x86"
+        ]
+      }
+    },
+    {
+      "names": [
+        "s390_pci_mmio_read",
+        "s390_pci_mmio_write",
+        "s390_runtime_instr"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      }
+    },
+    {
+      "names": [
+        "riscv_flush_icache"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "riscv64"
+        ]
+      }
+    },
+    {
+      "names": [
+        "open_by_handle_at"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_DAC_READ_SEARCH"
+        ]
+      }
+    },
+    {
+      "names": [
+        "bpf",
+        "clone",
+        "clone3",
+        "fanotify_init",
+        "fsconfig",
+        "fsmount",
+        "fsopen",
+        "fspick",
+        "lookup_dcookie",
+        "mount",
+        "mount_setattr",
+        "move_mount",
+        "open_tree",
+        "perf_event_open",
+        "quotactl",
+        "quotactl_fd",
+        "setdomainname",
+        "sethostname",
+        "setns",
+        "syslog",
+        "umount",
+        "umount2",
+        "unshare"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 2114060288,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ],
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 1,
+          "value": 2114060288,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "comment": "s390 parameter ordering for clone is different",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      },
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone3"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 38,
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "reboot"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_BOOT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "chroot"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_CHROOT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "delete_module",
+        "init_module",
+        "finit_module"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_MODULE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "acct"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PACCT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "kcmp",
+        "pidfd_getfd",
+        "process_madvise",
+        "process_vm_readv",
+        "process_vm_writev",
+        "ptrace"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PTRACE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "iopl",
+        "ioperm"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_RAWIO"
+        ]
+      }
+    },
+    {
+      "names": [
+        "settimeofday",
+        "stime",
+        "clock_settime",
+        "clock_settime64"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TIME"
+        ]
+      }
+    },
+    {
+      "names": [
+        "vhangup"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TTY_CONFIG"
+        ]
+      }
+    },
+    {
+      "names": [
+        "get_mempolicy",
+        "mbind",
+        "set_mempolicy"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_NICE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "syslog"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYSLOG"
+        ]
+      }
+    },
+    {
+      "names": [
+        "bpf"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_BPF"
+        ]
+      }
+    },
+    {
+      "names": [
+        "perf_event_open"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_PERFMON"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/e2e/browser_image_common.py
+++ b/tests/e2e/browser_image_common.py
@@ -1,0 +1,134 @@
+"""Shared helpers for the two browser-image e2e suites (jarbot#106 Phase 2).
+
+One test-side statement each of the two cross-package contracts both suites
+drive, so they cannot drift apart (an earlier revision's readiness poll had
+already dropped ``--workdir`` from its private copy):
+
+* :func:`invoke_argv` — the worker's EXACT exec shape
+  (``src/aios/sandbox/browser.py`` + ``backends/docker.py``):
+  ``docker exec --workdir /workspace C timeout -k 5 -s KILL N bash -c
+  "browser-cli invoke '<payload>'"``.
+* :func:`start_browser_container` — the production ``docker run`` recipe from
+  ``build_spec_from_browser`` + ``DockerBackend.create``: plane mount, the
+  authored seccomp profile, ``--ipc private``, ``no-new-privileges``,
+  ``--init``, and the default resource caps (2 CPU / 2 GiB+swap-pinned /
+  512 pids — ``src/aios/config.py`` ``sandbox_browser_*``), so the suites
+  exercise the capped regime production runs in. Omitted knowingly: the
+  ``aios-browser`` network (topology is the isolation gate's job),
+  ``--interactive`` (the daemon never reads stdin), labels (GC bookkeeping),
+  and ``--pull always`` (CI pre-pulls the immutable sha tag).
+
+Deliberately aios-import-free, like the suites themselves: image smoke must
+not break when the aios tree does.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Read directly from env. The name is stable — env_prefix="AIOS_" + field
+# "sandbox_browser_image" in src/aios/config.py. Empty ⇒ the suites skip.
+IMAGE = os.environ.get("AIOS_SANDBOX_BROWSER_IMAGE", "")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BROWSER_SECCOMP = REPO_ROOT / "docker" / "seccomp-browser.json"
+SANDBOX_SECCOMP = REPO_ROOT / "docker" / "seccomp-sandbox.json"
+
+
+def run(argv: list[str], *, timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, capture_output=True, text=True, check=False, timeout=timeout)
+
+
+def invoke_argv(container: str, payload: str, *, wrapper_s: int) -> list[str]:
+    """The worker's exact exec shape around one ``browser-cli invoke``.
+
+    ``payload`` is the raw request string (callers ``json.dumps`` well-formed
+    requests; the malformed-request test passes garbage verbatim — browser-cli
+    forwards bytes as-is by contract).
+    """
+    command = f"browser-cli invoke {shlex.quote(payload)}"
+    return [
+        *("docker", "exec", "--workdir", "/workspace", container),
+        *("timeout", "-k", "5", "-s", "KILL", str(wrapper_s)),
+        *("bash", "-c", command),
+    ]
+
+
+def invoke_raw(
+    container: str, payload: str, *, wrapper_s: int = 40
+) -> subprocess.CompletedProcess[str]:
+    return run(invoke_argv(container, payload, wrapper_s=wrapper_s), timeout=wrapper_s + 15)
+
+
+def invoke(container: str, request: dict[str, Any], *, wrapper_s: int = 40) -> dict[str, Any]:
+    """One well-formed invoke; fails the test on any transport-level
+    (nonzero-exit) fault and returns the parsed response document."""
+    r = invoke_raw(container, json.dumps(request), wrapper_s=wrapper_s)
+    assert r.returncode == 0, f"transport fault (rc={r.returncode}): {r.stderr.strip()[:500]}"
+    doc: dict[str, Any] = json.loads(r.stdout)
+    return doc
+
+
+def make_plane(root: Path) -> Path:
+    """A plane dir (the five production subdirs) the uid-1000 container can
+    write regardless of the host uid."""
+    plane = root / "plane"
+    for sub in ("profile", "shots", "frames", "downloads", "input"):
+        (plane / sub).mkdir(parents=True)
+    for p in (plane, *plane.iterdir()):
+        p.chmod(0o777)
+    return plane
+
+
+def start_browser_container(
+    image: str,
+    plane: Path,
+    name: str,
+    *,
+    seccomp: Path = BROWSER_SECCOMP,
+    env: dict[str, str] | None = None,
+    command: list[str] | None = None,
+) -> None:
+    """``docker run`` the way the worker does (see module docstring). ``env``
+    exists for the hermetic-test knob, ``command`` for daemon-suppressed
+    containers, ``seccomp`` for the negative control."""
+    argv = [
+        *("docker", "run", "--detach", "--name", name),
+        *("--volume", f"{plane}:/workspace"),
+        *("--security-opt", "no-new-privileges"),
+        *("--security-opt", f"seccomp={seccomp}"),
+        *("--ipc", "private"),
+        *("--cpus", "2"),
+        *("--memory", "2147483648", "--memory-swap", "2147483648"),
+        *("--pids-limit", "512"),
+        "--init",
+    ]
+    for key, value in (env or {}).items():
+        argv += ["--env", f"{key}={value}"]
+    argv.append(image)
+    argv.extend(command or [])
+    r = run(argv, timeout=120)
+    assert r.returncode == 0, f"docker run failed: {r.stderr.strip()}"
+
+
+def wait_ready(container: str, *, deadline_s: float = 90) -> None:
+    """Poll ``status`` until the driver answers ok (Chromium takes a moment to
+    launch on first boot)."""
+    payload = json.dumps({"op": "status", "timeout_ms": 10_000})
+    deadline = time.monotonic() + deadline_s
+    last: subprocess.CompletedProcess[str] | None = None
+    while time.monotonic() < deadline:
+        last = invoke_raw(container, payload, wrapper_s=15)
+        if last.returncode == 0 and json.loads(last.stdout).get("ok"):
+            return
+        time.sleep(1.0)
+    detail = f"rc={last.returncode} stdout={last.stdout!r} stderr={last.stderr!r}" if last else ""
+    pytest.fail(f"driver never became ready in {container}: {detail}")

--- a/tests/e2e/test_browser_driver_behavior.py
+++ b/tests/e2e/test_browser_driver_behavior.py
@@ -1,0 +1,434 @@
+"""Behavioral e2e for the aios-browser image: real Chromium, driven through
+the same ``docker exec browser-cli`` transport the worker uses.
+
+Two containers, both provisioned with the production flag set (seccomp
+profile, resource caps, --init, --ipc private, no-new-privileges, plane
+mount — see ``tests/e2e/browser_image_common.py``):
+
+* ``knob`` — carries ``AIOS_BROWSER_DRIVER_ALLOW_PRIVATE_NAV=1`` (the
+  hermetic-test knob; unsettable through aios because the browser spec pins
+  ``environment={}``) plus a loopback HTTP fixture served from the plane, and
+  hosts the action round-trips, the takeover lifecycle, and the RSS trip-wire.
+* ``strict`` — no knob: proves the navigate guard's deny matrix as shipped.
+
+Like the contract suite this file is aios-import-free and opt-in: it skips
+when ``AIOS_SANDBOX_BROWSER_IMAGE`` is unset.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.conftest import needs_docker
+from tests.e2e.browser_image_common import (
+    IMAGE,
+    invoke,
+    make_plane,
+    run,
+    start_browser_container,
+    wait_ready,
+)
+
+pytestmark = [
+    needs_docker,
+    pytest.mark.docker,
+    pytest.mark.skipif(
+        not IMAGE, reason="AIOS_SANDBOX_BROWSER_IMAGE not set; browser behavior suite is opt-in"
+    ),
+]
+
+_FIXTURE_PORT = 8907
+_FIXTURE_URL = f"http://127.0.0.1:{_FIXTURE_PORT}/"
+
+# The loopback fixture site. ``index.html`` exercises every action op the
+# suite drives; ``popup.html`` is the popup/staleness target; ``file.bin`` the
+# download payload. Title mutations are the observable back-channel: the
+# response's ``title`` is read post-settle, so DOM-event side effects
+# (form submit, scroll) become assertable through the wire contract alone.
+_INDEX_HTML = """<!doctype html><html><head><title>fixture</title></head><body>
+<h1>Behavior fixture</h1>
+<button id="add" onclick="this.textContent='clicked-ok'">Add item</button>
+<form onsubmit="event.preventDefault();document.title='typed-'+document.getElementById('t').value">
+  <input id="t" aria-label="Query">
+</form>
+<input type="password" aria-label="Secret">
+<select aria-label="Color"><option value="r">red</option><option value="g">green</option></select>
+<a href="/file.bin" download="file.bin">Download file</a>
+<button id="pop" onclick="window.open('/popup.html','_blank')">Open popup</button>
+<div style="height:4000px"></div>
+<script>addEventListener('scroll',()=>{document.title='scrolled-'+Math.round(scrollY)})</script>
+</body></html>"""
+_POPUP_HTML = (
+    "<!doctype html><html><head><title>popup</title></head><body><h1>Popup page</h1></body></html>"
+)
+
+
+def _action(container: str, op: str, **args: Any) -> dict[str, Any]:
+    """One action op for the suite's single agent session ``s1``."""
+    return invoke(container, {"op": op, "session_id": "s1", "args": args, "timeout_ms": 30_000})
+
+
+def _ref_of(snapshot: str, name: str) -> str:
+    """The [ref=eN] handle of the snapshot line naming *name*."""
+    for line in snapshot.splitlines():
+        if name in line:
+            m = re.search(r"\[ref=(e\d+)\]", line)
+            if m:
+                return m.group(1)
+    pytest.fail(f"no ref for {name!r} in snapshot:\n{snapshot}")
+
+
+def _write_fixture_site(plane: Path) -> None:
+    """The fixture site lives on the plane bind mount (a throwaway test
+    plane), so it needs no in-container writes — only the http.server exec."""
+    www = plane / "www"
+    www.mkdir()
+    www.chmod(0o777)
+    (www / "index.html").write_text(_INDEX_HTML)
+    (www / "popup.html").write_text(_POPUP_HTML)
+    (www / "file.bin").write_bytes(b"download-payload-" * 64)
+
+
+def _serve_fixture_site(container: str) -> None:
+    r = run(
+        [
+            *("docker", "exec", "--detach", container),
+            *("python3", "-m", "http.server", str(_FIXTURE_PORT)),
+            *("--bind", "127.0.0.1", "--directory", "/workspace/www"),
+        ],
+        timeout=30,
+    )
+    assert r.returncode == 0, f"fixture server start failed: {r.stderr}"
+    deadline = time.monotonic() + 15
+    probe = f"import urllib.request; urllib.request.urlopen('{_FIXTURE_URL}', timeout=2)"
+    while time.monotonic() < deadline:
+        if run(["docker", "exec", container, "python3", "-c", probe], timeout=15).returncode == 0:
+            return
+        time.sleep(0.5)
+    pytest.fail("in-container fixture server never came up")
+
+
+@pytest.fixture(scope="module")
+def knob(tmp_path_factory: pytest.TempPathFactory) -> Iterator[tuple[str, Path]]:
+    """(container_name, plane_dir) with the private-nav knob + fixture site."""
+    plane = make_plane(tmp_path_factory.mktemp("browser-knob"))
+    _write_fixture_site(plane)
+    name = f"aios-browser-behav-{uuid.uuid4().hex[:8]}"
+    start_browser_container(IMAGE, plane, name, env={"AIOS_BROWSER_DRIVER_ALLOW_PRIVATE_NAV": "1"})
+    try:
+        wait_ready(name)
+        _serve_fixture_site(name)
+        yield name, plane
+    finally:
+        run(["docker", "rm", "--force", name], timeout=30)
+
+
+@pytest.fixture(scope="module")
+def strict(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """A knobless container: the navigate guard as shipped."""
+    plane = make_plane(tmp_path_factory.mktemp("browser-strict"))
+    name = f"aios-browser-strict-{uuid.uuid4().hex[:8]}"
+    start_browser_container(IMAGE, plane, name)
+    try:
+        wait_ready(name)
+        yield name
+    finally:
+        run(["docker", "rm", "--force", name], timeout=30)
+
+
+# -- action round-trips (knob container) ---------------------------------------
+
+
+def test_navigate_click_type_scroll_roundtrip(knob: tuple[str, Path]) -> None:
+    container, _ = knob
+
+    nav = _action(container, "navigate", url=_FIXTURE_URL)
+    assert nav["ok"], nav["error"]
+    assert nav["url"] == _FIXTURE_URL
+    assert "[ref=" in nav["snapshot"]
+
+    # click mutates the button's own accessible name — visible in the next snapshot
+    ref = _ref_of(nav["snapshot"], "Add item")
+    clicked = _action(container, "click", ref=ref, description="add an item")
+    assert clicked["ok"], clicked["error"]
+    assert "clicked-ok" in clicked["snapshot"]
+
+    # type + submit drives the form; the title mutation proves the keystrokes landed
+    query_ref = _ref_of(clicked["snapshot"], "Query")
+    typed = _action(container, "type", ref=query_ref, text="hello", submit=True, description="q")
+    assert typed["ok"], typed["error"]
+    assert typed["title"] == "typed-hello"
+
+    # scroll down: positive scrollY proves the wheel sign (down = positive delta)
+    scrolled = _action(container, "scroll", direction="down")
+    assert scrolled["ok"], scrolled["error"]
+    m = re.fullmatch(r"scrolled-(\d+)", scrolled["title"] or "")
+    assert m and int(m.group(1)) > 0, f"wheel sign wrong or scroll inert: {scrolled['title']!r}"
+
+    # the remaining pointer ops accept the documented shapes. Refs are
+    # CURRENT-GENERATION: every action re-snapshots and supersedes earlier
+    # handles, so each ref must come from the immediately preceding response.
+    hovered = _action(container, "hover", ref=_ref_of(scrolled["snapshot"], "clicked-ok"))
+    assert hovered["ok"], hovered["error"]
+    dragged = invoke(
+        container,
+        {
+            "op": "drag",
+            "session_id": "s1",
+            "args": {"from": {"x": 100, "y": 100}, "to": {"x": 200, "y": 200}},
+            "timeout_ms": 30_000,
+        },
+    )
+    assert dragged["ok"], dragged["error"]
+    clicked_xy = _action(container, "click_xy", x=10, y=10, description="corner")
+    assert clicked_xy["ok"], clicked_xy["error"]
+
+    sel_ref = _ref_of(clicked_xy["snapshot"], "Color")
+    selected = _action(container, "select_option", ref=sel_ref, values=["g"])
+    assert selected["ok"], selected["error"]
+
+
+def test_screenshot_lands_in_plane_shots(knob: tuple[str, Path]) -> None:
+    container, plane = knob
+    _action(container, "navigate", url=_FIXTURE_URL)
+    shot = _action(container, "screenshot")
+    assert shot["ok"], shot["error"]
+    path = shot["shot_path"]
+    assert path and path.startswith("shots/")
+    host_file = plane / path
+    assert host_file.exists() and host_file.stat().st_size > 0
+    assert host_file.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_download_persists_to_plane(knob: tuple[str, Path]) -> None:
+    container, plane = knob
+    nav = _action(container, "navigate", url=_FIXTURE_URL)
+    ref = _ref_of(nav["snapshot"], "Download file")
+    clicked = _action(container, "click", ref=ref, description="download")
+    assert clicked["ok"], clicked["error"]
+    # Persisted under a ULID prefix (collision-proofing) + the suggested name.
+    deadline = time.monotonic() + 15
+    persisted: list[Path] = []
+    while time.monotonic() < deadline and not persisted:
+        persisted = sorted((plane / "downloads").glob("*-file.bin"))
+        if not persisted:
+            time.sleep(0.5)
+    assert persisted, "download never persisted to the plane downloads dir"
+    assert persisted[0].read_bytes().startswith(b"download-payload-")
+
+
+def test_ref_staleness_and_unknown_ref(knob: tuple[str, Path]) -> None:
+    container, _ = knob
+    nav = _action(container, "navigate", url=_FIXTURE_URL)
+    old_ref = _ref_of(nav["snapshot"], "Add item")
+    _action(container, "navigate", url=_FIXTURE_URL + "popup.html")
+    stale = _action(container, "click", ref=old_ref, description="stale")
+    assert not stale["ok"] and stale["error"]["code"] == "stale_snapshot"
+    assert stale["snapshot"], "ok:false must still carry a fresh snapshot (self-correction)"
+    unknown = _action(container, "click", ref="e99999", description="never issued")
+    assert not unknown["ok"] and unknown["error"]["code"] == "no_such_ref"
+
+
+def test_password_guardrail(knob: tuple[str, Path]) -> None:
+    container, _ = knob
+    nav = _action(container, "navigate", url=_FIXTURE_URL)
+    pw_ref = _ref_of(nav["snapshot"], "Secret")
+    refused = _action(container, "type", ref=pw_ref, text="hunter2", description="pw")
+    assert not refused["ok"] and refused["error"]["code"] == "not_interactable"
+
+
+def test_popup_is_auto_followed(knob: tuple[str, Path]) -> None:
+    container, _ = knob
+    nav = _action(container, "navigate", url=_FIXTURE_URL)
+    ref = _ref_of(nav["snapshot"], "Open popup")
+    popped = _action(container, "click", ref=ref, description="open popup")
+    assert popped["ok"], popped["error"]
+    assert popped["url"].endswith("/popup.html")
+    assert len(popped["tabs"]) == 2
+    active = [t for t in popped["tabs"] if t["active"]]
+    assert len(active) == 1 and active[0]["url"].endswith("/popup.html")
+
+
+# -- navigate guard as shipped (strict container) ------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_message"),
+    [
+        # Address rows must carry the guard's OWN message: any connect failure
+        # also maps to navigation_failed, so without the message assert these
+        # rows would stay green with the address check deleted.
+        (_FIXTURE_URL, "non-public address"),  # loopback, no knob
+        ("http://169.254.169.254/latest/meta-data/", "non-public address"),  # cloud metadata
+        ("https://[::1]/", "non-public address"),  # v6 loopback
+        ("file:///etc/passwd", "only http(s) URLs"),  # scheme
+        ("data:text/html,hi", "only http(s) URLs"),  # scheme
+    ],
+)
+def test_navigate_guard_denies(strict: str, url: str, expected_message: str) -> None:
+    denied = _action(strict, "navigate", url=url)
+    assert not denied["ok"], f"guard let {url!r} through"
+    assert denied["error"]["code"] == "navigation_failed"
+    assert expected_message in denied["error"]["message"], denied["error"]
+
+
+# -- takeover lifecycle over the wire ------------------------------------------
+
+
+def test_takeover_lifecycle_screencast_and_input(knob: tuple[str, Path]) -> None:
+    container, plane = knob
+
+    # Land on the fixture and focus the query input (so spooled text has a target).
+    nav = _action(container, "navigate", url=_FIXTURE_URL)
+    query_ref = _ref_of(nav["snapshot"], "Query")
+    focused = _action(container, "click", ref=query_ref, description="focus input")
+    assert focused["ok"], focused["error"]
+
+    grant = f"g-{uuid.uuid4().hex[:6]}"
+    opened = invoke(
+        container,
+        {
+            "op": "takeover_open",
+            "session_id": "s1",
+            "args": {"grant_id": grant, "reason": "e2e"},
+            "timeout_ms": 45_000,
+        },
+        wrapper_s=50,
+    )
+    assert opened["ok"], opened["error"]
+    epoch = opened["epoch"]
+    assert epoch > 0
+    assert opened["data"]["target"]["url"] == _FIXTURE_URL
+    # page-blind top level while the gate is closed
+    assert opened["snapshot"] is None and opened["tabs"] == []
+    assert opened["url"] is None and opened["title"] is None
+
+    # agent actions are refused, page-blind — including url/title (a login URL
+    # can itself carry secrets in its query string)
+    blocked = _action(container, "snapshot")
+    assert not blocked["ok"] and blocked["error"]["code"] == "takeover_active"
+    assert blocked["snapshot"] is None and blocked["tabs"] == []
+    assert blocked["url"] is None and blocked["title"] is None
+
+    # status is the ONE op the gate does not block (the product polls it during
+    # takeovers) — and it stays page-blind beyond url/title.
+    status = invoke(container, {"op": "status", "timeout_ms": 10_000}, wrapper_s=15)
+    assert status["ok"], status["error"]
+    assert status["snapshot"] is None and status["tabs"] == []
+
+    # idempotent re-open: pure echo of the original epoch
+    echo = invoke(
+        container,
+        {
+            "op": "takeover_open",
+            "session_id": "s1",
+            "args": {"grant_id": grant},
+            "timeout_ms": 45_000,
+        },
+        wrapper_s=50,
+    )
+    assert echo["ok"] and echo["epoch"] == epoch
+
+    # the screencast publishes an atomic manifest naming a real frame
+    manifest_path = plane / "frames" / "manifest.json"
+    deadline = time.monotonic() + 20
+    manifest: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        if manifest_path.exists():
+            manifest = json.loads(manifest_path.read_text())
+            break
+        time.sleep(0.5)
+    assert manifest, "screencast never published a manifest"
+    assert manifest["epoch"] == epoch
+    assert manifest["origin"] == _FIXTURE_URL.rstrip("/")
+    assert manifest["security"] == "insecure"  # http fixture — derived from scheme
+    assert manifest["file"] == f"frame-{manifest['seq']}.jpg" and "/" not in manifest["file"]
+    assert (plane / "frames" / manifest["file"]).exists()
+
+    # spooled human input drives the page: text lands in the focused input,
+    # Enter submits, and the title mutation is observed after close. A second
+    # batch under a STALE epoch must be dropped. Written BEFORE the slower RSS
+    # probe so the takeover never counts as unclaimed (the driver self-closes
+    # an input-less, heartbeat-less takeover after 60s).
+    spool = plane / "input" / "spool.jsonl"
+    batches = [
+        {
+            "grant_id": grant,
+            "epoch": epoch,
+            "seq": 1,
+            "events": [
+                {"type": "text", "text": "human"},
+                {"type": "key_down", "key": "Enter"},
+                {"type": "key_up", "key": "Enter"},
+            ],
+        },
+        {
+            "grant_id": grant,
+            "epoch": epoch - 1,
+            "seq": 2,
+            "events": [{"type": "text", "text": "STALE"}],
+        },
+    ]
+    with spool.open("a") as f:
+        f.write("".join(json.dumps(b) + "\n" for b in batches))
+    time.sleep(2.0)  # tailer polls every 50ms; give injection + submit time to land
+
+    # RSS trip-wire under an active screencast (plan R1): < 1.5 GiB, inside
+    # the production 2 GiB cap the container runs under.
+    stats = run(
+        ["docker", "stats", "--no-stream", "--format", "{{.MemUsage}}", container], timeout=30
+    )
+    assert stats.returncode == 0, stats.stderr
+    used = stats.stdout.split("/")[0].strip()
+    m = re.fullmatch(r"([\d.]+)\s*(KiB|MiB|GiB)", used)
+    assert m, f"unparseable mem usage {used!r}"
+    scale = {"KiB": 1 / (1024 * 1024), "MiB": 1 / 1024, "GiB": 1.0}[m.group(2)]
+    gib = float(m.group(1)) * scale
+    assert gib < 1.5, f"browser container RSS {gib:.2f} GiB exceeds the 1.5 GiB trip-wire"
+
+    closed = invoke(
+        container,
+        {"op": "takeover_close", "args": {"grant_id": grant, "outcome": "done"}},
+        wrapper_s=40,
+    )
+    assert closed["ok"], closed["error"]
+    assert closed["epoch"] > epoch  # rotated again on close
+    assert closed["url"] is not None
+    assert closed["snapshot"], "handback must carry a fresh snapshot"
+    assert closed["shot_path"] and closed["shot_path"].startswith("shots/")
+    assert (plane / closed["shot_path"]).exists()
+    assert "signed_in_hosts" in closed["data"]
+
+    # replay: a redriven close returns the cached handback
+    replay = invoke(
+        container,
+        {"op": "takeover_close", "args": {"grant_id": grant, "outcome": "done"}},
+        wrapper_s=40,
+    )
+    assert replay["ok"] and replay["url"] == closed["url"]
+
+    # unknown grant → no_takeover; the agent can act again
+    unknown = invoke(
+        container,
+        {"op": "takeover_close", "args": {"grant_id": "g-nope"}},
+        wrapper_s=40,
+    )
+    assert not unknown["ok"] and unknown["error"]["code"] == "no_takeover"
+
+    # The agent can act again — and the re-observed page proves the spooled
+    # input drove it: the text landed in the focused input and Enter submitted
+    # the form (title mutation), while the stale-epoch batch was dropped.
+    acting = _action(container, "snapshot")
+    assert acting["ok"], acting["error"]
+    assert acting["title"] == "typed-human", (
+        f"spooled input never drove the page (title={acting['title']!r}) — "
+        "or the stale-epoch batch was applied"
+    )

--- a/tests/e2e/test_browser_image_contract.py
+++ b/tests/e2e/test_browser_image_contract.py
@@ -1,0 +1,340 @@
+"""Contract tests for the aios-browser Docker image (jarbot#106 Phase 2).
+
+Asserts every property the aios worker depends on when it drives an account's
+browser container: the runtime posture (uid 1000, daemon CMD, no listeners),
+the installed wire contract being byte-identical to the worker's
+``src/aios/sandbox/browser_protocol.py``, the ``browser-cli`` exit-code matrix
+against a live daemon, and — the load-bearing security assertions — that
+Chromium's own layered sandbox is ON under ``docker/seccomp-browser.json``
+while mount-namespace creation stays denied, with a NEGATIVE control proving
+the authored profile is what makes the launch possible at all.
+
+These tests shell out to the Docker CLI directly — no aios harness, no
+Postgres, no async. They require only a Docker daemon plus the image under
+test. The whole suite is opt-in: it skips when ``AIOS_SANDBOX_BROWSER_IMAGE``
+is unset, so the docker e2e shard stays green on deployments (and PRs) where
+the browser image is not wired up.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import needs_docker
+from tests.e2e.browser_image_common import (
+    IMAGE,
+    REPO_ROOT,
+    SANDBOX_SECCOMP,
+    invoke,
+    invoke_raw,
+    make_plane,
+    run,
+    start_browser_container,
+    wait_ready,
+)
+
+pytestmark = [
+    needs_docker,
+    pytest.mark.docker,
+    pytest.mark.skipif(
+        not IMAGE, reason="AIOS_SANDBOX_BROWSER_IMAGE not set; browser-image suite is opt-in"
+    ),
+]
+
+# CLONE_NEW* flag values (linux/sched.h) for the namespace probes.
+_CLONE_NEWNS = 0x20000
+_CLONE_NEWUSER = 0x10000000
+
+
+def _docker_run(*args: str, timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    """``docker run --rm IMAGE *args`` — plain posture probes of image defaults."""
+    return run(["docker", "run", "--rm", IMAGE, *args], timeout=timeout)
+
+
+@pytest.fixture(scope="module")
+def pulled_image() -> str:
+    """Ensure IMAGE is present locally; pull only if absent (a fresh CI build
+    under the same tag must not be clobbered by an older registry image)."""
+    if run(["docker", "image", "inspect", IMAGE], timeout=10).returncode == 0:
+        return IMAGE
+    result = run(["docker", "pull", IMAGE], timeout=600)
+    if result.returncode != 0:
+        pytest.fail(f"could not pull {IMAGE!r}: {result.stderr.strip()}")
+    return IMAGE
+
+
+@pytest.fixture(scope="module")
+def daemon(pulled_image: str, tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """A live browser container (driver ready, Chromium launched) shared by
+    the exit-code-matrix and sandbox-probe tests. Torn down unconditionally."""
+    plane = make_plane(tmp_path_factory.mktemp("browser-plane"))
+    name = f"aios-browser-contract-{uuid.uuid4().hex[:8]}"
+    start_browser_container(pulled_image, plane, name)
+    try:
+        wait_ready(name)
+        yield name
+    finally:
+        run(["docker", "rm", "--force", name], timeout=30)
+
+
+# -- image posture -------------------------------------------------------------
+
+
+def test_runs_as_uid_1000_with_matching_home(pulled_image: str) -> None:
+    """USER 1000:1000 = browser_protocol.PLANE_OWNER_UID, resolving to the
+    named ``aios`` user, with $HOME owned by the running uid (Chromium refuses
+    a foreign-owned home)."""
+    r = _docker_run(
+        "bash",
+        "-c",
+        'id -u; id -un; test "$(stat -c %u "$HOME")" = "$(id -u)" && echo home-ok',
+    )
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.split() == ["1000", "aios", "home-ok"], r.stdout
+
+
+def test_image_cmd_is_absolute_daemon(pulled_image: str) -> None:
+    """CMD is the daemon by absolute path (and WORKDIR is the plane mount);
+    the worker never overrides either, so a bare-name CMD would couple
+    container init to PATH (#925/#938)."""
+    r = run(
+        [
+            *("docker", "inspect", "--format"),
+            "{{json .Config.Cmd}}\t{{.Config.WorkingDir}}",
+            pulled_image,
+        ],
+        timeout=30,
+    )
+    assert r.returncode == 0, r.stderr
+    cmd_json, workdir = r.stdout.strip().split("\t")
+    assert json.loads(cmd_json) == ["/usr/local/bin/aios-browser-driver"]
+    assert workdir == "/workspace"
+    r = _docker_run("test", "-x", "/usr/local/bin/aios-browser-driver")
+    assert r.returncode == 0, r.stderr
+
+
+def test_chromium_installed_world_readable(pulled_image: str) -> None:
+    """PLAYWRIGHT_BROWSERS_PATH persisted to runtime and pointing at a tree
+    the uid-1000 daemon can execute (root installed it at build time)."""
+    r = _docker_run(
+        "bash",
+        "-c",
+        'test "$PLAYWRIGHT_BROWSERS_PATH" = /opt/ms-playwright '
+        "&& ls /opt/ms-playwright/chromium-*/chrome-linux*/chrome",
+    )
+    assert r.returncode == 0, f"chromium binary not found/readable: {r.stderr or r.stdout}"
+
+
+def test_protocol_bytes_match_checkout(pulled_image: str) -> None:
+    """The installed ``aios_browser_driver.browser_protocol`` is byte-identical
+    to the worker's ``src/aios/sandbox/browser_protocol.py`` — the single-source
+    overwrite in the Dockerfile actually happened, so the wire contract cannot
+    fork between worker and driver."""
+    r = _docker_run(
+        "python3",
+        "-c",
+        "import aios_browser_driver.browser_protocol as m, sys;"
+        "sys.stdout.buffer.write(open(m.__file__, 'rb').read())",
+    )
+    assert r.returncode == 0, r.stderr
+    repo = (REPO_ROOT / "src" / "aios" / "sandbox" / "browser_protocol.py").read_text()
+    assert r.stdout == repo, (
+        "installed browser_protocol.py differs from src/aios/sandbox/browser_protocol.py — "
+        "the image was built from a different protocol revision (stale tag?)"
+    )
+
+
+# -- exit-code matrix (the readiness proof) ------------------------------------
+
+
+class TestExitCodeContract:
+    """The worker's transport currency: exit 0 iff a response document was
+    produced (including ``ok: false``); nonzero = browser unavailable."""
+
+    def test_status_ok(self, daemon: str) -> None:
+        doc = invoke(daemon, {"op": "status", "timeout_ms": 10_000}, wrapper_s=15)
+        assert doc["ok"] is True
+        assert doc["boot"]
+        assert "signed_in_hosts" in doc["data"]
+
+    def test_malformed_request_is_exit_zero_invalid_request(self, daemon: str) -> None:
+        """browser-cli forwards bytes verbatim; the DAEMON rejects garbage with
+        a full ``invalid_request`` envelope at exit 0."""
+        r = invoke_raw(daemon, "this is not json", wrapper_s=15)
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+        doc = json.loads(r.stdout)
+        assert doc["ok"] is False
+        assert doc["error"]["code"] == "invalid_request"
+
+    def test_unknown_op_is_exit_zero(self, daemon: str) -> None:
+        doc = invoke(daemon, {"op": "frobnicate", "timeout_ms": 10_000}, wrapper_s=15)
+        assert doc["ok"] is False
+        assert doc["error"]["code"] == "unknown_op"
+
+    def test_daemon_down_is_nonzero_connect_exit(self, pulled_image: str, tmp_path: Path) -> None:
+        """With no daemon bound, browser-cli must exit 7 (connect failure) —
+        never 0, never 137 — after its bounded connect retry."""
+        plane = make_plane(tmp_path)
+        name = f"aios-browser-nodaemon-{uuid.uuid4().hex[:8]}"
+        # CMD override: container alive, daemon NOT running.
+        start_browser_container(pulled_image, plane, name, command=["sleep", "300"])
+        try:
+            r = invoke_raw(name, json.dumps({"op": "status", "timeout_ms": 2_000}), wrapper_s=15)
+            assert r.returncode == 7, (
+                f"expected exit 7 (connect failure), got {r.returncode}: "
+                f"stdout={r.stdout!r} stderr={r.stderr!r}"
+            )
+        finally:
+            run(["docker", "rm", "--force", name], timeout=30)
+
+    def test_usage_error_is_exit_two(self, daemon: str) -> None:
+        r = run(["docker", "exec", daemon, "browser-cli"], timeout=30)
+        assert r.returncode == 2, f"stdout={r.stdout!r} stderr={r.stderr!r}"
+
+
+# -- Chromium sandbox (the load-bearing security assertions) -------------------
+
+
+def _renderer_pids(container: str) -> list[str]:
+    """PIDs of Chromium renderer processes inside the container."""
+    script = (
+        "for p in /proc/[0-9]*/cmdline; do "
+        "tr '\\0' ' ' < \"$p\" 2>/dev/null | grep -q -- --type=renderer "
+        '&& basename "$(dirname "$p")"; done; true'
+    )
+    r = run(["docker", "exec", container, "bash", "-c", script], timeout=30)
+    return [line.strip() for line in r.stdout.splitlines() if line.strip().isdigit()]
+
+
+def test_chromium_sandbox_is_on(daemon: str) -> None:
+    """PRIMARY sandbox-ON assertion (plan CI-C2), via the two /proc-observable
+    facts of Chromium's layered sandbox:
+
+    * layer 1 (namespace): the renderer's user namespace differs from the
+      container init's;
+    * layer 2 (seccomp-bpf): the renderer carries MORE seccomp filters than
+      init. ``Seccomp: 2`` alone is vacuous — docker's container-level profile
+      puts EVERY process in filter mode — so the load-bearing signal is the
+      ``Seccomp_filters`` count (kernel >= 5.9): init has only docker's, the
+      renderer has docker's plus Chromium's own.
+
+    chrome://sandbox scraping is deliberately not used (unreliable under new
+    headless)."""
+    deadline = time.monotonic() + 30
+    pids: list[str] = []
+    while time.monotonic() < deadline and not pids:
+        pids = _renderer_pids(daemon)
+        if not pids:
+            time.sleep(1.0)
+    assert pids, "no Chromium renderer process found — did the persistent context open a page?"
+
+    pid = pids[0]
+    r = run(
+        [
+            *("docker", "exec", daemon, "bash", "-c"),
+            f"grep -h '^Seccomp_filters:' /proc/{pid}/status /proc/1/status"
+            f" && readlink /proc/{pid}/ns/user /proc/1/ns/user",
+        ],
+        timeout=30,
+    )
+    assert r.returncode == 0, r.stderr
+    filters_line_r, filters_line_i, renderer_ns, init_ns = r.stdout.strip().splitlines()
+    renderer_filters = int(filters_line_r.split()[-1])
+    init_filters = int(filters_line_i.split()[-1])
+    assert renderer_filters > init_filters, (
+        f"renderer has {renderer_filters} seccomp filter(s) vs init's {init_filters} — "
+        "Chromium's own seccomp-bpf layer is NOT applied (docker's profile alone)"
+    )
+    assert renderer_ns != init_ns, (
+        "renderer shares the container's user namespace — Chromium's namespace "
+        f"sandbox is NOT active ({renderer_ns})"
+    )
+
+
+def test_chromium_launch_fails_under_sandbox_profile(pulled_image: str, tmp_path: Path) -> None:
+    """NEGATIVE control (plan CI-C2): under ``seccomp-sandbox.json`` (which
+    denies unprivileged userns creation) Chromium cannot construct its sandbox
+    and hard-aborts; the daemon crashes visibly, so the container EXITS
+    nonzero. This proves the authored browser profile is load-bearing — if
+    Chromium ever ran happily under the sandbox profile, either the sandbox
+    silently degraded or the profiles converged; both are red."""
+    plane = make_plane(tmp_path)
+    name = f"aios-browser-negctl-{uuid.uuid4().hex[:8]}"
+    start_browser_container(pulled_image, plane, name, seccomp=SANDBOX_SECCOMP)
+    try:
+        # docker wait blocks until the container exits and prints the exit
+        # code; the in-container timeout(1) is not involved, so bound it with
+        # the subprocess timeout and treat expiry as "still running".
+        try:
+            waited = run(["docker", "wait", name], timeout=90)
+        except Exception:
+            pytest.fail(
+                "container still running under the sandbox seccomp profile — Chromium "
+                "launched WITHOUT its namespace sandbox, or the profiles no longer differ"
+            )
+        assert waited.returncode == 0, waited.stderr
+        assert int(waited.stdout.strip()) != 0, "daemon exited 0 after a failed Chromium launch"
+    finally:
+        run(["docker", "rm", "--force", name], timeout=30)
+
+
+def test_mount_namespace_denied_userns_permitted(daemon: str) -> None:
+    """The authored mask, probed live in the daemon's own container. ORDER
+    MATTERS: the probe first enters a fresh user namespace — what Chromium's
+    zygote needs, and the step that grants CAP_SYS_ADMIN *in that namespace* —
+    and only then attempts unshare(CLONE_NEWNS). The kernel would permit that
+    second call (the process holds CAP_SYS_ADMIN in its userns), so EPERM
+    there proves the seccomp mask and nothing else. Probing NEWNS from the
+    initial namespace would be vacuous: the kernel itself EPERMs unprivileged
+    mount-namespace creation with or without seccomp."""
+    probe = (
+        "import ctypes;"
+        "libc = ctypes.CDLL(None, use_errno=True);"
+        f"ruser = libc.unshare({_CLONE_NEWUSER}); euser = ctypes.get_errno();"
+        f"rns = libc.unshare({_CLONE_NEWNS}); ens = ctypes.get_errno();"
+        "print(ruser, euser, rns, ens)"
+    )
+    r = run(["docker", "exec", daemon, "python3", "-c", probe], timeout=60)
+    assert r.returncode == 0, r.stderr
+    ruser, _euser, rns, ens = (int(x) for x in r.stdout.split())
+    assert ruser == 0, f"unshare(CLONE_NEWUSER) must succeed under the browser profile: {r.stdout}"
+    assert (rns, ens) == (-1, 1), (
+        f"unshare(CLONE_NEWNS) from inside a userns must fail EPERM (the seccomp mask), "
+        f"got rc={rns} errno={ens}"
+    )
+
+
+def test_no_tcp_listeners(daemon: str) -> None:
+    """No process in the container LISTENs on any TCP port — the daemon speaks
+    AF_UNIX only and Chromium's CDP rides playwright's --remote-debugging-pipe.
+    /proc/net state 0A = LISTEN."""
+    r = run(
+        ["docker", "exec", daemon, "bash", "-c", "cat /proc/net/tcp /proc/net/tcp6 2>/dev/null"],
+        timeout=30,
+    )
+    assert r.returncode == 0, r.stderr
+    listeners = [
+        line for line in r.stdout.splitlines() if len(line.split()) > 3 and line.split()[3] == "0A"
+    ]
+    assert listeners == [], f"unexpected TCP listeners in browser container:\n{listeners}"
+
+
+# -- multi-arch manifest -------------------------------------------------------
+
+
+def test_manifest_includes_amd64_and_arm64(pulled_image: str) -> None:
+    """Published images should be multi-arch. Queries the REMOTE manifest;
+    skips gracefully for local-only tags and offline runs."""
+    result = run(["docker", "buildx", "imagetools", "inspect", pulled_image], timeout=30)
+    if result.returncode != 0:
+        pytest.skip(f"imagetools inspect unavailable for {pulled_image}: {result.stderr.strip()}")
+    output = result.stdout + result.stderr
+    assert "linux/amd64" in output
+    assert "linux/arm64" in output

--- a/tests/unit/sandbox/test_browser_seccomp_profile.py
+++ b/tests/unit/sandbox/test_browser_seccomp_profile.py
@@ -1,0 +1,119 @@
+"""Structural pins for ``docker/seccomp-browser.json`` (jarbot#106 Phase 2).
+
+The authored browser profile has exactly one job: re-permit the unprivileged
+USER/PID/NET namespaces Chromium's own sandbox needs while keeping MOUNT (and
+CGROUP/UTS/IPC) namespace creation denied. These tests pin the JSON shape so a
+re-vendor or an edit cannot silently regress the mask — the failure mode the
+design review caught in draft (a mask omitting CLONE_NEWNS would have
+re-enabled mount-namespace creation). The live-kernel counterpart runs in
+``tests/e2e/test_browser_image_contract.py`` against a real container.
+
+Pure JSON inspection — no Docker required, runs in the normal unit lane.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_DOCKER_DIR = Path(__file__).resolve().parents[3] / "docker"
+
+# linux/sched.h CLONE_NEW* flag values.
+_NEWNS = 0x20000
+_NEWCGROUP = 0x2000000
+_NEWUTS = 0x4000000
+_NEWIPC = 0x8000000
+
+# The namespaces the browser profile keeps DENYING. Everything Chromium's
+# zygote needs (NEWUSER | NEWPID | NEWNET) is deliberately absent from the
+# mask; NEWNS is the must-not-regress bit.
+_DENIED_MASK = _NEWNS | _NEWCGROUP | _NEWUTS | _NEWIPC  # 0x0E020000 = 235012096
+
+
+@pytest.fixture(scope="module")
+def profile() -> dict[str, Any]:
+    data: dict[str, Any] = json.loads((_DOCKER_DIR / "seccomp-browser.json").read_text())
+    return data
+
+
+def test_default_action_is_eperm(profile: dict[str, Any]) -> None:
+    """Anything unmatched is denied with EPERM (never KILL)."""
+    assert profile["defaultAction"] == "SCMP_ACT_ERRNO"
+    assert profile["defaultErrnoRet"] == 1
+
+
+def test_authored_block_is_first_and_masks_exactly_the_denied_namespaces(
+    profile: dict[str, Any],
+) -> None:
+    """The authored clone/unshare allow sits at index 0 (ahead of every
+    vendored rule) and its mask is EXACTLY the four denied namespaces."""
+    block = profile["syscalls"][0]
+    assert sorted(block["names"]) == ["clone", "unshare"]
+    assert block["action"] == "SCMP_ACT_ALLOW"
+    (arg,) = block["args"]
+    assert arg == {
+        "index": 0,
+        "value": _DENIED_MASK,
+        "valueTwo": 0,
+        "op": "SCMP_CMP_MASKED_EQ",
+    }
+    # s390* pass clone flags in arg1; excluded rather than silently misread.
+    assert block["excludes"] == {"arches": ["s390", "s390x"]}
+
+
+def test_no_other_unconditional_clone_or_unshare_allow(profile: dict[str, Any]) -> None:
+    """Nothing after the authored block may allow clone/unshare more broadly:
+    every later allow must be arg-filtered or capability-gated, so the
+    authored mask stays the effective policy for plain processes."""
+    for block in profile["syscalls"][1:]:
+        if block.get("action") != "SCMP_ACT_ALLOW":
+            continue
+        if not set(block.get("names", [])) & {"clone", "unshare"}:
+            continue
+        gated = bool(block.get("args")) or bool((block.get("includes") or {}).get("caps"))
+        assert gated, f"ungated clone/unshare allow after the authored block: {block}"
+
+
+def test_clone3_stays_enosys(profile: dict[str, Any]) -> None:
+    """clone3 must return ENOSYS so glibc falls back to clone, where the
+    authored arg0 filter applies (clone3 passes flags in a struct seccomp
+    cannot inspect — allowing it would bypass the mask entirely)."""
+    rules = [b for b in profile["syscalls"] if "clone3" in b.get("names", [])]
+    enosys = [b for b in rules if b.get("action") == "SCMP_ACT_ERRNO" and b.get("errnoRet") == 38]
+    assert enosys, "no clone3 → ENOSYS rule; glibc would not fall back to filtered clone"
+    for rule in rules:
+        if rule.get("action") == "SCMP_ACT_ALLOW":
+            caps = (rule.get("includes") or {}).get("caps")
+            assert caps, f"ungated clone3 allow would bypass the arg0 mask: {rule}"
+
+
+def test_ptrace_stays_allowed_for_crashpad(profile: dict[str, Any]) -> None:
+    """Unlike seccomp-sandbox.json there is deliberately NO flat ptrace deny:
+    Chromium's crashpad handler ptraces its own processes, and no agent code
+    runs in this container. The vendored kernel>=4.8 allow must survive."""
+    for block in profile["syscalls"]:
+        names = set(block.get("names", []))
+        if "ptrace" in names and block.get("action") == "SCMP_ACT_ERRNO":
+            pytest.fail(f"ptrace deny block present — crashpad would break: {sorted(names)}")
+    allowed = any(
+        "ptrace" in block.get("names", []) and block.get("action") == "SCMP_ACT_ALLOW"
+        for block in profile["syscalls"]
+    )
+    assert allowed, "no ptrace allow rule found in the vendored base"
+
+
+def test_vendored_base_identical_to_sandbox_profile(profile: dict[str, Any]) -> None:
+    """Both profiles claim the same verbatim-vendored moby v24.0.7 base
+    (browser = 1 authored block + base; sandbox = 2 authored blocks + base).
+    A re-vendor of ONE file would silently fork that shared base — this pin
+    turns it into a failure that names the maintenance step: re-vendor both,
+    re-applying each file's authored front blocks."""
+    sandbox = json.loads((_DOCKER_DIR / "seccomp-sandbox.json").read_text())
+    assert profile["syscalls"][1:] == sandbox["syscalls"][2:], (
+        "the vendored syscall blocks of seccomp-browser.json and seccomp-sandbox.json have diverged"
+    )
+    for key in ("archMap", "defaultAction", "defaultErrnoRet"):
+        assert profile[key] == sandbox[key], f"top-level {key!r} diverged between the profiles"

--- a/tests/unit/sandbox/test_browser_spec_posture.py
+++ b/tests/unit/sandbox/test_browser_spec_posture.py
@@ -1,0 +1,55 @@
+"""Posture pins for ``build_spec_from_browser`` (jarbot#106).
+
+Three docstrings in the browser stack lean on claims about the browser
+container's spec that no test asserted directly — most load-bearing:
+``environment={}``, which is what makes the driver's
+``AIOS_BROWSER_DRIVER_ALLOW_PRIVATE_NAV`` test knob (an SSRF-guard bypass)
+unsettable through aios. If a future change threads env into the browser
+spec, this fails instead of silently arming the knob path in production.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aios.config import get_settings
+from aios.sandbox.network import BROWSER_NETWORK_NAME
+from aios.sandbox.spec import BrowserImageUnconfiguredError, build_spec_from_browser
+
+
+@pytest.fixture
+def browser_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    monkeypatch.setattr(settings, "sandbox_browser_image", "aios-browser:test")
+
+
+def test_browser_spec_posture(browser_settings: None) -> None:
+    spec = build_spec_from_browser("acc_TESTOWNER")
+    # No env injection — the driver's private-nav test knob (and any future
+    # env-keyed behavior) is unreachable through aios by construction.
+    assert spec.environment == {}
+    # No route to the worker; the worker reaches the container via exec only.
+    assert spec.host_gateway_alias is None
+    # The plane is the ONLY mount.
+    assert spec.extra_mounts == ()
+    assert spec.workspace.sandbox_path == "/workspace"
+    assert spec.network_name == BROWSER_NETWORK_NAME
+    assert spec.seccomp_profile == get_settings().sandbox_browser_seccomp_profile
+
+
+def test_browser_spec_rejects_non_account_owner(browser_settings: None) -> None:
+    with pytest.raises(ValueError, match="account id"):
+        build_spec_from_browser("ses_NOTANACCOUNT")
+
+
+def test_browser_spec_requires_configured_image(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    monkeypatch.setattr(settings, "sandbox_browser_image", "")
+    with pytest.raises(BrowserImageUnconfiguredError):
+        build_spec_from_browser("acc_TESTOWNER")


### PR DESCRIPTION
## Phase 2, PR4 of 5 — the browser image, its seccomp profile, and the gates

Fourth PR of the jarbot#106 **Phase 2** stack: the Docker image the worker execs into (Chromium + the `aios-browser-driver` daemon), the authored seccomp profile that lets Chromium's own sandbox run, the GHCR build/smoke workflow, and the two e2e suites that gate `:smoked`. **Ships dark** — nothing consumes the image until PR5 wires `AIOS_SANDBOX_BROWSER_IMAGE`, and the rollout gate (`test_browser_network_isolation.py` green per environment before any `browser_*` grant) is unchanged.

> **Stacked on #2286** (`feat/browser-driver-takeover`). Review the [PR3↔PR4 diff](https://github.com/eumemic/aios/compare/feat/browser-driver-takeover...feat/browser-driver-image); merges after PR3.

### What's here

- **`docker/Dockerfile.browser`** — python:3.13-slim + the driver installed standalone, with `src/aios/sandbox/browser_protocol.py` COPYed **over** the package's vendored copy (the installed wire contract is byte-identical to the worker's — asserted against a live container). Chromium via `playwright install --no-shell` under a persisted `PLAYWRIGHT_BROWSERS_PATH`; `USER 1000:1000` (= `PLANE_OWNER_UID`); CMD is the daemon by absolute path. Layers are ordered deps-first so a driver/protocol push rebuilds one cheap wheel layer, not the QEMU-arm64 apt+Chromium legs. ~1.29 GB/arch.
- **`docker/seccomp-browser.json`** — moby's default profile (v24.0.7, verbatim — same vendored base as the sandbox profile, now **pinned equal by a unit test**) plus ONE authored block: allow `clone`/`unshare` when `(arg0 & 0x0E020000) == 0`. That re-permits exactly the unprivileged USER/PID/NET namespaces Chromium's zygote needs while keeping MOUNT/CGROUP/UTS/IPC namespace creation denied; ptrace stays allowed (crashpad), clone3 stays ENOSYS. The browser-process userns residual and its compensations (runc default + patched-kernel floor, gVisor opt-in) are named in the profile itself.
- **`.github/workflows/build-browser-image.yml`** — QEMU amd64+arm64 → GHCR `latest`+`sha-<short>` → smoke runs **both** e2e suites against the immutable sha tag → retag `:smoked`. Triggers include the protocol module, the sandbox profile (the negative control's input), `.dockerignore`, and the gate suites themselves.
- **`tests/e2e/test_browser_image_contract.py`** — posture, protocol byte-equality, the `browser-cli` exit-code matrix through the worker's exact exec shape, no TCP listeners, and the security pair: **sandbox-ON** (renderer in a distinct userns AND carrying *more* seccomp filters than init — `Seccomp: 2` alone is vacuous under docker) + the **negative control** (the daemon container must EXIT under the sandbox profile) + the live mask probe (userns-first, so the observed `unshare(CLONE_NEWNS)` EPERM can only be the seccomp mask).
- **`tests/e2e/test_browser_driver_behavior.py`** — a knob container (loopback fixture off the plane mount) drives every action op end-to-end with title-mutation proofs (keystrokes, wheel sign), download persistence, ref staleness, the password guardrail, popup follow; a strict container proves the navigate deny matrix **with the guard's own message text** (any connect failure maps to the same code, so code-only asserts were bypassable); and the full takeover lifecycle over the wire — page-blind ack/refusals/status, idempotent echo, screencast manifest on the host plane, spooled input driving the page (stale-epoch batch provably dropped), RSS trip-wire under the production 2 GiB cap, close handback + replay.
- Both suites share `tests/e2e/browser_image_common.py` — one test-side statement of the exec shape and the production `docker run` recipe (**including the 2 CPU / 2 GiB / 512-pids caps**), and both self-skip without `AIOS_SANDBOX_BROWSER_IMAGE`, so the PR docker shard stays green until PR5.

### Found by this PR's gates, fixed at the source

The sandbox-ON probe caught that **PR2's Chromium had been running with `--no-sandbox`**: playwright defaults the sandbox OFF unless `chromium_sandbox=True` is passed — keeping the flag out of our args list was not enough. Fixed in PR2 (amended, stack rebased); the probe now proves renderers run namespaced + double-filtered.

### Review

5-agent plan red-team (prior session), then the usual **8-agent uncorrelated closing review** (reuse / simplification / efficiency / altitude + contract-conformance, seccomp/docker-infra, CI-workflow, security). Highlights folded: two initially-vacuous security probes made load-bearing (NEWNS-after-userns ordering, `Seccomp_filters` count vs init), guard-message asserts on the deny matrix, completed page-blind coverage incl. mid-takeover `status`, production resource caps on the test containers, the Dockerfile layer reorder, per-image gha cache scopes (siblings fixed too), and a detect-filter fix (`walker.js` — the first load-bearing non-Python source in `packages/` — escaped the `.py$` arm). Deferred with note: image dep-pinning via hashed export (hardening set); a real-provisioning-path sandbox-ON probe + the `sandbox_changed` tightening (PR5). Watch-item: the first master run is the first CI exercise of Chromium-userns-in-container on GHA ubuntu-24.04 — analysis says docker-default AppArmor exempts it; failure is loud and one sysctl step away.

### Checks

`ruff` / `mypy` clean; 5395 unit + 108 package tests pass; both e2e suites green against a locally built image (25 passed — sandbox-ON, negative control, mask probe, exit-code matrix, full takeover lifecycle all live against real Chromium under the authored profile), with probe non-vacuity proven under `seccomp=unconfined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
