### PR TITLE
feat(browser): Phase 2 PR5 — wire the browser image into worker + CI

### DIFF
--- a/.github/workflows/build-browser-image.yml
+++ b/.github/workflows/build-browser-image.yml
@@ -33,6 +33,10 @@ on:
       # The context filter shapes what the Dockerfile's COPYs see.
       - .dockerignore
       - packages/aios-browser-driver/**
+      # The driver's own tests are ``.dockerignore``d out of the build
+      # context — a tests-only push cannot change the image, so it must not
+      # burn the QEMU multi-arch build.
+      - "!packages/aios-browser-driver/tests/**"
       - src/aios/sandbox/browser_protocol.py
       # The gates themselves: ``:smoked`` means "passed THESE suites".
       - tests/e2e/test_browser_image_contract.py

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -31,6 +31,7 @@ jobs:
     outputs:
       run_checks: ${{ steps.filter.outputs.run_checks }}
       sandbox_changed: ${{ steps.filter.outputs.sandbox_changed }}
+      browser_changed: ${{ steps.filter.outputs.browser_changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,12 +60,13 @@ jobs:
 
           # First push to a new branch, force-push from a non-fast-forward,
           # or any case where `before` is the all-zeros SHA: be conservative
-          # and run the full pipeline AND rebuild the sandbox image (since
-          # we cannot tell whether its inputs changed).
+          # and run the full pipeline AND rebuild both images (since we
+          # cannot tell whether their inputs changed).
           if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
-            echo "No usable base ref — running checks and rebuilding sandbox."
+            echo "No usable base ref — running checks and rebuilding sandbox + browser images."
             echo "run_checks=true" >> "$GITHUB_OUTPUT"
             echo "sandbox_changed=true" >> "$GITHUB_OUTPUT"
+            echo "browser_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -87,7 +89,10 @@ jobs:
           # ``aios-browser-driver`` is matched whole: it ships the first
           # runtime-load-bearing non-Python source in ``packages/``
           # (``snapshot/walker.js``), which the ``\.py$`` arm would miss.
-          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^connectors/[^/]+/Dockerfile$|^bin/tool$|^\.github/workflows/|^packages/aios-browser-driver/|^packages/[^/]+/(pyproject\.toml|CHANGELOG\.md)$|^Dockerfile$|^compose\.yml$|^openapi\.json$'; then
+          # ``.dockerignore`` shapes the browser image's package COPY, so a
+          # PR touching only it must still reach the e2e job (where
+          # ``browser_changed`` routes it into a rebuild).
+          if echo "$changed" | grep -qE '\.py$|^pyproject\.toml$|^uv\.lock$|^alembic\.ini$|^migrations/|^docker/|^connectors/[^/]+/Dockerfile$|^bin/tool$|^\.github/workflows/|^packages/aios-browser-driver/|^packages/[^/]+/(pyproject\.toml|CHANGELOG\.md)$|^Dockerfile$|^compose\.yml$|^openapi\.json$|^\.dockerignore$'; then
             echo "Build-affecting changes detected — running checks."
             echo "run_checks=true" >> "$GITHUB_OUTPUT"
           else
@@ -95,19 +100,43 @@ jobs:
             echo "run_checks=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Sandbox image inputs: anything under ``docker/`` (currently
-          # only ``Dockerfile.sandbox``, but future COPY-source files
-          # added here would also count) plus the ``bin/tool`` binary the
-          # Dockerfile COPYs in.  When none changed, the ``e2e`` job can
-          # pull ``ghcr.io/eumemic/aios-sandbox:smoked`` (published by
+          # Sandbox image inputs: exactly what ``docker/Dockerfile.sandbox``
+          # is built from — itself plus the ``bin/tool`` binary it COPYs.
+          # When none changed, the ``e2e`` job can pull
+          # ``ghcr.io/eumemic/aios-sandbox:smoked`` (published by
           # ``build-sandbox.yml`` after its smoke test passes) instead of
-          # rebuilding from scratch — saves ~29 s per run.
-          if echo "$changed" | grep -qE '^docker/|^bin/tool$'; then
+          # rebuilding from scratch — saves ~29 s per run.  Deliberately NOT
+          # ``^docker/``: the browser image's inputs and the seccomp profiles
+          # live there too, and none of them are sandbox-image inputs (the
+          # profiles are read from the checkout at ``docker run`` time, never
+          # baked into either image), so a browser-only PR must not force a
+          # sandbox rebuild.  ``tests/unit/test_detect_filter_sync.py`` pins
+          # both image filters.
+          if echo "$changed" | grep -qE '^docker/Dockerfile\.sandbox$|^bin/tool$'; then
             echo "Sandbox inputs changed — rebuilding image."
             echo "sandbox_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "Sandbox inputs unchanged — will pull pre-built image."
             echo "sandbox_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Browser image inputs: what ``docker/Dockerfile.browser`` is built
+          # from — itself, the driver package's SHIPPED files (the package
+          # dir enumerated by top-level entry, because ``tests/`` is
+          # ``.dockerignore``d out of the build context and must not trigger
+          # the ~10 min rebuild), the protocol module COPYed over the
+          # package's vendored copy, and ``.dockerignore`` itself (it shapes
+          # the package-directory COPY; the sandbox image COPYs only single
+          # files, so it is not a sandbox input).  When none changed, the
+          # ``e2e`` job pulls ``ghcr.io/eumemic/aios-browser:smoked``
+          # (published by ``build-browser-image.yml`` after BOTH browser e2e
+          # suites pass) instead of paying the local build.
+          if echo "$changed" | grep -qE '^docker/Dockerfile\.browser$|^packages/aios-browser-driver/(aios_browser_driver/|pyproject\.toml$|README\.md$)|^src/aios/sandbox/browser_protocol\.py$|^\.dockerignore$'; then
+            echo "Browser-image inputs changed — rebuilding image."
+            echo "browser_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Browser-image inputs unchanged — will pull pre-built image."
+            echo "browser_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
   # The four check jobs below run in parallel.  Splitting them off the
@@ -384,19 +413,23 @@ jobs:
   e2e:
     needs: detect
     runs-on: ubuntu-latest
-    # Generous: covers the sandbox-build fallback and the non-docker
-    # shard's full-suite flake retry.
-    timeout-minutes: 30
+    # Docker shard: covers the image fallbacks — a sandbox rebuild plus,
+    # worst case, the ~10 min local browser build when ``:smoked`` is
+    # missing or stale.  Non-docker shard keeps the original 30 (its worst
+    # case is the full-suite flake retry); a wedge there should still fail
+    # fast.
+    timeout-minutes: ${{ matrix.shard == 'docker' && 45 || 30 }}
 
     strategy:
       fail-fast: false
       matrix:
         shard: [non-docker, docker]
 
-    # Required to ``docker pull`` the sandbox image from GHCR when its
-    # inputs are unchanged.  Read-only; the ``build-sandbox.yml`` workflow
-    # is the only writer.  Only the docker shard actually uses it, but
-    # GHA does not support per-matrix-leg permissions.
+    # Required to ``docker pull`` the sandbox/browser images from GHCR when
+    # their inputs are unchanged.  Read-only; ``build-sandbox.yml`` and
+    # ``build-browser-image.yml`` are the only writers.  Only the docker
+    # shard actually uses it, but GHA does not support per-matrix-leg
+    # permissions.
     permissions:
       contents: read
       packages: read
@@ -437,9 +470,10 @@ jobs:
         run: uv sync --dev
 
       - name: Log in to GHCR
-        # Needed only for the ``docker pull`` path below.  When the sandbox
-        # is being rebuilt locally this login is unused but harmless.
-        if: needs.detect.outputs.run_checks == 'true' && matrix.shard == 'docker' && needs.detect.outputs.sandbox_changed == 'false'
+        # Needed only for the ``docker pull`` paths below (sandbox and/or
+        # browser image).  When both are being rebuilt locally this login is
+        # unused but harmless.
+        if: needs.detect.outputs.run_checks == 'true' && matrix.shard == 'docker' && (needs.detect.outputs.sandbox_changed == 'false' || needs.detect.outputs.browser_changed == 'false')
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -490,9 +524,10 @@ jobs:
         # Post-build sanity probes the daemon's image store and the
         # one binary the build added; if either is missing the step
         # fails here rather than letting a silent fallback misroute
-        # later. ``set -euo pipefail`` is the workflow default but
-        # the explicit ``|| exit 1`` after the ``docker run`` makes
-        # the failure mode obvious in the log.
+        # later. GHA's default shell is ``bash -e {0}`` (NO pipefail —
+        # that needs an explicit ``shell: bash``), so avoid pipelines in
+        # these steps; the explicit ``|| exit 1`` after the ``docker run``
+        # makes the failure mode obvious in the log.
         #
         # Fires when the Dockerfile/bin/tool inputs changed (so the pull
         # path was skipped) OR when the pull path attempted and failed.
@@ -507,6 +542,54 @@ jobs:
             echo "::error::bin/tool not found in built image — build step did not produce expected artifacts"
             exit 1
           }
+
+      - name: Pull browser image from GHCR
+        # Same shape and rationale as the sandbox pull above; ``:smoked`` is
+        # published by ``build-browser-image.yml`` only after BOTH browser
+        # e2e suites pass against the freshly built sha tag.
+        #
+        # The stale-probe mirrors the sandbox lane's ``which tool``: the
+        # image's installed ``browser_protocol.py`` must be byte-identical to
+        # the checkout's.  The contract e2e asserts the same equality later,
+        # but only THIS step's failure routes into the local-build fallback —
+        # probing here turns a stale ``:smoked`` (protocol advanced on master
+        # between this PR's base and the last publish) into a self-healing
+        # rebuild instead of a red shard.
+        id: pull_browser
+        if: needs.detect.outputs.run_checks == 'true' && matrix.shard == 'docker' && needs.detect.outputs.browser_changed == 'false'
+        continue-on-error: true
+        run: |
+          docker pull ghcr.io/eumemic/aios-browser:smoked
+          docker tag ghcr.io/eumemic/aios-browser:smoked aios-browser:ci
+          docker image inspect aios-browser:ci --format 'image registered: {{.Id}}'
+          docker run --rm aios-browser:ci python3 -c \
+            "import aios_browser_driver.browser_protocol as m, sys; sys.stdout.buffer.write(open(m.__file__, 'rb').read())" \
+            > /tmp/installed-protocol.py
+          cmp /tmp/installed-protocol.py src/aios/sandbox/browser_protocol.py || {
+            echo "::error::installed browser_protocol.py differs from checkout — :smoked is stale relative to HEAD"
+            exit 1
+          }
+
+      - name: Build browser image
+        # Fires when the image inputs changed (the pull path was skipped) OR
+        # the pull attempted and failed — GHCR outage, ``:smoked`` not yet
+        # published (e.g. the first run after the browser lane merges, before
+        # ``build-browser-image.yml``'s first master publish), or the
+        # stale-probe above tripped.  amd64-only and QEMU-free, unlike the
+        # publishing workflow — roughly a 10-minute cold build (apt
+        # install-deps + Chromium download dominate).
+        #
+        # Deliberately no post-build protocol probe (the sandbox lane re-runs
+        # ``which tool`` here): a from-checkout build is protocol-identical
+        # by construction, and the contract e2e re-asserts byte equality in
+        # this same shard.
+        if: needs.detect.outputs.run_checks == 'true' && matrix.shard == 'docker' && ( needs.detect.outputs.browser_changed == 'true' || steps.pull_browser.outcome == 'failure' )
+        run: |
+          if [[ "${{ steps.pull_browser.outcome }}" == "failure" ]]; then
+            echo "::warning::GHCR pull failed; falling back to local browser build"
+          fi
+          docker build -t aios-browser:ci -f docker/Dockerfile.browser .
+          docker image inspect aios-browser:ci --format 'image registered: {{.Id}}'
 
       - name: E2E tests (non-docker shard)
         # These tests are "non-docker" only in the sandbox-image sense: most
@@ -537,6 +620,11 @@ jobs:
         if: needs.detect.outputs.run_checks == 'true' && matrix.shard == 'docker'
         env:
           AIOS_DOCKER_IMAGE: aios-sandbox:ci
+          # Points the three browser suites (image contract, driver behavior,
+          # and the isolation gate's real-provisioning-path probes) at the
+          # CI-local image pulled/built above; those suites self-skip when
+          # this is unset.
+          AIOS_SANDBOX_BROWSER_IMAGE: aios-browser:ci
         # ``-m "docker and not perf"``: the ``perf`` mark is the ADVISORY
         # wall-clock scaling backstop (#1661) — it is deliberately EXCLUDED
         # from this gating run because shared-runner jitter can exceed its
@@ -560,5 +648,6 @@ jobs:
         continue-on-error: true
         env:
           AIOS_DOCKER_IMAGE: aios-sandbox:ci
+          AIOS_SANDBOX_BROWSER_IMAGE: aios-browser:ci
         run: |
           uv run pytest tests/e2e -q -m "docker and perf" -n 4 --dist=loadfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,11 +56,15 @@ COPY migrations ./migrations
 # worker image; the worker resolves it via ``Path(__file__).parents[3]``.
 COPY bin ./bin
 COPY src ./src
-# Authored seccomp profile for sandbox containers (#807). The worker's docker
-# CLI reads this from its OWN filesystem and ships the JSON to the daemon (the
-# daemon never reads the worker's FS). Must match the default resolved by
-# Settings.sandbox_seccomp_profile (/app/docker/seccomp-sandbox.json).
+# Authored seccomp profiles — sandbox containers (#807) and browser
+# containers (jarbot#106 Phase 2). The worker's docker CLI reads these from
+# its OWN filesystem and ships the JSON to the daemon (the daemon never reads
+# the worker's FS). Paths must match the defaults resolved by
+# Settings.sandbox_seccomp_profile / sandbox_browser_seccomp_profile
+# (/app/docker/seccomp-*.json); a missing COPY fails every container start
+# loudly, because the --security-opt flag is always emitted.
 COPY docker/seccomp-sandbox.json /app/docker/seccomp-sandbox.json
+COPY docker/seccomp-browser.json /app/docker/seccomp-browser.json
 RUN uv sync --frozen --no-dev
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -376,14 +376,18 @@ class Settings(BaseSettings):
         "ample slack while bounding a fork bomb. None = unlimited.",
     )
     sandbox_browser_seccomp_profile: str = Field(
-        default="unconfined",
-        description="Seccomp profile path for browser containers. Defaults to "
-        "'unconfined' until the browser image ships its own authored profile "
-        "(docker/seccomp-browser.json — MUST permit unprivileged user namespaces "
-        "so Chromium's internal sandbox stays ON; running --no-sandbox inside "
-        "the container that holds the credential jar is a red result, not a "
-        "workaround). The sandbox profile is NOT reused: it denies the "
-        "namespace syscalls Chromium's sandbox requires.",
+        default=str(Path(__file__).resolve().parents[2] / "docker" / "seccomp-browser.json"),
+        description="Seccomp profile path for browser containers (docker run "
+        "--security-opt seccomp=<path>; the docker CLI reads the file from the "
+        "WORKER's filesystem). Defaults to the baked-in authored profile "
+        "(docker/seccomp-browser.json), which re-permits the unprivileged "
+        "USER/PID/NET namespaces Chromium's internal sandbox needs while still "
+        "denying mount/cgroup/uts/ipc namespace creation. The sandbox profile "
+        "is NOT interchangeable: it denies the namespace syscalls Chromium's "
+        "sandbox requires, so Chromium cannot launch under it at all. "
+        "Emergency rollback ONLY: 'unconfined' disables filtering for the "
+        "container that renders untrusted web content and holds durable "
+        "logins. Never defaults to unconfined; the flag is always emitted.",
     )
     sandbox_browser_runtime: str | None = Field(
         default=None,

--- a/tests/e2e/browser_image_common.py
+++ b/tests/e2e/browser_image_common.py
@@ -1,6 +1,6 @@
-"""Shared helpers for the two browser-image e2e suites (jarbot#106 Phase 2).
+"""Shared helpers for the browser-image e2e suites (jarbot#106 Phase 2).
 
-One test-side statement each of the two cross-package contracts both suites
+One test-side statement each of the cross-package contracts the suites
 drive, so they cannot drift apart (an earlier revision's readiness poll had
 already dropped ``--workdir`` from its private copy):
 
@@ -17,6 +17,10 @@ already dropped ``--workdir`` from its private copy):
   ``aios-browser`` network (topology is the isolation gate's job),
   ``--interactive`` (the daemon never reads stdin), labels (GC bookkeeping),
   and ``--pull always`` (CI pre-pulls the immutable sha tag).
+* :func:`assert_chromium_sandbox_on` / :func:`assert_mount_ns_denied` — the
+  two live security probes (Chromium's own sandbox engaged; the authored
+  mask's deny half), shared between the image-contract suite (hand-built
+  ``docker run``) and the isolation gate (the REAL provisioning path).
 
 Deliberately aios-import-free, like the suites themselves: image smoke must
 not break when the aios tree does.
@@ -77,14 +81,23 @@ def invoke(container: str, request: dict[str, Any], *, wrapper_s: int = 40) -> d
     return doc
 
 
+def world_writable(plane: Path) -> None:
+    """chmod the plane tree open to the uid-1000 container.
+
+    Tests run as an arbitrary host uid; in production the root worker chowns
+    the plane to the workspaces owner (uid 1000) instead. One statement of the
+    accommodation, shared with the isolation gate's real-provisioning tests."""
+    for p in (plane, *plane.iterdir()):
+        p.chmod(0o777)
+
+
 def make_plane(root: Path) -> Path:
     """A plane dir (the five production subdirs) the uid-1000 container can
     write regardless of the host uid."""
     plane = root / "plane"
     for sub in ("profile", "shots", "frames", "downloads", "input"):
         (plane / sub).mkdir(parents=True)
-    for p in (plane, *plane.iterdir()):
-        p.chmod(0o777)
+    world_writable(plane)
     return plane
 
 
@@ -132,3 +145,96 @@ def wait_ready(container: str, *, deadline_s: float = 90) -> None:
         time.sleep(1.0)
     detail = f"rc={last.returncode} stdout={last.stdout!r} stderr={last.stderr!r}" if last else ""
     pytest.fail(f"driver never became ready in {container}: {detail}")
+
+
+# CLONE_NEW* flag values (linux/sched.h) for the namespace probes.
+CLONE_NEWNS = 0x20000
+CLONE_NEWUSER = 0x10000000
+
+
+def assert_mount_ns_denied(container: str) -> None:
+    """The authored mask's DENY half, probed live. ORDER MATTERS: the probe
+    first enters a fresh user namespace — what Chromium's zygote needs, and
+    the step that grants CAP_SYS_ADMIN *in that namespace* — and only then
+    attempts ``unshare(CLONE_NEWNS)``. The kernel would permit that second
+    call (the process holds CAP_SYS_ADMIN in its userns), so EPERM there
+    proves the seccomp mask and nothing else. Probing NEWNS from the initial
+    namespace would be vacuous: the kernel itself EPERMs unprivileged
+    mount-namespace creation with or without seccomp.
+
+    Complements :func:`assert_chromium_sandbox_on`, which only proves the
+    ALLOW half (any profile permissive enough lets Chromium's sandbox
+    engage — including one hand-weakened beyond the authored mask)."""
+    probe = (
+        "import ctypes;"
+        "libc = ctypes.CDLL(None, use_errno=True);"
+        f"ruser = libc.unshare({CLONE_NEWUSER}); euser = ctypes.get_errno();"
+        f"rns = libc.unshare({CLONE_NEWNS}); ens = ctypes.get_errno();"
+        "print(ruser, euser, rns, ens)"
+    )
+    r = run(["docker", "exec", container, "python3", "-c", probe], timeout=60)
+    assert r.returncode == 0, r.stderr
+    ruser, _euser, rns, ens = (int(x) for x in r.stdout.split())
+    assert ruser == 0, f"unshare(CLONE_NEWUSER) must succeed under the browser profile: {r.stdout}"
+    assert (rns, ens) == (-1, 1), (
+        f"unshare(CLONE_NEWNS) from inside a userns must fail EPERM (the seccomp mask), "
+        f"got rc={rns} errno={ens}"
+    )
+
+
+def renderer_pids(container: str) -> list[str]:
+    """PIDs of Chromium renderer processes inside the container."""
+    script = (
+        "for p in /proc/[0-9]*/cmdline; do "
+        "tr '\\0' ' ' < \"$p\" 2>/dev/null | grep -q -- --type=renderer "
+        '&& basename "$(dirname "$p")"; done; true'
+    )
+    r = run(["docker", "exec", container, "bash", "-c", script], timeout=30)
+    return [line.strip() for line in r.stdout.splitlines() if line.strip().isdigit()]
+
+
+def assert_chromium_sandbox_on(container: str) -> None:
+    """PRIMARY sandbox-ON assertion (plan CI-C2), via the two /proc-observable
+    facts of Chromium's layered sandbox:
+
+    * layer 1 (namespace): the renderer's user namespace differs from the
+      container init's;
+    * layer 2 (seccomp-bpf): the renderer carries MORE seccomp filters than
+      init. ``Seccomp: 2`` alone is vacuous — docker's container-level profile
+      puts EVERY process in filter mode — so the load-bearing signal is the
+      ``Seccomp_filters`` count (kernel >= 5.9): init has only docker's, the
+      renderer has docker's plus Chromium's own.
+
+    chrome://sandbox scraping is deliberately not used (unreliable under new
+    headless). Shared between the image-contract suite (hand-built ``docker
+    run``) and the isolation gate (the REAL ``build_spec_from_browser``
+    provisioning path) so the two probes cannot drift apart."""
+    deadline = time.monotonic() + 30
+    pids: list[str] = []
+    while time.monotonic() < deadline and not pids:
+        pids = renderer_pids(container)
+        if not pids:
+            time.sleep(1.0)
+    assert pids, "no Chromium renderer process found — did the persistent context open a page?"
+
+    pid = pids[0]
+    r = run(
+        [
+            *("docker", "exec", container, "bash", "-c"),
+            f"grep -h '^Seccomp_filters:' /proc/{pid}/status /proc/1/status"
+            f" && readlink /proc/{pid}/ns/user /proc/1/ns/user",
+        ],
+        timeout=30,
+    )
+    assert r.returncode == 0, r.stderr
+    filters_line_r, filters_line_i, renderer_ns, init_ns = r.stdout.strip().splitlines()
+    renderer_filters = int(filters_line_r.split()[-1])
+    init_filters = int(filters_line_i.split()[-1])
+    assert renderer_filters > init_filters, (
+        f"renderer has {renderer_filters} seccomp filter(s) vs init's {init_filters} — "
+        "Chromium's own seccomp-bpf layer is NOT applied (docker's profile alone)"
+    )
+    assert renderer_ns != init_ns, (
+        "renderer shares the container's user namespace — Chromium's namespace "
+        f"sandbox is NOT active ({renderer_ns})"
+    )

--- a/tests/e2e/test_browser_image_contract.py
+++ b/tests/e2e/test_browser_image_contract.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import time
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
@@ -32,6 +31,8 @@ from tests.e2e.browser_image_common import (
     IMAGE,
     REPO_ROOT,
     SANDBOX_SECCOMP,
+    assert_chromium_sandbox_on,
+    assert_mount_ns_denied,
     invoke,
     invoke_raw,
     make_plane,
@@ -47,10 +48,6 @@ pytestmark = [
         not IMAGE, reason="AIOS_SANDBOX_BROWSER_IMAGE not set; browser-image suite is opt-in"
     ),
 ]
-
-# CLONE_NEW* flag values (linux/sched.h) for the namespace probes.
-_CLONE_NEWNS = 0x20000
-_CLONE_NEWUSER = 0x10000000
 
 
 def _docker_run(*args: str, timeout: int = 60) -> subprocess.CompletedProcess[str]:
@@ -202,60 +199,12 @@ class TestExitCodeContract:
 # -- Chromium sandbox (the load-bearing security assertions) -------------------
 
 
-def _renderer_pids(container: str) -> list[str]:
-    """PIDs of Chromium renderer processes inside the container."""
-    script = (
-        "for p in /proc/[0-9]*/cmdline; do "
-        "tr '\\0' ' ' < \"$p\" 2>/dev/null | grep -q -- --type=renderer "
-        '&& basename "$(dirname "$p")"; done; true'
-    )
-    r = run(["docker", "exec", container, "bash", "-c", script], timeout=30)
-    return [line.strip() for line in r.stdout.splitlines() if line.strip().isdigit()]
-
-
 def test_chromium_sandbox_is_on(daemon: str) -> None:
-    """PRIMARY sandbox-ON assertion (plan CI-C2), via the two /proc-observable
-    facts of Chromium's layered sandbox:
-
-    * layer 1 (namespace): the renderer's user namespace differs from the
-      container init's;
-    * layer 2 (seccomp-bpf): the renderer carries MORE seccomp filters than
-      init. ``Seccomp: 2`` alone is vacuous — docker's container-level profile
-      puts EVERY process in filter mode — so the load-bearing signal is the
-      ``Seccomp_filters`` count (kernel >= 5.9): init has only docker's, the
-      renderer has docker's plus Chromium's own.
-
-    chrome://sandbox scraping is deliberately not used (unreliable under new
-    headless)."""
-    deadline = time.monotonic() + 30
-    pids: list[str] = []
-    while time.monotonic() < deadline and not pids:
-        pids = _renderer_pids(daemon)
-        if not pids:
-            time.sleep(1.0)
-    assert pids, "no Chromium renderer process found — did the persistent context open a page?"
-
-    pid = pids[0]
-    r = run(
-        [
-            *("docker", "exec", daemon, "bash", "-c"),
-            f"grep -h '^Seccomp_filters:' /proc/{pid}/status /proc/1/status"
-            f" && readlink /proc/{pid}/ns/user /proc/1/ns/user",
-        ],
-        timeout=30,
-    )
-    assert r.returncode == 0, r.stderr
-    filters_line_r, filters_line_i, renderer_ns, init_ns = r.stdout.strip().splitlines()
-    renderer_filters = int(filters_line_r.split()[-1])
-    init_filters = int(filters_line_i.split()[-1])
-    assert renderer_filters > init_filters, (
-        f"renderer has {renderer_filters} seccomp filter(s) vs init's {init_filters} — "
-        "Chromium's own seccomp-bpf layer is NOT applied (docker's profile alone)"
-    )
-    assert renderer_ns != init_ns, (
-        "renderer shares the container's user namespace — Chromium's namespace "
-        f"sandbox is NOT active ({renderer_ns})"
-    )
+    """PRIMARY sandbox-ON assertion (plan CI-C2) — renderer namespaced AND
+    double-filtered; see :func:`assert_chromium_sandbox_on` for the /proc
+    rationale. The isolation gate re-runs the same assertion against a
+    container provisioned through the REAL ``build_spec_from_browser`` path."""
+    assert_chromium_sandbox_on(daemon)
 
 
 def test_chromium_launch_fails_under_sandbox_profile(pulled_image: str, tmp_path: Path) -> None:
@@ -286,29 +235,10 @@ def test_chromium_launch_fails_under_sandbox_profile(pulled_image: str, tmp_path
 
 
 def test_mount_namespace_denied_userns_permitted(daemon: str) -> None:
-    """The authored mask, probed live in the daemon's own container. ORDER
-    MATTERS: the probe first enters a fresh user namespace — what Chromium's
-    zygote needs, and the step that grants CAP_SYS_ADMIN *in that namespace* —
-    and only then attempts unshare(CLONE_NEWNS). The kernel would permit that
-    second call (the process holds CAP_SYS_ADMIN in its userns), so EPERM
-    there proves the seccomp mask and nothing else. Probing NEWNS from the
-    initial namespace would be vacuous: the kernel itself EPERMs unprivileged
-    mount-namespace creation with or without seccomp."""
-    probe = (
-        "import ctypes;"
-        "libc = ctypes.CDLL(None, use_errno=True);"
-        f"ruser = libc.unshare({_CLONE_NEWUSER}); euser = ctypes.get_errno();"
-        f"rns = libc.unshare({_CLONE_NEWNS}); ens = ctypes.get_errno();"
-        "print(ruser, euser, rns, ens)"
-    )
-    r = run(["docker", "exec", daemon, "python3", "-c", probe], timeout=60)
-    assert r.returncode == 0, r.stderr
-    ruser, _euser, rns, ens = (int(x) for x in r.stdout.split())
-    assert ruser == 0, f"unshare(CLONE_NEWUSER) must succeed under the browser profile: {r.stdout}"
-    assert (rns, ens) == (-1, 1), (
-        f"unshare(CLONE_NEWNS) from inside a userns must fail EPERM (the seccomp mask), "
-        f"got rc={rns} errno={ens}"
-    )
+    """The authored mask's deny half, probed live in the daemon's own
+    container — see :func:`assert_mount_ns_denied` for the userns-first
+    ordering that keeps the probe non-vacuous."""
+    assert_mount_ns_denied(daemon)
 
 
 def test_no_tcp_listeners(daemon: str) -> None:

--- a/tests/e2e/test_browser_network_isolation.py
+++ b/tests/e2e/test_browser_network_isolation.py
@@ -11,7 +11,14 @@ against real Docker:
 * two containers on ``aios-browser`` cannot reach each other (ICC off) — one
   account's computer can never reach another's;
 * a container provisioned through the REAL ``build_spec_from_browser`` path
-  lands on ``aios-browser`` and publishes no ports.
+  lands on ``aios-browser`` and publishes no ports;
+* on that same real path, with the REAL browser image
+  (``AIOS_SANDBOX_BROWSER_IMAGE``), the DEFAULT seccomp profile flows through
+  spec → backend → ``docker run``: Chromium's own sandbox engages (the
+  profile's allow half) and mount-namespace creation stays denied (its deny
+  half) — the per-environment proof that a deploy's config actually delivers
+  the authored profile, not just that the image can be sandboxed when a test
+  passes the flag by hand.
 
 Each unreachability assertion is double-guarded against a vacuous pass: the
 listener curls ITSELF (so the target is proven up, absorbing the bind race),
@@ -41,6 +48,13 @@ from aios.sandbox.network import (
 )
 from aios.sandbox.spec import build_spec_from_browser
 from tests.conftest import needs_docker
+from tests.e2e.browser_image_common import IMAGE as BROWSER_IMAGE
+from tests.e2e.browser_image_common import (
+    assert_chromium_sandbox_on,
+    assert_mount_ns_denied,
+    wait_ready,
+    world_writable,
+)
 
 pytestmark = [needs_docker, pytest.mark.docker]
 
@@ -235,14 +249,18 @@ async def test_real_browser_spec_lands_on_browser_network_with_no_ports(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A container provisioned through the REAL spec builder joins the ICC-off
-    browser bridge (only), publishes no ports, and mounts the plane dir."""
+    browser bridge (only), publishes no ports, and mounts the plane dir.
+
+    Prefers the real browser image; the sandbox image stands in when it isn't
+    built (network posture is image-independent)."""
     settings = get_settings()
     monkeypatch.setattr(settings, "workspace_root", tmp_path)
-    monkeypatch.setattr(settings, "sandbox_browser_image", IMAGE)
+    monkeypatch.setattr(settings, "sandbox_browser_image", BROWSER_IMAGE or IMAGE)
     account_id = f"acc_{uuid.uuid4().hex[:8].upper()}"
 
     backend = DockerBackend()
     spec = build_spec_from_browser(account_id)
+    world_writable(spec.workspace.host_path)
     handle = await backend.create(spec)
     try:
         inspect = await _run(
@@ -263,5 +281,53 @@ async def test_real_browser_spec_lands_on_browser_network_with_no_ports(
         # No published ports of any kind.
         for blob in (ports_json, bindings_json):
             assert blob in ("{}", "null"), f"browser container publishes ports: {blob}"
+    finally:
+        await backend.destroy(handle)
+
+
+async def test_real_browser_spec_runs_chromium_sandboxed(
+    _networks_ready: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The DEFAULT config delivers the authored seccomp profile end to end.
+
+    The image-contract suite proves the image CAN run Chromium sandboxed when
+    a test hand-passes ``--security-opt seccomp=…``; this test proves a
+    container provisioned exactly the way production provisions one — spec
+    defaults, no hand-passed flags — actually gets that profile. Both halves
+    are asserted, because each catches what the other cannot:
+
+    * sandbox-ON (renderer namespaced + double-filtered) proves the ALLOW
+      half — it fails when the profile is over-restrictive or missing
+      (docker's own default denies unprivileged userns, so Chromium cannot
+      even launch under it), but passes under ANY sufficiently permissive
+      profile, weakened ones included;
+    * the mount-ns probe proves the DENY half — it fails when the delivered
+      profile no longer masks CLONE_NEWNS, e.g. a deploy-side profile file
+      hand-weakened in place under the expected name.
+
+    Per-environment, this is the gate that catches a worker image lacking the
+    profile COPY or a wrong ``AIOS_SANDBOX_BROWSER_SECCOMP_PROFILE`` override:
+    the flag is always emitted, a bad path fails provisioning loudly, and
+    ``unconfined`` fails the endswith pin below."""
+    if not BROWSER_IMAGE:
+        pytest.skip("AIOS_SANDBOX_BROWSER_IMAGE not set; needs the real browser image")
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    monkeypatch.setattr(settings, "sandbox_browser_image", BROWSER_IMAGE)
+    account_id = f"acc_{uuid.uuid4().hex[:8].upper()}"
+
+    backend = DockerBackend()
+    spec = build_spec_from_browser(account_id)
+    assert spec.seccomp_profile.endswith("seccomp-browser.json"), (
+        f"spec default no longer resolves to the authored browser profile: {spec.seccomp_profile!r}"
+    )
+    world_writable(spec.workspace.host_path)
+    handle = await backend.create(spec)
+    try:
+        await asyncio.to_thread(wait_ready, handle.sandbox_id)
+        await asyncio.to_thread(assert_chromium_sandbox_on, handle.sandbox_id)
+        await asyncio.to_thread(assert_mount_ns_denied, handle.sandbox_id)
     finally:
         await backend.destroy(handle)

--- a/tests/unit/sandbox/test_browser_seccomp_profile.py
+++ b/tests/unit/sandbox/test_browser_seccomp_profile.py
@@ -8,7 +8,9 @@ design review caught in draft (a mask omitting CLONE_NEWNS would have
 re-enabled mount-namespace creation). The live-kernel counterpart runs in
 ``tests/e2e/test_browser_image_contract.py`` against a real container.
 
-Pure JSON inspection — no Docker required, runs in the normal unit lane.
+Also pins the profile's DELIVERY: the settings default resolves to this file
+and the worker image bakes it at that path (PR5 wiring — the flip and the
+COPY must never separate). No Docker required; runs in the normal unit lane.
 """
 
 from __future__ import annotations
@@ -103,6 +105,38 @@ def test_ptrace_stays_allowed_for_crashpad(profile: dict[str, Any]) -> None:
         for block in profile["syscalls"]
     )
     assert allowed, "no ptrace allow rule found in the vendored base"
+
+
+def test_settings_default_path_points_at_repo_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``Settings().sandbox_browser_seccomp_profile`` defaults to the authored
+    profile ('unconfined' was only the pre-image placeholder — the container
+    renders untrusted web content and holds durable logins)."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_EGRESS_CA_KEY=e\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_SANDBOX_BROWSER_SECCOMP_PROFILE", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))
+    assert s.sandbox_browser_seccomp_profile.endswith("docker/seccomp-browser.json")
+    assert Path(s.sandbox_browser_seccomp_profile).exists()
+
+
+@pytest.mark.parametrize("profile_file", ["seccomp-sandbox.json", "seccomp-browser.json"])
+def test_worker_image_bakes_profile(profile_file: str) -> None:
+    """The worker Dockerfile COPYs each authored profile to the path its
+    settings default resolves to inside the container (/app/docker/…): the
+    docker CLI reads the file from the WORKER's filesystem at ``docker run``
+    time, and the ``--security-opt seccomp=`` flag is always emitted — so a
+    missing COPY fails every container start on deploy. This pin makes the
+    default-flip ⇄ COPY pairing mechanical instead of a release note."""
+    dockerfile = (_DOCKER_DIR.parent / "Dockerfile").read_text()
+    assert f"COPY docker/{profile_file} /app/docker/{profile_file}" in dockerfile, (
+        f"the worker Dockerfile no longer bakes docker/{profile_file} at the path the "
+        f"settings default resolves to in the worker image"
+    )
 
 
 def test_vendored_base_identical_to_sandbox_profile(profile: dict[str, Any]) -> None:

--- a/tests/unit/test_detect_filter_sync.py
+++ b/tests/unit/test_detect_filter_sync.py
@@ -9,6 +9,10 @@ generated surface so a regen-only PR can never take the docs-only skip path:
   and add the new prefix to the regex if this test fails.
 - The detect regex matches the root config/generated artifacts ``Dockerfile``,
   ``compose.yml``, and ``openapi.json``.
+- The per-image ``sandbox_changed`` / ``browser_changed`` filters each match
+  exactly their image's build inputs and nothing of the other's, so a PR
+  touching one image never forces a rebuild of the other and never pulls a
+  stale ``:smoked`` for its own.
 - ``.github/workflows/build-sandbox.yml`` triggers on ``bin/tool`` changes,
   because ``docker/Dockerfile.sandbox`` COPYs that binary into the image — a
   tool-only master push must rebuild the image, not silently skip it.
@@ -25,24 +29,42 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _detect_regex() -> str:
-    """Extract the ERE pattern from the ``run_checks`` grep -qE in code-validation.yml.
+def _filter_regex(output: str) -> str:
+    """Extract the ERE pattern of the ``grep -qE`` that sets ``<output>=true``.
 
-    The workflow has two ``grep -qE`` lines — the ``run_checks`` filter and a
-    later ``sandbox_changed`` filter.  Key on the ``run_checks=true`` that
-    follows the pattern (with no intervening ``grep -qE``) so a reordered or
-    inserted grep can't silently make this test guard the wrong filter.
+    The workflow has three ``grep -qE`` filters (``run_checks``,
+    ``sandbox_changed``, ``browser_changed``).  Key on the ``<output>=true``
+    that follows the pattern with no intervening ``grep -qE``, so a reordered
+    or inserted grep can't silently make a test guard the wrong filter.
     """
     workflow = (_REPO_ROOT / ".github" / "workflows" / "code-validation.yml").read_text()
-    m = re.search(r"grep -qE '([^']*)'(?:(?!grep -qE).)*?run_checks=true", workflow, re.DOTALL)
-    assert m is not None, "Could not find the run_checks 'grep -qE ...' in code-validation.yml"
+    m = re.search(rf"grep -qE '([^']*)'(?:(?!grep -qE).)*?{output}=true", workflow, re.DOTALL)
+    assert m is not None, f"Could not find the {output} 'grep -qE ...' in code-validation.yml"
     return m.group(1)
 
 
-@pytest.mark.parametrize("path", ["Dockerfile", "compose.yml", "openapi.json"])
+def _ls_files(prefix: str, *pathspecs: str) -> list[str]:
+    """Committed repo-relative POSIX paths under ``prefix`` — no __pycache__,
+    no untracked/gitignored artefacts. Extra pathspecs (e.g. ``:!…/tests``)
+    narrow the listing."""
+    out = subprocess.run(
+        ["git", "ls-files", prefix, *pathspecs],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    files = out.stdout.split()
+    assert files, f"git ls-files found no committed files under {prefix}"
+    return files
+
+
+@pytest.mark.parametrize("path", ["Dockerfile", "compose.yml", "openapi.json", ".dockerignore"])
 def test_new_root_paths_match_detect_filter(path: str) -> None:
-    """Root generated/config artifacts must not slip through the docs-only skip."""
-    pattern = _detect_regex()
+    """Root generated/config artifacts must not slip through the docs-only
+    skip (``.dockerignore`` is a browser-image input — ``browser_changed`` is
+    dead unless ``run_checks`` also fires)."""
+    pattern = _filter_regex("run_checks")
     assert re.search(pattern, path), (
         f"{path!r} does not match the detect-filter regex in code-validation.yml;\n"
         f"add it to the grep -qE alternation so PRs touching only this file still run CI.\n"
@@ -58,20 +80,8 @@ def test_detect_filter_matches_all_generated_artifacts() -> None:
     any of them always triggers CI.  If this test fails, add the new path prefix
     to the grep -qE alternation in code-validation.yml.
     """
-    pattern = _detect_regex()
-
-    # ``git ls-files`` gives exactly the committed files (repo-relative POSIX
-    # paths) — no __pycache__, no untracked/gitignored artefacts.
-    out = subprocess.run(
-        ["git", "ls-files", "packages/aios-sdk/aios_sdk/_generated/"],
-        cwd=_REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    sdk_files = out.stdout.split()
-    assert sdk_files, "git ls-files found no committed files under aios_sdk/_generated/"
-
+    pattern = _filter_regex("run_checks")
+    sdk_files = _ls_files("packages/aios-sdk/aios_sdk/_generated/")
     artifact_paths = ["openapi.json", *sdk_files]
     unmatched = [p for p in artifact_paths if not re.search(pattern, p)]
 
@@ -80,6 +90,107 @@ def test_detect_filter_matches_all_generated_artifacts() -> None:
         f"in code-validation.yml.  First 10: {unmatched[:10]}\n"
         f"Pattern: {pattern!r}"
     )
+
+
+def test_sandbox_image_filter_matches_exactly_its_inputs() -> None:
+    """``sandbox_changed`` gates pull-``:smoked``-vs-rebuild for the SANDBOX
+    image; it must match exactly that image's build inputs
+    (``docker/Dockerfile.sandbox`` + the COPYed ``bin/tool``) and must NOT
+    match the browser image's inputs — a browser-only PR pulling the
+    pre-built sandbox image is the point of the tightening."""
+    pattern = _filter_regex("sandbox_changed")
+    for path in ("docker/Dockerfile.sandbox", "bin/tool"):
+        assert re.search(pattern, path), f"sandbox input {path!r} escapes the sandbox filter"
+    for path in ("docker/Dockerfile.browser", "docker/seccomp-browser.json", ".dockerignore"):
+        assert not re.search(pattern, path), (
+            f"{path!r} is not a sandbox-image input but matches the sandbox filter — "
+            "it would force a pointless sandbox rebuild"
+        )
+
+
+def test_browser_image_filter_matches_exactly_its_inputs() -> None:
+    """``browser_changed`` gates pull-``:smoked``-vs-rebuild for the BROWSER
+    image; it must match every build input of ``docker/Dockerfile.browser`` —
+    the Dockerfile itself, every committed file of the driver package that
+    reaches the build context (the directory is COPYed but ``tests/`` is
+    ``.dockerignore``d out of it), the protocol module COPYed over the
+    package's vendored copy, and ``.dockerignore`` (it shapes that directory
+    COPY) — and must match neither sandbox inputs nor the context-excluded
+    driver tests (either would force a pointless ~10 min browser rebuild)."""
+    pattern = _filter_regex("browser_changed")
+
+    shipped = _ls_files("packages/aios-browser-driver/", ":!packages/aios-browser-driver/tests")
+    inputs = [
+        "docker/Dockerfile.browser",
+        "src/aios/sandbox/browser_protocol.py",
+        ".dockerignore",
+        *shipped,
+    ]
+    unmatched = [p for p in inputs if not re.search(pattern, p)]
+    assert not unmatched, (
+        f"browser-image input(s) escape the browser filter — a stale ``:smoked`` would be "
+        f"pulled for a PR that changes them.  First 10: {unmatched[:10]}\nPattern: {pattern!r}"
+    )
+
+    # The exclusion is only sound while .dockerignore actually keeps the
+    # driver tests out of the build context — pin that line alongside.
+    dockerignore = (_REPO_ROOT / ".dockerignore").read_text()
+    assert re.search(r"(?m)^packages/aios-browser-driver/tests$", dockerignore), (
+        ".dockerignore no longer excludes packages/aios-browser-driver/tests — the "
+        "browser_changed filter's tests/ exclusion is now unsound; re-align both"
+    )
+    driver_tests = _ls_files("packages/aios-browser-driver/tests/")
+    non_inputs = ["docker/Dockerfile.sandbox", "bin/tool", *driver_tests]
+    over_matched = [p for p in non_inputs if re.search(pattern, p)]
+    assert not over_matched, (
+        f"path(s) that cannot change the browser image match the browser filter — "
+        f"pointless ~10 min rebuilds.  First 10: {over_matched[:10]}\nPattern: {pattern!r}"
+    )
+
+
+def test_image_filter_inputs_all_reach_run_checks() -> None:
+    """Every path either image filter fires on must also fire ``run_checks``:
+    the pull/build/e2e steps are all ANDed with ``run_checks == 'true'``, so
+    an image input outside the outer gate would compute a dead
+    ``*_changed=true`` while the whole pipeline takes the docs-only skip."""
+    run_checks = _filter_regex("run_checks")
+    inputs = [
+        "docker/Dockerfile.sandbox",
+        "bin/tool",
+        "docker/Dockerfile.browser",
+        "src/aios/sandbox/browser_protocol.py",
+        ".dockerignore",
+        *_ls_files("packages/aios-browser-driver/", ":!packages/aios-browser-driver/tests"),
+    ]
+    escapees = [p for p in inputs if not re.search(run_checks, p)]
+    assert not escapees, (
+        f"image-filter input(s) do not match run_checks — their *_changed output is dead "
+        f"because every consumer step requires run_checks == 'true'.  {escapees}"
+    )
+
+
+def test_build_browser_image_triggers_on_its_inputs() -> None:
+    """build-browser-image.yml's ``on.push.paths`` must list every browser
+    input (and the negated driver-tests glob, mirroring the CI filter): a
+    master push touching an input the trigger misses leaves ``:smoked``
+    silently stale — the sandbox precedent is ``bin/tool`` below."""
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "build-browser-image.yml").read_text()
+    for entry in (
+        "docker/Dockerfile.browser",
+        "docker/seccomp-browser.json",
+        "docker/seccomp-sandbox.json",
+        ".dockerignore",
+        "packages/aios-browser-driver/**",
+        '"!packages/aios-browser-driver/tests/**"',
+        "src/aios/sandbox/browser_protocol.py",
+        "tests/e2e/test_browser_image_contract.py",
+        "tests/e2e/test_browser_driver_behavior.py",
+        "tests/e2e/browser_image_common.py",
+    ):
+        assert re.search(rf"(?m)^\s*-\s*{re.escape(entry)}\s*$", workflow), (
+            f"{entry!r} is not listed in the on.push.paths trigger of "
+            f"build-browser-image.yml; a push touching it would leave :smoked stale"
+        )
 
 
 def test_build_sandbox_triggers_on_bin_tool() -> None:


### PR DESCRIPTION
## Phase 2, PR5 of 5 — wire the browser image into worker + CI

Final PR of the jarbot#106 **Phase 2** stack: nothing new is built — the image (PR4), the driver (PR2/PR3), and the Phase-1 substrate get connected, and the per-environment rollout gate gains the probes that close the loop. **Rollout posture unchanged**: `browser_*` grants stay gated on `test_browser_network_isolation.py` green per environment, and no deployment sets `AIOS_SANDBOX_BROWSER_IMAGE` yet.

> **Stacked on #2287** (`feat/browser-driver-image`). Review the [PR4↔PR5 diff](https://github.com/eumemic/aios/compare/feat/browser-driver-image...feat/browser-image-wiring); merges after PR4.

### What's here

- **Worker `Dockerfile`** — `COPY docker/seccomp-browser.json /app/docker/seccomp-browser.json`, next to the sandbox profile. Ships in the **same deploy** as the config flip: the `--security-opt` flag is always emitted, so a flipped default without the COPY would fail every browser container start. A new unit pin makes the pairing mechanical (settings default resolves to the file AND the worker Dockerfile bakes it at that path — parametrized over both profiles).
- **`config.py`** — `sandbox_browser_seccomp_profile` default flips from the pre-image `"unconfined"` placeholder to the baked-in authored profile, mirroring `sandbox_seccomp_profile`. The `browser_seccomp_unconfined` worker warning now fires only on an explicit operator rollback.
- **`code-validation.yml`** — a `browser_changed` detect filter drives a pull-`:smoked`-vs-local-build pair mirroring the sandbox lane, with a **stale-probe** (installed `browser_protocol.py` byte-compared to the checkout — only this step's failure routes into the fallback, so a stale `:smoked` self-heals into a rebuild instead of failing the shard red). `AIOS_SANDBOX_BROWSER_IMAGE=aios-browser:ci` on the docker e2e steps un-skips the two PR4 image suites and the gate's real-path probes in **every PR docker shard** from here on; the first post-merge run takes the local-build fallback once, before `build-browser-image.yml`'s first master publish. `sandbox_changed` tightened from `^docker/` to exactly the sandbox image's inputs — a browser-only PR no longer forces a sandbox rebuild, nor vice versa. Per-shard e2e timeout (docker 45 / non-docker 30).
- **The rollout gate** (`test_browser_network_isolation.py`) — the review-deferred **real-provisioning-path probe**: with the real image, a container provisioned through `build_spec_from_browser` with **spec defaults** (no hand-passed flags) must run Chromium sandboxed (renderer namespaced + double-filtered, the profile's *allow* half) **and** keep mount-namespace creation denied (the *deny* half, via the PR4 userns-first mask probe — now shared in `browser_image_common` and asserted by both the contract suite and the gate). The contract suite proves the image *can* be sandboxed; this proves each deploy's config actually *delivers* the authored profile — a missing worker COPY fails provisioning loudly, `unconfined` fails the endswith pin, an in-place weakened profile fails the mask probe.
- **Sync tests** (`test_detect_filter_sync.py`) — per-image filter⇄inputs pins (browser inputs enumerated via `git ls-files` minus the context-excluded `tests/`, with the `.dockerignore` exclusion line pinned alongside), a subset pin (every image input must also fire `run_checks`), and a `build-browser-image.yml` paths-trigger pin (the `bin/tool` precedent shape).

### Review

5-agent plan red-team (prior session), then the usual **8-agent uncorrelated closing review**. Highlights folded: `.dockerignore` escaped the `run_checks` gate (found independently twice — `browser_changed=true` was *dead* for a `.dockerignore`-only PR since every consumer step requires `run_checks`); the gate probe's docstring claim was direction-inverted (sandbox-ON fails on *over*-restrictive profiles — the deny half needed the mask probe, now asserted on the real path); driver-test-only PRs no longer pay the ~10 min rebuild for files `.dockerignore` keeps out of the build context (filter + publish-trigger `!tests/**` + sync-test enumeration all aligned); the pre-existing "`set -euo pipefail` is the workflow default" comment was false (GHA default shell is `bash -e {0}`) — corrected where the new steps' failure-propagation analysis leans on it; dedup folds (shared `BROWSER_IMAGE`/`world_writable`/`_ls_files`, inlined leftover alias). The security agent refuted the probe-vacuity hypothesis from primary sources: moby's default profile denies unprivileged userns, so a silently-dropped profile means Chromium cannot launch at all — the gate cannot pass vacuously. Deferred with note: digest-pinning `:smoked` pulls (pre-existing precedent, both lanes), deriving filter inputs from Dockerfile COPY parsing.

### Checks

`ruff` / `mypy` clean; 5403 unit + 108 package tests; all three browser e2e suites green against the PR4 image (29 passed, 1 expected local-tag skip), with the gate's probe pair verified non-vacuous (boot-to-renderer measured at 0.8 s); both workflows YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
