### PR TITLE
fix(harness): restore the context window's history floor (#2289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Restore the context window's history floor: `window_min` again bounds
+  RETAINED HISTORY only, so the per-request prelude (system prompt + tool
+  schemas + reserves) is subtracted from `window_max` alone. Subtracting it
+  from both bounds let a fat tool prelude satisfy the floor by itself, driving
+  the effective floor to 0 so every snap emptied the window down to a single
+  event — the agent then saw only the harness's own "history has scrolled out
+  of view, search first" notice and looped on `search_events`. A floor the
+  band cannot afford is now clamped to 75% of the events budget (keeping the
+  snap chunk usable) and reported on the `read_window_end` span plus a
+  `window.floor_clamped` warning, rather than silently zeroed (#2289).
+
 - Distinguish a dead OAuth refresh token (RFC 6749 `invalid_grant` — revoked,
   expired, or otherwise unrecoverable) from a generic/transient
   `OAuthRefreshError` via a new `OAuthReauthRequiredError` subclass

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -22,7 +22,7 @@ from aios.errors import (
     NotFoundError,
 )
 from aios.harness.chat_type import ChatType, chat_type_of
-from aios.harness.window import WindowedEvents, WindowOmission
+from aios.harness.window import WindowedEvents, WindowFloor, WindowOmission
 from aios.ids import (
     EVENT,
     make_id,
@@ -256,6 +256,20 @@ _MODEL_TOKEN_CLASS_MAX = 8.0
 # this factor before the snap math, so the *real* sent prompt sits at least
 # this far under ``window_max``.
 _WINDOW_SAFETY_MARGIN = 0.30
+
+# Ceiling on the retained-history floor, as a fraction of the events budget
+# (``window_max`` minus the prelude's effective cost) — issue #2289.
+# ``window_min`` floors RETAINED HISTORY, so the prelude is NOT subtracted
+# from it; but a floor that eats the whole events budget leaves
+# ``chunk = max - min`` near zero, which means a snap (and a full prefix-cache
+# miss) every few hundred tokens — worse than the bug it replaces.  Capping the
+# floor at 75% keeps the snap chunk at >= 25% of the events budget, so an
+# unaffordable band degrades to "less history than configured" with the snap
+# cadence intact.  Deliberately NOT a hard failure: the prelude grows whenever
+# an upstream MCP server adds tools, and raising here would wedge every session
+# in the fleet at wake time.  The clamp is reported instead — see
+# :class:`~aios.harness.window.WindowFloor`.
+_WINDOW_FLOOR_MAX_FRACTION = 0.75
 
 _model_token_ratio_cache: dict[tuple[str, float], tuple[float, dict[str, float]]] = {}
 
@@ -2574,9 +2588,16 @@ async def read_windowed_events(
     the returned events — system prompt plus tool schemas — in local
     (``approx_tokens``) units.  It is NOT included in
     ``cumulative_tokens``, so the windower has to subtract it from the
-    effective budget up-front or the sent prompt will exceed
-    ``window_max`` by the overhead amount.  Callers that don't have any
-    such overhead (preview tooling, test scaffolds) pass ``0``.
+    **maximum** up-front or the sent prompt will exceed ``window_max`` by
+    the overhead amount.  Callers that don't have any such overhead
+    (preview tooling, test scaffolds) pass ``0``.
+
+    It is NOT subtracted from ``window_min``, which floors RETAINED
+    HISTORY rather than the whole prompt (issue #2289).  The floor is
+    instead clamped to ``_WINDOW_FLOOR_MAX_FRACTION`` of the remaining
+    events budget so the snap chunk stays usable; the result reports
+    which of the two happened via
+    :class:`~aios.harness.window.WindowFloor`.
 
     ``model`` must be the session's currently-active model string —
     ``agent.model`` on the session's pinned agent/version.  The same
@@ -2660,12 +2681,25 @@ async def read_windowed_events(
     # happens in the same effective space tokens_to_drop operates in.
     overhead_effective = round(overhead.total * effective_ratio)
     events_window_max = window_max - overhead_effective
-    events_window_min = max(0, window_min - overhead_effective)
     if events_window_max <= 0:
         raise ValueError(
             f"system+tools overhead ({overhead_effective} provider tokens) "
             f"exceeds window_max ({window_max}); no budget remains for events"
         )
+
+    # ``window_min`` floors RETAINED HISTORY, so the overhead subtracts from
+    # the max leg ONLY (issue #2289 — subtracting it here too turned the floor
+    # into a floor on the whole prompt, which a fat tool prelude satisfies by
+    # itself with zero history).  Clamp instead, so the snap chunk
+    # (``max - min``) stays usable; see ``_WINDOW_FLOOR_MAX_FRACTION``.
+    events_window_min = min(window_min, int(events_window_max * _WINDOW_FLOOR_MAX_FRACTION))
+    floor = WindowFloor(
+        configured=window_min,
+        effective=events_window_min,
+        events_window_max=events_window_max,
+        overhead_effective=overhead_effective,
+        outcome="honored" if events_window_min == window_min else "clamped",
+    )
 
     total_effective = round(total * effective_ratio)
     if total_effective <= events_window_max:
@@ -2674,6 +2708,7 @@ async def read_windowed_events(
                 conn, session_id, account_id=account_id
             ),
             omission=None,
+            floor=floor,
         )
 
     from aios.harness.tokens import tokens_to_drop
@@ -2692,19 +2727,22 @@ async def read_windowed_events(
                 conn, session_id, account_id=account_id
             ),
             omission=None,
+            floor=floor,
         )
 
     drop = math.ceil(drop_effective / effective_ratio)
 
     # Never drop the entire window: the window must keep a non-empty tail.
-    # Here ``events_window_min`` can clamp to 0 when overhead exceeds
-    # ``window_min`` (above), and the asymmetric ceil back-conversion can then
-    # push ``drop`` up to ``total`` — the retained scan (``cumulative_tokens >
-    # drop``) would match zero rows while the omission complement still matches
-    # every row. That pairing (empty events + a non-None omission) crashes
-    # ``build_messages``, which reads ``events[0].created_at`` to anchor the
-    # omission marker and relies on the inverse invariant. Clamp so the most
-    # recent event always survives (its ``cumulative_tokens == total``) — the
+    # The floor clamp above bounds how much a snap can take, but it does not
+    # by itself prove ``drop < total``: a caller-supplied ``window_min == 0``
+    # (the adaptive context-overflow retry) leaves a full-budget chunk, and the
+    # asymmetric ceil back-conversion can round ``drop`` up to ``total``. The
+    # retained scan (``cumulative_tokens > drop``) would then match zero rows
+    # while the omission complement still matches every row. That pairing
+    # (empty events + a non-None omission) crashes ``build_messages``, which
+    # reads ``events[0].created_at`` to anchor the omission marker and relies
+    # on the inverse invariant. Clamp so the most recent event always survives
+    # (its ``cumulative_tokens == total``) — the
     # retain-the-tail-even-when-oversized guarantee.
     drop = min(drop, total - 1)
 
@@ -2738,7 +2776,7 @@ async def read_windowed_events(
     )
     if boundary_row is None:
         # Nothing omitted.
-        return WindowedEvents(events=events, omission=None)
+        return WindowedEvents(events=events, omission=None, floor=floor)
 
     omitted_messages = boundary_row["cumulative_messages"]
     if omitted_messages is None:
@@ -2769,7 +2807,7 @@ async def read_windowed_events(
         account_id,
     )
     omission = WindowOmission(began_at=began_at, omitted_messages=omitted_messages)
-    return WindowedEvents(events=events, omission=omission)
+    return WindowedEvents(events=events, omission=omission, floor=floor)
 
 
 async def find_latest_model_workflow_park(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1053,6 +1053,31 @@ async def _run_session_step_body(
         )
         raise
     events = windowed.events
+    # The floor facts (#2289) ride the same span as ``event_count_read``: when
+    # the incident that produced them hit, the span showed the count collapsing
+    # 60 -> 1 but not WHY, so diagnosis needed provider-side request dumps.
+    floor = windowed.floor
+    floor_span: dict[str, Any] = (
+        {
+            "configured_window_min": floor.configured,
+            "effective_window_min": floor.effective,
+            "events_window_max": floor.events_window_max,
+            "overhead_effective": floor.overhead_effective,
+            "window_floor_outcome": floor.outcome,
+        }
+        if floor is not None
+        else {}
+    )
+    if floor is not None and floor.outcome == "clamped":
+        log.warning(
+            "window.floor_clamped",
+            session_id=session_id,
+            configured_window_min=floor.configured,
+            effective_window_min=floor.effective,
+            events_window_max=floor.events_window_max,
+            overhead_effective=floor.overhead_effective,
+            request_window_max=request_window_max,
+        )
     await sessions_service.append_event(
         pool,
         session_id,
@@ -1064,6 +1089,7 @@ async def _run_session_step_body(
             "event_count_read": len(events),
             "request_window_max": request_window_max,
             "configured_window_max": agent.window_max,
+            **floor_span,
         },
         account_id=account_id,
     )

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1033,7 +1033,16 @@ async def _run_session_step_body(
             # attempt. The provider rejection is the authoritative bound; a
             # zero minimum lets the windower discard exactly as much history
             # as the progressively smaller maximum requires.
-            window_min=0 if adaptive_context_retry else min(agent.window_min, request_window_max),
+            #
+            # Otherwise the agent's CONFIGURED floor goes through verbatim: the
+            # windower owns the feasibility clamp (#2289) and reports what it
+            # did on ``WindowFloor``. Pre-clamping to ``request_window_max``
+            # here would be inert — the windower's 75%-of-events-budget ceiling
+            # is below the request ceiling either way — while making
+            # ``configured_window_min`` on the span report the served ceiling
+            # instead of the agent's setting, misreading the exact diagnosis the
+            # span exists for.
+            window_min=0 if adaptive_context_retry else agent.window_min,
             window_max=request_window_max,
             model=capability_model,
             overhead_local=prelude_overhead_local(prelude),

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -553,19 +553,23 @@ def tokens_to_drop(total: int, *, window_min: int, window_max: int) -> int:
     chunk = window_max - window_min
     if chunk <= 0:
         # Degenerate band ``window_min >= window_max``: no chunk to snap within,
-        # so drop exactly the overshoot and retain ``window_max``. The equal case
-        # is reachable from a VALID config — the context-overflow shrink ladder
-        # collapses the effective band to a point once the shrunk request ceiling
-        # falls to or below ``agent.window_min`` (see the ``min()`` in ``loop.py``
-        # feeding ``read_windowed_events``). Dividing by zero here would crash the
-        # very step meant to shrink the prompt, wedging overflow recovery.
+        # so drop exactly the overshoot and retain ``window_max``.
         #
-        # An INVERTED band lands here too. No caller produces one today (the
-        # windower's floor clamp keeps ``min`` under ``max``, and agent config
-        # validates ``window_min < window_max``), but the ceil division below
-        # would silently return a NEGATIVE drop on one — a garbage boundary that
-        # widens the retained scan instead of narrowing it. Treating it as
-        # degenerate keeps the failure mode "retain exactly ``window_max``".
+        # No live caller produces such a band. ``read_windowed_events`` clamps
+        # its floor to ``_WINDOW_FLOOR_MAX_FRACTION`` of the events budget
+        # (issue #2289), which keeps ``events_window_min`` strictly under
+        # ``events_window_max`` for every budget >= 1 — and agent config
+        # validates ``window_min < window_max``. (Before #2289 the equal case
+        # WAS reachable: the overflow shrink ladder collapsed the effective band
+        # to a point once the shrunk ceiling fell to ``agent.window_min``.)
+        #
+        # The branch stays because both failure modes are silent rather than
+        # loud: an equal band would divide by zero here, crashing the very step
+        # meant to shrink the prompt; an INVERTED band would make the ceil
+        # division below return a NEGATIVE drop — a garbage boundary that widens
+        # the retained scan (``cumulative_tokens > drop`` matches everything)
+        # instead of narrowing it. Treating both as degenerate keeps the failure
+        # mode "retain exactly ``window_max``".
         return overshoot
     snaps = (overshoot + chunk - 1) // chunk  # ceil division
     return snaps * chunk

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -551,14 +551,21 @@ def tokens_to_drop(total: int, *, window_min: int, window_max: int) -> int:
         return 0
     overshoot = total - window_max
     chunk = window_max - window_min
-    if chunk == 0:
-        # Degenerate band ``window_min == window_max``: no chunk to snap within,
-        # so drop exactly the overshoot and retain ``window_max``. This band is
-        # reachable from a VALID config — the context-overflow shrink ladder
+    if chunk <= 0:
+        # Degenerate band ``window_min >= window_max``: no chunk to snap within,
+        # so drop exactly the overshoot and retain ``window_max``. The equal case
+        # is reachable from a VALID config — the context-overflow shrink ladder
         # collapses the effective band to a point once the shrunk request ceiling
         # falls to or below ``agent.window_min`` (see the ``min()`` in ``loop.py``
         # feeding ``read_windowed_events``). Dividing by zero here would crash the
         # very step meant to shrink the prompt, wedging overflow recovery.
+        #
+        # An INVERTED band lands here too. No caller produces one today (the
+        # windower's floor clamp keeps ``min`` under ``max``, and agent config
+        # validates ``window_min < window_max``), but the ceil division below
+        # would silently return a NEGATIVE drop on one — a garbage boundary that
+        # widens the retained scan instead of narrowing it. Treating it as
+        # degenerate keeps the failure mode "retain exactly ``window_max``".
         return overshoot
     snaps = (overshoot + chunk - 1) // chunk  # ceil division
     return snaps * chunk

--- a/src/aios/harness/window.py
+++ b/src/aios/harness/window.py
@@ -23,9 +23,9 @@ Concretely, given a per-agent ``min_tokens`` / ``max_tokens`` (defaults
   to a stable prefix, so prompt prefix caching keeps hitting until the next
   snap.
 
-Both bounds describe RETAINED CONVERSATION, but the per-request prelude
-(system prompt + tool schemas + reserves) is asymmetric between them, and
-the asymmetry is load-bearing (issue #2289):
+The per-request prelude (system prompt + tool schemas + reserves) enters
+the two bounds asymmetrically, and the asymmetry is load-bearing
+(issue #2289):
 
 * ``max_tokens`` bounds the *sent prompt*, so the prelude's cost must be
   subtracted from it — the retained slate gets whatever is left over.

--- a/src/aios/harness/window.py
+++ b/src/aios/harness/window.py
@@ -23,6 +23,25 @@ Concretely, given a per-agent ``min_tokens`` / ``max_tokens`` (defaults
   to a stable prefix, so prompt prefix caching keeps hitting until the next
   snap.
 
+Both bounds describe RETAINED CONVERSATION, but the per-request prelude
+(system prompt + tool schemas + reserves) is asymmetric between them, and
+the asymmetry is load-bearing (issue #2289):
+
+* ``max_tokens`` bounds the *sent prompt*, so the prelude's cost must be
+  subtracted from it — the retained slate gets whatever is left over.
+* ``min_tokens`` bounds the *retained history* only. Subtracting the
+  prelude from it too would reinterpret the floor as a floor on the whole
+  prompt, which a fat tool prelude satisfies by itself with zero history —
+  the incident that produced #2289 (121 tool schemas ≈ 99k effective
+  overhead against a 50k/150k band drove the floor to 0, so every snap
+  emptied the window to a single event and the agent was left talking to
+  its own "history has scrolled out of view" notice).
+
+The floor is instead *clamped* to a fraction of the events budget, so an
+unaffordable band degrades to "less history than asked for" rather than
+"no history" — see ``_WINDOW_FLOOR_MAX_FRACTION`` in
+:mod:`aios.db.queries.events` and :class:`WindowFloor` below.
+
 Note: a ``context_overflow`` safety check (idle the session when
 windowed content still exceeds ``max_tokens * 1.5``) is planned but
 not yet implemented.
@@ -36,6 +55,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
 
 from aios.models.events import Event
 
@@ -64,11 +84,47 @@ class WindowOmission:
 
 
 @dataclass(frozen=True, slots=True)
+class WindowFloor:
+    """How the retained-history floor resolved for one windowed read (#2289).
+
+    ``configured`` is the ``window_min`` the caller asked for; ``effective``
+    is the floor the snap math actually ran with, after clamping it to a
+    fraction of ``events_window_max`` (the events budget left once
+    ``overhead_effective`` — the prelude's cost in the same effective space —
+    is subtracted from ``window_max``).
+
+    ``outcome`` is a kind rather than an ``is_clamped`` flag so the two
+    regimes stay nameable at every call site: ``"honored"`` means the
+    configured floor survived intact, ``"clamped"`` means the agent's
+    configured band cannot deliver it against the current prelude and the
+    read degraded deliberately.  ``"clamped"`` is an operator signal — the
+    band or the tool surface wants attention — not an error: the prelude
+    grows whenever an upstream MCP server adds tools, so failing hard here
+    would brick every session in the fleet at wake time.
+
+    Producer: :func:`~aios.db.queries.events.read_windowed_events`;
+    consumer: :func:`~aios.harness.loop.run_session_step`, which stamps
+    these onto the ``read_window_end`` span and warns on ``"clamped"``.
+    """
+
+    configured: int
+    effective: int
+    events_window_max: int
+    overhead_effective: int
+    outcome: Literal["honored", "clamped"]
+
+
+@dataclass(frozen=True, slots=True)
 class WindowedEvents:
     """A context window over a session log: the retained trailing slate,
     plus facts about what the drop boundary excluded.  ``omission`` is
     ``None`` when nothing is excluded — the whole transcript fits, or an
-    oversized first event straddles the boundary."""
+    oversized first event straddles the boundary.
+
+    ``floor`` carries how the retained-history floor resolved (#2289).  It is
+    ``None`` only on the pre-backfill fallback path, where no snap arithmetic
+    runs at all, and for callers that construct the shape directly."""
 
     events: list[Event]
     omission: WindowOmission | None
+    floor: WindowFloor | None = None

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -476,6 +476,22 @@ class TestTokensToDrop:
         # A collapsed band that still fits takes the early return, never the divide.
         assert tokens_to_drop(120_000, window_min=120_000, window_max=120_000) == 0
 
+    def test_inverted_band_returns_overshoot_not_negative_drop(self) -> None:
+        """Inverted band (``window_min > window_max``) must not yield a negative
+        drop (issue #2289).
+
+        No caller produces one today — the windower clamps its floor below the
+        events budget and agent config validates ``window_min < window_max`` —
+        but the ceil division is defined over a negative ``chunk`` and would
+        return a NEGATIVE drop rather than crashing: a boundary that WIDENS the
+        retained scan (``cumulative_tokens > drop`` matches everything) instead
+        of narrowing it, i.e. a silently oversized prompt. The degenerate branch
+        must swallow this band too.
+        """
+        drop = tokens_to_drop(200_000, window_min=150_000, window_max=120_000)
+        assert drop == 80_000  # overshoot; remaining == window_max, never negative
+        assert tokens_to_drop(100_000, window_min=150_000, window_max=120_000) == 0
+
 
 class TestImageBaselines:
     """The three token baselines (#2050, jarbot#106 PR1) diverge only on

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -413,24 +413,26 @@ async def test_ceil_div_never_overshoots_window(
 async def test_overhead_clamp_never_drops_entire_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The windower must never drop the *entire* window.
+    """The windower must never drop the *entire* window — the load-bearing
+    invariant behind the whole snap path.
 
-    When per-step overhead exceeds ``window_min``, ``events_window_min``
-    clamps to its 0 floor (events.py) — losing the floor that normally
-    guarantees a non-empty tail (the chunked policy requires
-    ``min_tokens >= 1``). The chunked snap then drops in full-window chunks,
-    and the asymmetric ``ceil(drop_effective / ratio)`` back-conversion can
-    push ``drop`` up to ``total``. The retained scan (``cumulative_tokens >
-    drop``) then matches ZERO rows while the omission complement
-    (``<= drop``) matches every row — so ``read_windowed_events`` returns an
-    empty event list paired with a non-None omission. ``build_messages``
-    relies on the inverse invariant and reads ``events[0].created_at`` to
-    anchor the omission marker, crashing with IndexError — and since
-    ``build_messages`` is pure replay, the session wedges permanently.
+    An empty retained scan (``cumulative_tokens > drop`` matching ZERO rows)
+    paired with a non-None omission complement (``<= drop`` matching every
+    row) crashes ``build_messages``, which reads ``events[0].created_at`` to
+    anchor the omission marker and relies on the inverse invariant — and
+    since ``build_messages`` is pure replay, the session wedges permanently.
+    So the boundary must keep ``drop < total``: the most recent event always
+    survives (its ``cumulative_tokens == total``; the scan is ``> drop``).
 
-    The boundary must keep ``drop < total`` so the most recent event always
-    survives (the last event's ``cumulative_tokens == total``; the scan is
-    ``> drop``).
+    This geometry originally reached ``drop == total`` through the overhead
+    zeroing the floor (``events_window_min = max(0, 1000 - 1248) == 0``) and
+    the asymmetric ``ceil(drop_effective / ratio)`` back-conversion rounding
+    up. Issue #2289 removed that zeroing — the floor now clamps to 75% of the
+    events budget (564 here) rather than to 0 — so the geometry no longer
+    drives ``drop`` anywhere near ``total``. The invariant it defends is
+    unchanged and still needs a fence: ``window_min=0`` is a *live* caller
+    (the adaptive context-overflow retry) and restores exactly the
+    full-budget chunk that produced the crash.
     """
     account_id = "acc_test_stub"
     ratio = 1.2
@@ -438,10 +440,10 @@ async def test_overhead_clamp_never_drops_entire_window(
     window_min, window_max, overhead_local = 1_000, 2_000, 800
     # A uniform calibrated coef => R_eff=1.2; calibrated safety margin x1.3 =>
     # eff = 1.56. overhead_effective = round(800*1.56) = 1248 ->
-    # events_window_max = 752, events_window_min = max(0, 1000-1248) = 0.
-    # total_effective = round(483*1.56) = 753 > 752 -> drop_effective =
-    # tokens_to_drop(753, min=0, max=752) = 752 -> ceil(752/1.56) = 483 ==
-    # total: without the clamp the snap would drop the *entire* window.
+    # events_window_max = 752, events_window_min = min(1000, int(752*0.75))
+    # = 564 (clamped). total_effective = round(483*1.56) = 753 > 752 ->
+    # chunk = 188, overshoot = 1 -> drop_effective = 188 ->
+    # ceil(188/1.56) = 121, comfortably below total.
     monkeypatch.setattr(
         queries,
         "model_token_class_ratios",
@@ -488,3 +490,212 @@ async def test_overhead_clamp_never_drops_entire_window(
         "window, leaving an empty retained scan paired with a non-None "
         "omission — which crashes build_messages on events[0]"
     )
+
+
+# --- issue #2289: ``window_min`` floors RETAINED HISTORY, not the whole prompt
+
+
+def _uniform_ratio(monkeypatch: pytest.MonkeyPatch, coef: float = 1.5) -> float:
+    """Force a uniform calibrated coefficient and return the effective factor.
+
+    A uniform coef blends to ``R_eff == coef`` for ANY composition, and being
+    != 1.0 it counts as calibrated, so the x1.3 safety margin applies. The
+    returned value is what the windower multiplies both the overhead and the
+    session total by.
+    """
+    monkeypatch.setattr(
+        queries,
+        "model_token_class_ratios",
+        AsyncMock(
+            return_value={
+                c: coef for c in ("text", "tool_result", "thinking", "tool_use", "system", "tools")
+            }
+        ),
+    )
+    return coef * 1.3
+
+
+@pytest.mark.asyncio
+async def test_incident_geometry_retains_history_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the 2026-08-28 self-query incident (#2289).
+
+    A fat tool prelude (121 MCP schemas, ~99k effective) against the default
+    50k/150k band used to drive ``events_window_min`` to 0, so every snap took
+    a full-budget chunk and left the agent with the single event the
+    ``drop < total`` guard preserves — its own "history has scrolled out of
+    view, search first" notice, which then commanded a search loop.
+
+    With the floor no longer reduced by overhead, the retained slate must stay
+    at or above the (clamped) floor, and the snap chunk must stay large enough
+    that snaps remain rare.
+    """
+    account_id = "acc_test_stub"
+    eff = _uniform_ratio(monkeypatch)  # 1.95
+    total_local, overhead_local = 200_000, 50_000
+    window_min, window_max = 50_000, 150_000
+    # overhead_effective = round(50_000*1.95) = 97_500 -> events_window_max =
+    # 52_500; floor = min(50_000, int(52_500*0.75)) = 39_375 (clamped).
+    conn = _FakeConn(total_local=total_local, ratio_n=50, ratio_mean=0.0)
+    result = await queries.read_windowed_events(
+        conn,
+        "sess_x",
+        window_min=window_min,
+        window_max=window_max,
+        model="m",
+        overhead_local=overhead_local,
+        account_id=account_id,
+    )
+    floor = result.floor
+    assert floor is not None
+    assert floor.outcome == "clamped"
+    assert floor.events_window_max == 52_500
+    assert floor.effective == 39_375
+
+    _session_id, drop_local, *_ = conn.fetch_calls[-1]
+    retained_effective = (total_local - drop_local) * eff
+    # The heart of the bug: retained history used to collapse below the floor
+    # (to a single event). It must now land inside the band.
+    assert floor.effective <= retained_effective <= floor.events_window_max, (
+        f"retained {retained_effective} outside [{floor.effective}, {floor.events_window_max}]"
+    )
+    # And the snap chunk stays a meaningful fraction of the budget, so snaps
+    # (= full prefix-cache misses) stay rare.
+    chunk = floor.events_window_max - floor.effective
+    assert chunk >= 0.25 * floor.events_window_max
+
+
+@pytest.mark.asyncio
+async def test_comfortable_band_honors_configured_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Overhead small relative to the band: the floor passes through EXACTLY.
+
+    This is the direct fence against re-introducing ``window_min - overhead``.
+    """
+    account_id = "acc_test_stub"
+    _uniform_ratio(monkeypatch)
+    conn = _FakeConn(total_local=500_000, ratio_n=50, ratio_mean=0.0)
+    result = await queries.read_windowed_events(
+        conn,
+        "sess_x",
+        window_min=10_000,
+        window_max=200_000,
+        model="m",
+        overhead_local=1_000,  # -> 1_950 effective; budget 198_050
+        account_id=account_id,
+    )
+    floor = result.floor
+    assert floor is not None
+    assert floor.outcome == "honored"
+    assert floor.effective == 10_000  # NOT 10_000 - 1_950
+    assert floor.overhead_effective == 1_950
+
+
+@pytest.mark.asyncio
+async def test_infeasible_floor_clamps_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A floor the band cannot afford degrades, it does not raise.
+
+    Deliberate exception to the repo's fail-hard stance: the prelude grows
+    whenever an upstream MCP server adds tools, so raising here would wedge
+    every session in the fleet at wake time. The clamp is reported instead.
+    """
+    account_id = "acc_test_stub"
+    _uniform_ratio(monkeypatch)
+    conn = _FakeConn(total_local=500_000, ratio_n=50, ratio_mean=0.0)
+    result = await queries.read_windowed_events(
+        conn,
+        "sess_x",
+        window_min=140_000,
+        window_max=150_000,
+        model="m",
+        overhead_local=51_282,  # -> 100_000 effective; budget 50_000
+        account_id=account_id,
+    )
+    floor = result.floor
+    assert floor is not None
+    assert floor.outcome == "clamped"
+    assert floor.events_window_max == 50_000
+    assert floor.effective == 37_500  # 75% of the events budget
+    assert floor.configured == 140_000
+
+
+@pytest.mark.asyncio
+async def test_overhead_exceeding_window_max_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The one hard failure on this path survives the floor rework: with no
+    events budget at all there is nothing to degrade to."""
+    account_id = "acc_test_stub"
+    _uniform_ratio(monkeypatch)
+    conn = _FakeConn(total_local=5_000, ratio_n=50, ratio_mean=0.0)
+    with pytest.raises(ValueError, match="no budget remains for events"):
+        await queries.read_windowed_events(
+            conn,
+            "sess_x",
+            window_min=500,
+            window_max=1_000,
+            model="m",
+            overhead_local=1_000,  # -> 1_950 effective > window_max
+            account_id=account_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_adaptive_retry_zero_floor_is_inert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``window_min=0`` — the adaptive context-overflow retry (``loop.py``) —
+    must stay a no-op under the clamp, and must NOT report a clamp.
+
+    Otherwise every overflow recovery would trip the operator alarm.
+    """
+    account_id = "acc_test_stub"
+    _uniform_ratio(monkeypatch)
+    conn = _FakeConn(total_local=200_000, ratio_n=50, ratio_mean=0.0)
+    result = await queries.read_windowed_events(
+        conn,
+        "sess_x",
+        window_min=0,
+        window_max=150_000,
+        model="m",
+        overhead_local=50_000,
+        account_id=account_id,
+    )
+    floor = result.floor
+    assert floor is not None
+    assert floor.effective == 0
+    assert floor.outcome == "honored"
+
+
+@pytest.mark.asyncio
+async def test_omission_always_pairs_with_non_empty_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``build_messages`` reads ``events[0]`` unguarded whenever an omission is
+    present, so the two can never be (empty, non-None).
+
+    Asserted here on the boundary rather than on the row list, which the fake
+    conn does not materialize: ``drop < total`` is exactly the condition that
+    keeps the retained scan (``cumulative_tokens > drop``) non-empty, since the
+    newest event's ``cumulative_tokens == total``.
+    """
+    account_id = "acc_test_stub"
+    _uniform_ratio(monkeypatch)
+    total_local = 200_000
+    conn = _FakeConn(total_local=total_local, ratio_n=50, ratio_mean=0.0)
+    result = await queries.read_windowed_events(
+        conn,
+        "sess_x",
+        window_min=50_000,
+        window_max=150_000,
+        model="m",
+        overhead_local=50_000,
+        account_id=account_id,
+    )
+    assert result.omission is not None
+    _session_id, drop_local, *_ = conn.fetch_calls[-1]
+    assert drop_local < total_local


### PR DESCRIPTION
## Summary

Fixes #2289. `read_windowed_events` subtracted the per-request prelude overhead (system prompt + tool schemas + reserves) from **both** window bounds. Subtracting from `max` is correct — the sent prompt must fit `window_max`. Subtracting from `min` silently reinterpreted the **history floor** as a floor on the whole prompt, a condition a fat tool prelude satisfies by itself with zero history. `harness/window.py` is unambiguous that both bounds describe *retained conversation*.

On 2026-08-28 five to six bots with 121 MCP tool schemas (~99k effective overhead) against the default 50k/150k band computed a floor of **0**, so every snap emptied the window down to the single event preserved by the `drop = min(drop, total - 1)` guard — the harness's own "history has scrolled out of view, search first" notice, which then commanded a `search_events` self-query loop (593 model calls / ~$22 in 65 min for one bot).

The overhead now subtracts from the max leg only, and the floor is clamped to `_WINDOW_FLOOR_MAX_FRACTION` (75%) of the remaining events budget.

### Two things worth arguing explicitly

**1. The clamp is needed in the *feasible* regime too** — a refinement of the issue text, which scoped it to the infeasible case. With the incident geometry the full floor is nominally affordable (99k + 50k ≤ 150k) but leaves `chunk = 51k − 50k = 1k`: a snap every ~1k tokens, i.e. prefix-cache thrash worse than the bug. The 75% fraction guarantees `chunk ≥ 25%` of the events budget.

**2. An infeasible floor clamps and alarms, it does not raise** — a deliberate exception to this repo's "fail hard, no fallbacks" stance. The prelude grows whenever an upstream MCP server adds tools, so a raise here would brick every session in the fleet at wake time, with no operator action available in that moment. The degradation is bounded (history shrinks, snap cadence stays intact) and *reported*, which is the property the fail-hard rule actually protects. The one genuinely unrecoverable case — `overhead ≥ window_max`, no events budget at all — still raises, unchanged.

### The alarm

`read_windowed_events` must not emit it itself: it lives in `db/queries/`, takes a bare `conn`, and `append_event` locks the session row and advances `last_event_seq` (the gapless-seq invariant). So it's returned as data — a frozen `WindowFloor` on `WindowedEvents` — and stamped by the harness. `loop.py` folds the fields into the existing `read_window_end` span (which carried `event_count_read` but nothing explaining it, precisely why diagnosing this incident needed provider-side request dumps) and logs `window.floor_clamped` on the clamped outcome. Per "encode variation as a kind, never a boolean flag", the outcome is `Literal["honored", "clamped"]`, not an `is_clamped` bool.

Spans are the right primary channel: durable, per-session, SQL-queryable — the same surface that caught `event_count_read` 60 → 1 during the incident, so an ops audit check needs no new plumbing.

### Also

- `tokens_to_drop`'s degenerate branch widens from `chunk == 0` to `chunk <= 0`. An inverted band is unreachable today, but the ceil division is *defined* over a negative chunk and would return a negative drop — a boundary that widens the retained scan instead of narrowing it.
- `window_min=0` (the adaptive context-overflow retry, `loop.py`) is inert under the clamp: `min(0, …) == 0`, no clamp and no alarm, so overflow recovery does not spam the signal.
- `loop.py` now passes `agent.window_min` verbatim instead of `min(agent.window_min, request_window_max)`. **Behaviour-identical** — the windower's 75%-of-events-budget ceiling is strictly below `request_window_max` for every budget ≥ 1, so the pre-min can never bind — but it does change the telemetry: without it, a shrunk served ceiling would make the span report `configured_window_min` as the *served ceiling* rather than the agent's setting, i.e. exactly the misreading the span exists to prevent.

### Scope

Floor fix only. The issue's second defect — snap boundaries leaping between adjacent steps because `effective_ratio` and the reserve bounds drift live — splits into a follow-up issue.

**Named residual, deliberately not fixed here:** `window.floor_clamped` fires once per session step for as long as the clamp is active, and the clamp is the *steady state* for the very configuration that motivated this issue (default band + a large MCP tool surface) — so the signal risks its own alarm fatigue. Throttling or dedup is a behaviour change beyond this fix, and `WindowFloor` deliberately frames "clamped" as a standing operator signal; it goes to the follow-up issue alongside the boundary-freeze defect. The durable channel (the span) is unaffected either way.

## Substrate state changes

None — code-only change.

## Test plan

Red-first unit tests in `tests/unit/test_windowed_ratio.py`:

1. **Incident geometry regression** — 50k/150k with ~97.5k effective overhead: retained history lands inside `[floor, budget]` (under the old arithmetic it collapsed to ~22.5k effective, below the 39,375 floor), `chunk ≥ 25%` of the budget, `outcome == "clamped"`.
2. **Comfortable band** — `events_window_min == window_min` exactly. The direct fence against re-introducing `window_min - overhead`.
3. **Infeasible floor** — 140k/150k with 100k overhead clamps to 75% of the ~50k budget, no exception.
4. **Overhead ≥ `window_max`** still raises `ValueError`.
5. **Adaptive-retry path** — `window_min=0` → floor 0, `outcome == "honored"`, no alarm.
6. **Never-empty invariant** — `omission is not None` ⇒ `drop < total` (`build_messages` reads `events[0]` unguarded).
7. **`tokens_to_drop` inverted band** (`tests/unit/test_tokens.py`) returns the overshoot rather than a negative drop.

**Load-bearing test whose behaviour changed:** `test_overhead_clamp_never_drops_entire_window`. Its geometry (`1_000/2_000`, overhead 800) reached `drop == total` *through* the floor zeroing; under the fix the floor clamps to 564 and the geometry no longer drives `drop` anywhere near `total`. Its assertion is unchanged; its docstring is restated as the invariant it really defends, plus why the invariant still needs a fence (`window_min=0` is a live caller and restores exactly the full-budget chunk that produced the crash).

Kept green rather than duplicated: `test_ceil_div_never_overshoots_window` (max-leg invariant) and `test_insufficient_ratio_1_matches_today` (marked "load-bearing backward-compatibility fence").

```
uv run mypy src tests                                   # clean
uv run ruff check src tests && ruff format --check      # clean
uv run python scripts/pooled_connection_lint.py         # clean
uv run pytest tests/unit -q -n 4                        # 5553 passed
uv run pytest tests/e2e/test_windowing_overhead.py \
  tests/e2e/test_read_window_span.py \
  tests/integration/test_windowed_fs_lifecycle.py -q    # 9 passed
```

The e2e pair is the surrounding contract: `test_windowing_overhead.py` (full payload ≤ `window_max`, from #165) and `test_read_window_span.py` (span-pair shape, which this change extends).

Reviewed with `/code-review --fix` at high effort; three findings folded in as the second commit, one named above as a residual. No correctness findings.

## Risk / rollback

**Expected side effect:** sessions whose floor was previously zeroed now retain more history, so their prompts get larger — still bounded by `window_max`, since the max leg is untouched. That is the point of the fix, but it does mean a step-change in per-request token cost for the affected (fat-prelude) agents.

Post-merge sanity on prod, using the query that diagnosed the incident: `read_window_end` spans for the jarbot-org sessions should show `event_count_read` well above 1 and `window_floor_outcome: "honored"` at the current 200k/400k windows.

Rollback is a plain revert — no migration, no substrate state, no `openapi.json`/SDK regen.
