### PR TITLE
fix: return search_events/memory_search tables as plain text (#2291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   snap chunk usable) and reported on the `read_window_end` span plus a
   `window.floor_clamped` warning, rather than silently zeroed (#2289).
 
+- `search_events` and `memory_search` now return their formatted table as plain multi-line text (`ToolResult`) instead of a `{"result": …}` JSON envelope, so an inline or spilled result stays line-oriented for `grep`/`sed`/`wc -l`/`read` (#2291).
 - Distinguish a dead OAuth refresh token (RFC 6749 `invalid_grant` — revoked,
   expired, or otherwise unrecoverable) from a generic/transient
   `OAuthRefreshError` via a new `OAuthReauthRequiredError` subclass

--- a/src/aios/tools/memory_search.py
+++ b/src/aios/tools/memory_search.py
@@ -30,7 +30,9 @@ Safety:
   so a session only sees memories of its own attached stores.
 - Results are capped at MAX_ROWS rows, ordered by ts_rank DESC.
 
-Return shape: {"result": "<formatted text table>"}
+Return shape: :class:`~aios.tools.registry.ToolResult` whose ``content`` is the
+formatted text table as plain multi-line text (#2291) — not a JSON envelope, so a
+spilled result stays line-oriented for ``grep``/``sed``/``wc -l``/``read``.
 On an expected failure (empty query, timeout, query error) raises
 :class:`~aios.tools.invoke.ToolBail` (one typed failure channel — #1680); the single
 event writer stamps ``is_error``.
@@ -45,7 +47,7 @@ import asyncpg
 from aios.harness import runtime
 from aios.logging import get_logger
 from aios.tools.invoke import ToolBail
-from aios.tools.registry import registry
+from aios.tools.registry import ToolResult, registry
 
 log = get_logger(__name__)
 
@@ -168,7 +170,7 @@ MEMORY_SEARCH_PARAMETERS_SCHEMA: dict[str, Any] = {
 }
 
 
-async def memory_search_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+async def memory_search_handler(session_id: str, arguments: dict[str, Any]) -> ToolResult:
     """Handler for the memory_search tool."""
     query = arguments.get("query")
     if not isinstance(query, str) or not query.strip():
@@ -186,8 +188,11 @@ async def memory_search_handler(session_id: str, arguments: dict[str, Any]) -> d
         log.warning("memory_search.query_failed", error=str(exc))
         raise ToolBail(f"Query failed: {exc}") from exc
 
-    text = _format_results(rows, truncated)
-    return {"result": text}
+    # Plain-string ``ToolResult`` content, never ``{"result": text}`` (#2291) — see the
+    # note on ``search_events_handler``: only a ``ToolResult`` reaches the consumer
+    # verbatim; any other return type is JSON-encoded and collapses the table onto one
+    # escaped line.
+    return ToolResult(content=_format_results(rows, truncated))
 
 
 def _register() -> None:

--- a/src/aios/tools/search_events.py
+++ b/src/aios/tools/search_events.py
@@ -10,7 +10,9 @@ Safety:
 - A 10-second statement_timeout prevents runaway queries.
 - Results are capped at 200 rows.
 
-Return shape: {"result": "<formatted text table>"}
+Return shape: :class:`~aios.tools.registry.ToolResult` whose ``content`` is the
+formatted text table as plain multi-line text (#2291) — not a JSON envelope, so a
+spilled result stays line-oriented for ``grep``/``sed``/``wc -l``/``read``.
 On an expected failure (empty query, SQL validation, timeout, query error) raises
 :class:`~aios.tools.invoke.ToolBail` (one typed failure channel — #1680); the single
 event writer stamps ``is_error``, which is what the ``WHERE is_error`` example queries
@@ -28,7 +30,7 @@ from sqlglot import exp
 from aios.harness import runtime
 from aios.logging import get_logger
 from aios.tools.invoke import ToolBail
-from aios.tools.registry import registry
+from aios.tools.registry import ToolResult, registry
 
 log = get_logger(__name__)
 
@@ -365,7 +367,7 @@ SEARCH_EVENTS_PARAMETERS_SCHEMA: dict[str, Any] = {
 }
 
 
-async def search_events_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+async def search_events_handler(session_id: str, arguments: dict[str, Any]) -> ToolResult:
     """Handler for the search_events tool."""
     query = arguments.get("query")
     if not isinstance(query, str) or not query.strip():
@@ -387,8 +389,14 @@ async def search_events_handler(session_id: str, arguments: dict[str, Any]) -> d
         log.warning("search_events.query_failed", error=str(exc))
         raise ToolBail(f"Query failed: {exc}") from exc
 
-    text = _format_results(rows, truncated)
-    return {"result": text}
+    # Plain-string ``ToolResult`` content, never ``{"result": text}`` (#2291):
+    # ``_shape_tool_result`` passes str content through verbatim ONLY for a
+    # ``ToolResult``; every other return type falls to its ``json.dumps`` arm, which
+    # escapes each newline and collapses the table into one line. That makes a bare
+    # ``str`` return silently wrong too — it is JSON-encoded into a quoted string
+    # literal: still one line, now with extra quotes. ``ToolResult`` is the only
+    # correct shape, and nothing type-checks this at the registry boundary.
+    return ToolResult(content=_format_results(rows, truncated))
 
 
 def _register() -> None:

--- a/tests/e2e/test_search_events.py
+++ b/tests/e2e/test_search_events.py
@@ -14,11 +14,18 @@ import pytest
 
 from aios.harness import runtime
 from aios.tools.invoke import ToolBail
+from aios.tools.registry import ToolResult
 from aios.tools.search_events import search_events_handler
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness, assistant
 
 pytestmark = pytest.mark.docker
+
+
+def _text(result: ToolResult) -> str:
+    """The handler's table text — plain-string ``ToolResult`` content (#2291)."""
+    assert isinstance(result.content, str)
+    return result.content
 
 
 @needs_docker
@@ -51,8 +58,8 @@ class TestSearchEvents:
             },
         )
 
-        assert "result" in result
-        assert "docker" in result["result"].lower()
+        assert isinstance(result, ToolResult) and result.is_error is False
+        assert "docker" in _text(result).lower()
 
     async def test_count_by_role(self, harness: Harness) -> None:
         """Aggregate query: count events by role."""
@@ -71,8 +78,8 @@ class TestSearchEvents:
             },
         )
 
-        assert "result" in result
-        text = result["result"]
+        assert isinstance(result, ToolResult) and result.is_error is False
+        text = _text(result)
         # Should have at least user and assistant rows
         assert "user" in text
         assert "assistant" in text
@@ -96,7 +103,7 @@ class TestSearchEvents:
                 "query": ("SELECT * FROM events_search WHERE content_text ILIKE '%kubernetes%'"),
             },
         )
-        assert result_a["result"] == "No results."
+        assert _text(result_a) == "No results."
 
         # Session B should NOT see "Docker"
         result_b = await search_events_handler(
@@ -105,7 +112,7 @@ class TestSearchEvents:
                 "query": ("SELECT * FROM events_search WHERE content_text ILIKE '%docker%'"),
             },
         )
-        assert result_b["result"] == "No results."
+        assert _text(result_b) == "No results."
 
     async def test_select_star(self, harness: Harness) -> None:
         """SELECT * returns all widened-view columns (migration 0022)."""
@@ -118,7 +125,7 @@ class TestSearchEvents:
             },
         )
 
-        text = result["result"]
+        text = _text(result)
         header = text.split("\n")[0]
         for col in (
             "id",
@@ -207,7 +214,7 @@ class TestSearchEvents:
             },
         )
 
-        assert result["result"] == "No results."
+        assert _text(result) == "No results."
 
     async def test_view_excludes_non_message_events(self, harness: Harness) -> None:
         """The events_search view must only expose message events.
@@ -235,7 +242,7 @@ class TestSearchEvents:
             {"query": "SELECT count(*) AS n FROM events_search"},
         )
 
-        text = result["result"]
+        text = _text(result)
         assert str(msg_count) in text, f"expected {msg_count} rows in view, got: {text}"
 
 
@@ -303,10 +310,10 @@ class TestPromotedColumns:
                 ),
             },
         )
-        assert "slack:CHANA" in result["result"]
-        assert "alice" in result["result"]
-        assert "hello on A" in result["result"]
-        assert "CHANB" not in result["result"]
+        assert "slack:CHANA" in _text(result)
+        assert "alice" in _text(result)
+        assert "hello on A" in _text(result)
+        assert "CHANB" not in _text(result)
 
     async def test_tool_name_column_for_assistant_and_tool_rows(self, harness: Harness) -> None:
         """Assistant turns with tool_calls promote the first name;
@@ -361,7 +368,7 @@ class TestPromotedColumns:
                 ),
             },
         )
-        text = result["result"]
+        text = _text(result)
         # Both the assistant row (first tool_call was 'bash') and the tool
         # row (name='bash') should match.
         assert text.count("bash") >= 2
@@ -373,7 +380,7 @@ class TestPromotedColumns:
             session_id,
             {"query": "SELECT 1 FROM events_search WHERE tool_name = 'read'"},
         )
-        assert result2["result"] == "No results."
+        assert _text(result2) == "No results."
 
     async def test_is_error_column_nullable_true_only(self, harness: Harness) -> None:
         """is_error is TRUE on failures, NULL on success — never FALSE."""
@@ -427,4 +434,4 @@ class TestPromotedColumns:
             session_id,
             {"query": "SELECT count(*) AS n FROM events_search WHERE is_error"},
         )
-        assert "1" in result["result"]
+        assert "1" in _text(result)

--- a/tests/integration/test_migrations_0119_memories_fts.py
+++ b/tests/integration/test_migrations_0119_memories_fts.py
@@ -25,8 +25,16 @@ import asyncio
 import asyncpg
 import pytest
 
+from aios.tools.registry import ToolResult
 from tests.conftest import needs_docker
 from tests.helpers.alembic import run_alembic
+
+
+def _text(result: ToolResult) -> str:
+    """The handler's table text — plain-string ``ToolResult`` content (#2291)."""
+    assert isinstance(result.content, str)
+    return result.content
+
 
 # Two tenants, two stores, two sessions; each session is attached to exactly
 # one store. The isolation invariant: a session only ever sees memories of its
@@ -230,7 +238,7 @@ def test_memory_search_rank_and_handler(migration_db_url: str) -> None:
         )
     )
 
-    async def _run() -> dict[str, object]:
+    async def _run() -> ToolResult:
         from aios.db.pool import create_pool
         from aios.harness import runtime
         from aios.tools.memory_search import memory_search_handler
@@ -245,9 +253,8 @@ def test_memory_search_rank_and_handler(migration_db_url: str) -> None:
             await pool.close()
 
     result = asyncio.run(_run())
-    assert "result" in result, result
-    text = result["result"]
-    assert isinstance(text, str)
+    assert result.is_error is False
+    text = _text(result)
     # Both match; the keyword-dense memory ranks first.
     assert "/hi.md" in text and "/lo.md" in text
     assert text.index("/hi.md") < text.index("/lo.md")

--- a/tests/integration/test_migrations_0144_search_views.py
+++ b/tests/integration/test_migrations_0144_search_views.py
@@ -50,9 +50,17 @@ from typing import Any
 import asyncpg
 import pytest
 
+from aios.tools.registry import ToolResult
 from aios.tools.search_events import _ALLOWED_RELATIONS
 from tests.conftest import needs_docker
 from tests.helpers.alembic import run_alembic
+
+
+def _text(result: ToolResult) -> str:
+    """The handler's table text — plain-string ``ToolResult`` content (#2291)."""
+    assert isinstance(result.content, str)
+    return result.content
+
 
 # ---------------------------------------------------------------------------
 # Seed: two tenants, two sessions. Session X carries the full menagerie —
@@ -1136,7 +1144,7 @@ def test_every_documented_example_executes_and_returns_rows(db_url: str) -> None
                 except Exception as exc:
                     failures.append((query, f"raised: {exc}"))
                     continue
-                if result["result"] == "No results.":
+                if _text(result) == "No results.":
                     failures.append((query, "returned no rows against the seeded fixture"))
         finally:
             runtime.pool = prev

--- a/tests/unit/sandbox/test_tool_broker.py
+++ b/tests/unit/sandbox/test_tool_broker.py
@@ -32,8 +32,9 @@ from aios.models.agents import (
     StepSurface,
     ToolSpec,
 )
-from aios.sandbox.tool_broker import ToolBroker
+from aios.sandbox.tool_broker import ToolBroker, _envelope_from_result
 from aios.tools.registry import ToolDefinition, ToolResult, registry
+from aios.tools.search_events import _format_results, search_events_handler
 
 # ── shared fixtures + helpers ─────────────────────────────────────────────────
 
@@ -735,3 +736,57 @@ class TestRetiredSessionsMessages:
         # Starlette returns 404 for an unmatched path (405 only when the
         # path matches but the method doesn't). The route is gone entirely.
         assert r.status_code in (404, 405)
+
+
+# ── envelope shaping ──────────────────────────────────────────────────────────
+
+
+class _FakeRecord:
+    """Minimal ``asyncpg.Record`` stand-in for ``_format_results``."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def keys(self) -> Any:
+        return self._data.keys()
+
+    def values(self) -> Any:
+        return self._data.values()
+
+
+class TestEnvelopeFromResult:
+    """``search_events`` reaches the in-sandbox CLI as a raw table (#2291).
+
+    The point of the fix is that the multi-line table survives to the consumer
+    *unescaped* — a JSON-encoded envelope is what collapsed a 333KB spilled
+    result onto a single line and defeated ``grep``/``sed``/``wc -l``.
+    """
+
+    async def test_search_events_result_is_the_raw_table(self) -> None:
+        rows: list[Any] = [
+            _FakeRecord({"seq": 1, "role": "user", "content_text": "hello"}),
+            _FakeRecord({"seq": 2, "role": "assistant", "content_text": "hi"}),
+        ]
+        with (
+            patch(
+                "aios.tools.search_events._execute_query",
+                new_callable=AsyncMock,
+                return_value=(rows, False),
+            ),
+            patch("aios.tools.search_events.runtime.require_pool"),
+        ):
+            result = await search_events_handler(
+                "sess_01TEST", {"query": "SELECT * FROM events_search"}
+            )
+
+        envelope = _envelope_from_result(result)
+        assert envelope == {"content": _format_results(rows, False)}
+        # The load-bearing property: real newlines, not ``\n`` escapes.
+        content = envelope["content"]
+        assert "\\n" not in content
+        assert content.count("\n") == 3
+        assert content.splitlines()[0] == "seq | role | content_text"
+
+    def test_dict_result_is_still_json_encoded(self) -> None:
+        """The generic dict arm is untouched — only these two tools changed shape."""
+        assert _envelope_from_result({"result": "a\nb"}) == {"content": '{"result": "a\\nb"}'}

--- a/tests/unit/test_search_events_handler.py
+++ b/tests/unit/test_search_events_handler.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from aios.tools.invoke import ToolBail
+from aios.tools.registry import ToolResult
 from aios.tools.search_events import (
     MAX_ROWS,
     SEARCH_EVENTS_DESCRIPTION,
@@ -16,6 +17,12 @@ from aios.tools.search_events import (
     _validate_sql,
     search_events_handler,
 )
+
+
+def _text(result: ToolResult) -> str:
+    """The handler's table text — plain-string ``ToolResult`` content (#2291)."""
+    assert isinstance(result.content, str)
+    return result.content
 
 
 class TestSearchEventsDescription:
@@ -371,9 +378,9 @@ class TestSearchEventsHandler:
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )
-        assert "result" in result
-        assert "assistant" in result["result"]
-        assert "Hello" in result["result"]
+        assert isinstance(result, ToolResult) and result.is_error is False
+        assert "assistant" in _text(result)
+        assert "Hello" in _text(result)
 
     async def test_sql_validation_error(self) -> None:
         # Post-#1680: an expected failure raises ``ToolBail`` (one typed failure
@@ -419,7 +426,7 @@ class TestSearchEventsHandler:
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )
-        assert "truncat" not in result["result"].lower()
+        assert "truncat" not in _text(result).lower()
 
     async def test_row_limit_truncation(self) -> None:
         rows = [_FakeRecord({"id": f"evt_{i}"}) for i in range(MAX_ROWS)]
@@ -427,11 +434,11 @@ class TestSearchEventsHandler:
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )
-        assert "truncat" in result["result"].lower()
+        assert "truncat" in _text(result).lower()
 
     async def test_no_results(self) -> None:
         with _mock_execute(return_value=([], False)), _mock_pool():
             result = await search_events_handler(
                 "sess_01TEST", {"query": "SELECT * FROM events_search"}
             )
-        assert result["result"] == "No results."
+        assert _text(result) == "No results."

--- a/tests/unit/test_tool_result_spill.py
+++ b/tests/unit/test_tool_result_spill.py
@@ -9,10 +9,13 @@ the cached settings so the spill file lands somewhere inspectable (mirrors the
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from aios.config import get_settings
+from aios.harness.tool_dispatch import _shape_tool_result, _ToolCall
 from aios.sandbox.tool_result_spill import (
     _MAX_TOOL_RESULT_PARTS,
     cap_tool_result_content,
@@ -20,9 +23,23 @@ from aios.sandbox.tool_result_spill import (
     record_spill_attachment,
 )
 from aios.sandbox.volumes import ensure_session_attachments_dir
+from aios.tools.search_events import search_events_handler
 
 _SESSION_ID = "sess_spill_unit"
 _TOOL_CALL_ID = "tc_unit_1"
+
+
+class _FakeRecord:
+    """Minimal ``asyncpg.Record`` stand-in for ``search_events._format_results``."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def keys(self) -> Any:
+        return self._data.keys()
+
+    def values(self) -> Any:
+        return self._data.values()
 
 
 def _spill_path(session_id: str, tool_call_id: str) -> Path:
@@ -192,3 +209,47 @@ class TestCapToolResultParts:
         out = cap_tool_result_parts(parts, max_chars=4)
         assert out[:5] == parts[:5]
         assert out[5] == self._text("tail")
+
+
+async def test_spilled_search_events_result_is_line_oriented(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A spilled ``search_events`` result greps and pages by line (#2291).
+
+    The regression this pins: the handler used to return ``{"result": table}``,
+    which ``_shape_tool_result`` JSON-encoded — so the spill file was one
+    enormous line with every newline escaped, ``wc -l`` reported 0, and
+    ``grep -n`` / ``sed -n`` / the line-paged ``read`` tool were all useless
+    against it (the 333KB jarbot-org incident, 2026-08-28). Covering the full
+    handler → shape → spill chain is the point: the bug lived in the seam
+    between them, so neither layer alone would have caught it.
+    """
+    monkeypatch.setattr(get_settings(), "workspace_root", tmp_path)
+    rows: list[Any] = [
+        _FakeRecord({"seq": i, "role": "user", "content_text": f"line {i}"}) for i in range(200)
+    ]
+    with (
+        patch(
+            "aios.tools.search_events._execute_query",
+            new_callable=AsyncMock,
+            return_value=(rows, False),
+        ),
+        patch("aios.tools.search_events.runtime.require_pool"),
+    ):
+        result = await search_events_handler(
+            "sess_01TEST", {"query": "SELECT * FROM events_search"}
+        )
+
+    tc = _ToolCall(call_id=_TOOL_CALL_ID, name="search_events", raw_args={}, bound_log=None)
+    content = _shape_tool_result(tc, result)["content"]
+    assert isinstance(content, str)
+
+    capped = await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
+    assert capped.attachment is not None, "fixture must be large enough to spill"
+
+    spilled = _spill_path(_SESSION_ID, _TOOL_CALL_ID).read_text(encoding="utf-8")
+    # header + divider + one line per row — what ``wc -l`` reports.
+    assert len(spilled.splitlines()) == len(rows) + 2
+    # A known row greps on its own line, not buried in one escaped blob.
+    assert "\\n" not in spilled
+    assert [ln for ln in spilled.splitlines() if ln.startswith("42 | ")] == ["42 | user | line 42"]


### PR DESCRIPTION
## Summary

`search_events` and `memory_search` build a clean, line-structured text table and then returned it wrapped as `{"result": text}`. `_shape_tool_result` (`src/aios/harness/tool_dispatch.py:638`) JSON-encodes any plain-dict return, so every newline was escaped and the model — and, worse, the **spill file** — received one enormous single line. This returns `ToolResult(content=text)` instead, so the formatted table reaches the model, the event log and the spill file as plain multi-line text.

That envelope is what bit us on 2026-08-28: a 333,091-byte spilled `search_events` result with **zero** physical newlines. `wc -l` → 0; `grep -n` / `sed -n` / line-paged `read` were all useless against it. The agent concluded the file was empty and re-queried, feeding a `search_events` self-query loop; the operator investigating hit the identical trap. The content was intact the whole time (`json.load` read it fine) — the envelope alone defeated every line-oriented probe. Spilling itself is working as designed (the file is a query-result cache the agent interrogates with `grep`/`read` follow-ups, preserving prefix caching); the envelope is what made that cache unreadable for these two tools.

Fixes #2291.

Notes for the reviewer:

- **A bare `str` return would have been silently wrong** — it falls into `_shape_tool_result`'s dict arm and gets `json.dumps`'d into a quoted JSON *string literal*: still one line, now with extra quotes. Nothing type-checks this at the registry boundary. `ToolResult` is the only correct shape; both call sites carry a comment saying so.
- **This changes a tool result's on-the-wire shape.** Old spilled files stay single-line and old event rows keep their `{"result": …}` content — no migration is needed or possible; they age out. Nothing reads that content programmatically.
- **Sequencing: this should land before #2292** (spill threshold 200k → 16k). #2292 makes results spill far more often, which would multiply this pathology's frequency before the fix exists. The two touch disjoint files, so only the order matters.
- Side benefit: `events_search.content_text` / `tool_calls_search.result_text` (migrations 0010, 0144) derive from `data->>'content'`, so an agent self-querying its own past results now reads a readable table instead of an escaped blob.
- `memory_search` is a near-verbatim sibling with its own duplicated `_format_results` and the same latent pathology. It searches memory stores — a different corpus, actively used — so it gets the same fix rather than deletion.

Nothing else in the serialization chain changes:

- `_shape_tool_result` stores `str` content verbatim, no encoding.
- The spill cap runs *after* shaping on that same string and `_write_spill` writes it verbatim, so the multi-line spill file falls out for free. **No spill-side change**, which also keeps this clear of #2292's files.
- `_strip_to_spec` (`harness/context.py:202`) passes `content` straight to the wire shape.
- The in-sandbox CLI improves for free: `_envelope_from_result` (`sandbox/tool_broker.py`) returns `{"content": <raw table>}` for str content and `bin/tool` prints `content` raw by default (`--full` still yields the JSON envelope). The transport-level envelope contract is untouched.
- Error path unchanged: both tools raise `ToolBail` for every expected failure, which never reaches `_shape_tool_result` — errors stay JSON (acceptance criterion 3).
- `_format_results` output is byte-identical in both tools (the `"No results."` sentinel is compared literally by an integration test; the truncation trailer is asserted in unit tests).

## Substrate state changes

None — code-only change.

- [ ] Required env-var contract changed (added, removed, renamed, validation tightened)
- [ ] File-mount content shape changed (e.g. `/config/config.yaml`)
- [ ] Container UID, working-dir, or volume-permission expectations changed
- [ ] Persistent-volume layout changed (new mount points, names, ownership)
- [ ] External-service contract changed (DB schema, downstream API surface, public auth shape)
- [ ] First-boot / migration grandfather hook needed for live consumers

## Test plan

Red-first: with the handler reverted to `{"result": …}`, both new tests plus 4 existing handler tests fail; with the fix they all pass.

Two new tests, both verified red against the old shape:

- `tests/unit/test_tool_result_spill.py::test_spilled_search_events_result_is_line_oriented` — the issue's acceptance criterion 2, encoded at the layer the bug actually lived in. Drives the real `search_events_handler` (mocked `_execute_query`, 200 rows) through `_shape_tool_result` → `cap_tool_result_content` and asserts the spill file's `splitlines()` count equals `rows + 2` and that a known row lands on its own line. Covering the full chain is the point: the bug lived in the seam between the handler and dispatch, so neither layer alone would have caught it.
- `tests/unit/sandbox/test_tool_broker.py::TestEnvelopeFromResult` — the in-sandbox CLI path: `_envelope_from_result` yields `{"content": <raw table>}` with **real newlines, not `\n` escapes**. A companion case pins that the generic dict arm is still JSON-encoded.

Existing suites updated mechanically (`result["result"]` → a `_text(result)` helper that narrows `ToolResult.content` to `str`), plus an `isinstance(result, ToolResult) and result.is_error is False` assertion at the representative sites:

```
uv run mypy src tests                                      # Success: no issues found in 1042 source files
uv run ruff check src tests && uv run ruff format --check src tests   # clean
uv run pytest tests/unit -q -n 4                           # 5549 passed

DOCKER_HOST=unix:///Users/tom/.docker/run/docker.sock uv run pytest \
  tests/e2e/test_search_events.py \
  tests/integration/test_migrations_0144_search_views.py \
  tests/integration/test_migrations_0119_memories_fts.py -q   # 29 passed
```

Not verified locally (needs a live session): the end-to-end spill check — run a `search_events` query large enough to spill, then confirm in the sandbox that `wc -l` on `/mnt/attachments/tool_results/<toolu_id>.txt` returns the row count rather than 0 and that a known row `grep -n`s on its own line. Post-merge prod sanity: a fresh `search_events` tool-result event's `data.content` should start with the table header (`seq | …`), not `{"result":`.

## Risk / rollback

Low. Two handler return statements plus their test assertions; no schema, API, SDK or spill-path change. Rollback is a straight revert — the old envelope shape comes back with no cleanup, since nothing persists a dependency on either shape.

Out of scope, worth a follow-up if it ever bites: `read`'s text arm returns `{"path", "content"}` and has the same escaped-newline behavior when spilled; `bash`'s envelope is genuinely load-bearing and should keep it.
