### PR TITLE
perf(tools): workflow tool schemas 69KB -> 5.8KB via progressive disclosure (#2294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   `window.floor_clamped` warning, rather than silently zeroed (#2289).
 
 - `search_events` and `memory_search` now return their formatted table as plain multi-line text (`ToolResult`) instead of a `{"result": …}` JSON envelope, so an inline or spilled result stays line-oriented for `grep`/`sed`/`wc -l`/`read` (#2291).
+- Cut the model-facing `create_workflow`/`update_workflow`/`call_workflow` tool schemas from ~69KB to ~5.8KB combined by moving the script-authoring contract behind a new on-demand `get_workflow_script_contract` builtin and rendering the declared tool/MCP/HTTP surface as opaque arrays; pydantic validation and the HTTP/SDK schemas are unchanged (#2294).
 - Distinguish a dead OAuth refresh token (RFC 6749 `invalid_grant` — revoked,
   expired, or otherwise unrecoverable) from a generic/transient
   `OAuthRefreshError` via a new `OAuthReauthRequiredError` subclass

--- a/openapi.json
+++ b/openapi.json
@@ -19015,6 +19015,7 @@
                   "unarchive_workflow",
                   "resume_gate",
                   "get_workflow",
+                  "get_workflow_script_contract",
                   "list_workflows",
                   "get_run",
                   "list_runs",

--- a/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
@@ -28,6 +28,7 @@ class ToolSpecTypeType0(str, Enum):
     GET_AGENT = "get_agent"
     GET_RUN = "get_run"
     GET_WORKFLOW = "get_workflow"
+    GET_WORKFLOW_SCRIPT_CONTRACT = "get_workflow_script_contract"
     GLOB = "glob"
     GREP = "grep"
     HTTP_REQUEST = "http_request"

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -90,6 +90,28 @@ _MCP_CLI_HINT = (
 )
 
 
+def _inject_workflow_script_contract(tools: list[dict[str, Any]]) -> None:
+    """Append the workflow script-contract reader when an authoring tool is offered.
+
+    The companion half of the #2294 schema diet: ``create_workflow`` /
+    ``update_workflow`` / ``call_workflow`` no longer inline the authoring manual,
+    so the reader that serves it must be offered wherever they are — otherwise the
+    trimmed ``script`` description points at a tool the agent cannot call. Injected
+    (rather than required as a grant) so the fleet's existing agents keep a
+    reachable contract with no re-provisioning. Idempotent: an agent that also
+    declares the tool gets exactly one entry.
+    """
+    from aios.tools.workflow_management import (
+        SCRIPT_CONTRACT_TOOL_NAME,
+        WORKFLOW_AUTHORING_TOOL_NAMES,
+        script_contract_tool_spec,
+    )
+
+    offered = {(entry.get("function") or {}).get("name") for entry in tools}
+    if offered & WORKFLOW_AUTHORING_TOOL_NAMES and SCRIPT_CONTRACT_TOOL_NAME not in offered:
+        tools.append(script_contract_tool_spec())
+
+
 def _has_always_allow_mcp_tool(agent_tools: list[ToolSpec]) -> bool:
     """True iff at least one enabled mcp_toolset entry resolves any tool
     to ``always_allow``.
@@ -311,6 +333,12 @@ async def compute_step_prelude(
     # focal attention; inject it whenever the session has bound channels.
     if channels:
         tools.append(_switch_channel_tool_spec())
+    # #2294: the workflow script contract is no longer inlined in the authoring
+    # tools' schemas (~69KB → ~5KB across the trio) — it is read on demand. Inject
+    # the reader whenever an authoring tool is offered, so the manual stays
+    # reachable for agents already provisioned with those tools (and so the
+    # offered-set guard admits the call). Explicitly granting it is a no-op.
+    _inject_workflow_script_contract(tools)
     # return/error are how a session ANSWERS a request it owes — a background child
     # of a run (§3.5), OR a session-caller invoke target (#1127). The gate is owning
     # an open request edge (#1123), not child-ness: a plain foreground session that

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -60,6 +60,7 @@ BuiltinToolType = Literal[
     "unarchive_workflow",
     "resume_gate",
     "get_workflow",
+    "get_workflow_script_contract",
     "list_workflows",
     "get_run",
     "list_runs",

--- a/src/aios/tools/input.py
+++ b/src/aios/tools/input.py
@@ -33,6 +33,16 @@ def tool_input[M: BaseModel](model: type[M], arguments: dict[str, Any]) -> M:
     the JSON Schema can't encode (custom field_validators, cross-field
     rules) surface as ToolBail, so the model self-corrects through the
     session log instead of evicting the sandbox.
+
+    The one sanctioned divergence is the model-facing schema diet
+    (:mod:`aios.tools.schema_diet`, #2294): a registration may pass
+    ``slim_tool_schema(Model.model_json_schema())``, which only ever
+    *loosens* what the dispatch-time jsonschema check enforces (it drops
+    boilerplate and collapses a config subtree to a bare array) and never
+    touches ``additionalProperties: false``. This model stays the enforcing
+    source of truth, so what the diet stops catching at dispatch is caught
+    here instead — with a field-precise pydantic error rather than a
+    schema one.
     """
     try:
         return model.model_validate(arguments)

--- a/src/aios/tools/invoke_session.py
+++ b/src/aios/tools/invoke_session.py
@@ -69,6 +69,7 @@ from aios.tools.schema_errors import (
     format_schema_violation,
     normalize_and_format_schema_violation,
 )
+from aios.tools.workflow_management import slim_workflow_schema
 
 # Per-park await budget. The tool task is fire-and-forget (implicit-async), so a
 # long park never blocks the caller's other turns; we re-poll in a loop so a
@@ -157,28 +158,26 @@ class _CallAgentArgs(BaseModel):
 class _CallWorkflowArgs(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    # Field prose is deliberately terse (#2294): the "exactly one source arm" rule
+    # lives once, in CALL_WORKFLOW_DESCRIPTION, rather than being restated on both
+    # arms. The safety-bearing facts (shared workspace = live write access; vault
+    # subset semantics) are kept — those are guidance, not manual.
     workflow_id: str | None = Field(
-        default=None,
-        description=(
-            "The id of the same-account workflow to run and await. Supply EITHER this or "
-            "`inline` (exactly one). Omit to launch an inline one-shot run."
-        ),
+        default=None, description="The same-account workflow to run and await."
     )
     inline: InlineScriptBody | None = Field(
         default=None,
         description=(
-            "Inline-script body for an anonymous one-shot run (T5): `{script, schemas, "
-            "surface}`. NO workflow is registered; the run snapshots the script and clamps "
-            "the declared surface to your own. Supply EITHER this or `workflow_id`."
+            "Inline one-shot script body; no workflow row is created and the declared "
+            "surface is clamped to your own."
         ),
     )
     input: Any = Field(default=None, description="The run input (JSON or a string).")
     workspace: Literal["shared", "fresh"] = Field(
         default="fresh",
         description=(
-            "Workspace for the run. Defaults to `fresh` (an empty run workspace): sharing "
-            "hands the run LIVE WRITE ACCESS to this session's workspace, so it is opt-in. "
-            "Pass `shared` explicitly to hand the run this session's workspace."
+            "`fresh` (default) = an empty run workspace. `shared` hands the run LIVE "
+            "WRITE ACCESS to this session's workspace, so it is opt-in."
         ),
     )
     output_schema: dict[str, Any] | None = Field(
@@ -188,9 +187,7 @@ class _CallWorkflowArgs(BaseModel):
     vault_ids: list[str] | None = Field(
         default=None,
         description=(
-            "Vault ids to bind to the run. Omit or pass null to inherit all vaults "
-            "currently bound to this session; pass [] to bind none; a nonempty list "
-            "must be a subset of the session's vaults."
+            "Vaults to bind (a subset of your own). Omit to inherit this session's; [] binds none."
         ),
     )
     budget_usd: float | None = Field(
@@ -478,14 +475,11 @@ CALL_AGENT_DESCRIPTION = (
     "responsive while waiting."
 )
 CALL_WORKFLOW_DESCRIPTION = (
-    "Launch a run and wait for its result ({ok: output} on completion, an error if it "
-    "errored/was cancelled). Run EITHER a registered workflow (`workflow_id`) OR an "
-    "inline one-shot script (`inline`: {script, schemas, surface}) with no workflow "
-    "registered — supply exactly one; inline is the ergonomic default for one-shot work. "
-    "An inline run's declared surface is clamped to your own. The run uses your own "
-    "environment. Optionally attach `vault_ids` (a subset of your own vaults), set a "
-    "shared `budget_usd` spend ceiling, and constrain the output with `output_schema` (a "
-    "non-conforming output is reported as an error). Single-shot per call."
+    "Launch a run and wait for its result ({ok: output}, or an error if it errored or "
+    "was cancelled). Supply EXACTLY ONE of `workflow_id` (a registered workflow) or "
+    "`inline` (a one-shot script; the default for one-off work). The run uses your own "
+    "environment. Single-shot per call. Read `get_workflow_script_contract` before "
+    "writing an inline script."
 )
 
 
@@ -513,7 +507,10 @@ def _register() -> None:
     registry.register(
         name="call_workflow",
         description=CALL_WORKFLOW_DESCRIPTION,
-        parameters_schema=_CallWorkflowArgs.model_json_schema(),
+        # Model-facing diet (#2294): the nested inline body's script description and
+        # declared-surface trees are collapsed; _CallWorkflowArgs itself (and so
+        # InlineScriptBody validation) is untouched — see tools/schema_diet.py.
+        parameters_schema=slim_workflow_schema(_CallWorkflowArgs.model_json_schema()),
         handler=call_workflow_handler,
         transport="agent_tool",
         resumable=True,

--- a/src/aios/tools/schema_diet.py
+++ b/src/aios/tools/schema_diet.py
@@ -1,0 +1,177 @@
+"""Model-facing tool-schema slimming — progressive disclosure at the schema edge.
+
+A pydantic request body is the right shape for the HTTP/SDK plane: precise,
+exhaustively documented, fully expanded. It is the *wrong* shape for a
+model-facing tool schema, because a tool schema ships in **every request** of
+every agent that holds the tool, whether or not the turn touches it. The
+workflow-authoring trio (``create_workflow`` / ``update_workflow`` /
+``call_workflow``) rendered at ~69KB combined — the fattest schemas on the tool
+surface — from two inlining decisions (#2294):
+
+1. the whole script-authoring manual inlined as the ``script`` field
+   description, duplicated per tool; and
+2. the declared-surface config models (``ToolSpec`` / ``McpServerSpec`` /
+   ``HttpServerSpec``) expanded into ``$defs``, per tool.
+
+This module is the fix, applied *only* where the registry renders a tool for
+the model. It is deliberately a post-render transform on the JSON Schema rather
+than a second set of parallel pydantic models:
+
+* the HTTP/SDK contract is untouched — ``openapi.json`` and the generated SDK
+  still render the full ``WorkflowCreate``/``WorkflowUpdate``/``InlineScriptBody``;
+* server-side validation is untouched — the handlers still parse the *real*
+  models, so a malformed body still gets a field-precise 422/``ToolBail``, which
+  is what actually teaches the model; and
+* there is no parallel model to drift out of sync with the real one.
+
+The trade the schema makes is explicit: the model is told less up front, and
+learns the rest from a precise error or from the on-demand authoring contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+_REF_PREFIX = "#/$defs/"
+
+
+def slim_tool_schema(
+    schema: Mapping[str, Any],
+    *,
+    opaque_arrays: Mapping[str, str],
+    redescribe: Mapping[str, str],
+) -> dict[str, Any]:
+    """Return a slimmed copy of a rendered JSON Schema.
+
+    ``opaque_arrays`` maps a property name to the one-line description that
+    replaces its fully-expanded subschema: the property becomes a bare
+    ``{"type": "array"}`` (null-arm preserved when the original allowed null),
+    which drops the whole ``$defs`` tree it referenced.
+
+    ``redescribe`` maps a property name to a replacement ``description``, with
+    the rest of the property's subschema left exactly as rendered.
+
+    Both maps are applied to **every** ``properties`` object in the schema, not
+    just the root — that is how a nested body reached only through a ``$ref``
+    (``call_workflow``'s ``inline``) is slimmed by the same call. Property names
+    here are unambiguous within these schemas.
+
+    Four kinds of pydantic boilerplate are dropped unconditionally, because they
+    are bytes the model never benefits from: every ``title`` (mechanically derived
+    from the field name it sits next to); every ``"default": null`` (a restatement
+    of "absent from ``required``" — non-null defaults are kept, they carry real
+    information); every ``"additionalProperties": true`` (the JSON Schema default
+    — the load-bearing ``false``, which is what keeps trusted ids out of these
+    schemas, is never touched); and every MODEL-level ``description`` — the root's
+    and each ``$defs`` entry's — which pydantic sources from the class docstring.
+    Those are prose written for developers ("Request body for ``POST /v1/workflows``",
+    issue numbers, even the names of the trusted kwargs the model must never see);
+    the tool's own ``description`` is what introduces the tool. Field-level
+    ``description`` is untouched: that is the guidance the model actually reads.
+
+    ``$defs`` entries that are no longer reachable are dropped.
+    """
+    out = deepcopy(dict(schema))
+    for properties in _iter_properties(out):
+        for name, description in opaque_arrays.items():
+            prop = properties.get(name)
+            if prop is not None:
+                properties[name] = _opaque_array(prop, description)
+        for name, description in redescribe.items():
+            prop = properties.get(name)
+            if isinstance(prop, dict):
+                prop["description"] = description
+    _prune_unreachable_defs(out)
+    _strip_boilerplate(out)
+    out.pop("description", None)
+    for definition in out.get("$defs", {}).values():
+        if isinstance(definition, dict):
+            definition.pop("description", None)
+    return out
+
+
+def _iter_properties(node: Any) -> list[dict[str, Any]]:
+    """Every ``properties`` mapping anywhere in the schema, root first."""
+    found: list[dict[str, Any]] = []
+    stack: list[Any] = [node]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            properties = current.get("properties")
+            if isinstance(properties, dict):
+                found.append(properties)
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+    return found
+
+
+def _strip_boilerplate(node: Any) -> None:
+    """Remove titles, null defaults, and permissive ``additionalProperties``, in place."""
+    stack: list[Any] = [node]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            current.pop("title", None)
+            if current.get("default", ...) is None:
+                del current["default"]
+            if current.get("additionalProperties") is True:
+                del current["additionalProperties"]
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+
+
+def _opaque_array(prop: Any, description: str) -> dict[str, Any]:
+    """Collapse a rendered list-of-model property to a bare array."""
+    array: dict[str, Any] = {"type": "array"}
+    if _allows_null(prop):
+        return {"anyOf": [array, {"type": "null"}], "description": description}
+    return {**array, "description": description}
+
+
+def _allows_null(prop: Any) -> bool:
+    if not isinstance(prop, dict):
+        return False
+    arms = prop.get("anyOf")
+    if not isinstance(arms, list):
+        return False
+    return any(isinstance(arm, dict) and arm.get("type") == "null" for arm in arms)
+
+
+def _prune_unreachable_defs(schema: dict[str, Any]) -> None:
+    """Drop ``$defs`` entries no longer referenced from the schema body."""
+    defs = schema.get("$defs")
+    if not isinstance(defs, dict):
+        return
+    body = {k: v for k, v in schema.items() if k != "$defs"}
+    reachable: set[str] = set()
+    frontier = _refs_in(body)
+    while frontier:
+        name = frontier.pop()
+        if name in reachable or name not in defs:
+            continue
+        reachable.add(name)
+        frontier |= _refs_in(defs[name])
+    for name in set(defs) - reachable:
+        del defs[name]
+    if not defs:
+        del schema["$defs"]
+
+
+def _refs_in(node: Any) -> set[str]:
+    """Every ``#/$defs/<name>`` target referenced anywhere under ``node``."""
+    names: set[str] = set()
+    stack: list[Any] = [node]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            ref = current.get("$ref")
+            if isinstance(ref, str) and ref.startswith(_REF_PREFIX):
+                names.add(ref[len(_REF_PREFIX) :])
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+    return names

--- a/src/aios/tools/schema_diet.py
+++ b/src/aios/tools/schema_diet.py
@@ -48,7 +48,8 @@ def slim_tool_schema(
     ``opaque_arrays`` maps a property name to the one-line description that
     replaces its fully-expanded subschema: the property becomes a bare
     ``{"type": "array"}`` (null-arm preserved when the original allowed null),
-    which drops the whole ``$defs`` tree it referenced.
+    which drops the whole ``$defs`` tree it referenced. A property that is not
+    actually an array is left alone — see :func:`_opaque_array`.
 
     ``redescribe`` maps a property name to a replacement ``description``, with
     the rest of the property's subschema left exactly as rendered.
@@ -92,53 +93,103 @@ def slim_tool_schema(
     return out
 
 
-def _iter_properties(node: Any) -> list[dict[str, Any]]:
-    """Every ``properties`` mapping anywhere in the schema, root first."""
+#: Keywords whose value is a NAME → schema mapping (the names are field names,
+#: never schema keywords — which is exactly why a blind ``dict`` walk is wrong).
+_SCHEMA_MAPS = ("properties", "$defs", "patternProperties", "definitions")
+#: Keywords whose value is a list of schemas.
+_SCHEMA_LISTS = ("anyOf", "oneOf", "allOf", "prefixItems")
+#: Keywords whose value is a single schema.
+_SCHEMA_VALUES = ("items", "not", "contains", "additionalProperties", "propertyNames")
+
+
+def _walk_schemas(root: Any) -> list[dict[str, Any]]:
+    """Every genuine schema object reachable from ``root``, root first.
+
+    Structural, not a blind ``dict`` walk: it descends only through JSON Schema
+    keywords. That distinction is load-bearing — inside ``properties`` the keys
+    are FIELD names, so a field named ``title`` (or ``default``, or
+    ``additionalProperties``) would otherwise be mistaken for the keyword of the
+    same name and stripped, leaving a property that ``required`` still demands.
+    """
     found: list[dict[str, Any]] = []
-    stack: list[Any] = [node]
+    stack: list[Any] = [root]
     while stack:
         current = stack.pop()
-        if isinstance(current, dict):
-            properties = current.get("properties")
-            if isinstance(properties, dict):
-                found.append(properties)
-            stack.extend(current.values())
-        elif isinstance(current, list):
-            stack.extend(current)
+        if not isinstance(current, dict):
+            continue
+        found.append(current)
+        for keyword in _SCHEMA_MAPS:
+            group = current.get(keyword)
+            if isinstance(group, dict):
+                stack.extend(group.values())
+        for keyword in _SCHEMA_LISTS:
+            arms = current.get(keyword)
+            if isinstance(arms, list):
+                stack.extend(arms)
+        for keyword in _SCHEMA_VALUES:
+            sub = current.get(keyword)
+            if isinstance(sub, dict):
+                stack.append(sub)
     return found
 
 
-def _strip_boilerplate(node: Any) -> None:
+def _iter_properties(root: Any) -> list[dict[str, Any]]:
+    """Every ``properties`` mapping anywhere in the schema."""
+    return [
+        node["properties"]
+        for node in _walk_schemas(root)
+        if isinstance(node.get("properties"), dict)
+    ]
+
+
+def _strip_boilerplate(root: Any) -> None:
     """Remove titles, null defaults, and permissive ``additionalProperties``, in place."""
-    stack: list[Any] = [node]
-    while stack:
-        current = stack.pop()
-        if isinstance(current, dict):
-            current.pop("title", None)
-            if current.get("default", ...) is None:
-                del current["default"]
-            if current.get("additionalProperties") is True:
-                del current["additionalProperties"]
-            stack.extend(current.values())
-        elif isinstance(current, list):
-            stack.extend(current)
+    for node in _walk_schemas(root):
+        node.pop("title", None)
+        if node.get("default", ...) is None:
+            del node["default"]
+        if node.get("additionalProperties") is True:
+            del node["additionalProperties"]
 
 
 def _opaque_array(prop: Any, description: str) -> dict[str, Any]:
-    """Collapse a rendered list-of-model property to a bare array."""
+    """Collapse a rendered list-of-model property to a bare array.
+
+    Wholesale replacement, so everything the rendered property carried goes —
+    including a ``default: []``, which says nothing the field's absence from
+    ``required`` doesn't already say. Returns ``prop`` unchanged if it isn't
+    actually an array: collapsing a non-array to ``{"type": "array"}`` would be
+    the one way this module could TIGHTEN the dispatch-time check, so a
+    name-only match is not enough to fire.
+    """
+    if isinstance(prop, dict) and not _is_array(prop):
+        return prop
     array: dict[str, Any] = {"type": "array"}
     if _allows_null(prop):
         return {"anyOf": [array, {"type": "null"}], "description": description}
     return {**array, "description": description}
 
 
-def _allows_null(prop: Any) -> bool:
+def _arms(prop: Any) -> list[Any]:
+    """The property's type arms — its ``anyOf`` branches, or itself."""
     if not isinstance(prop, dict):
-        return False
+        return []
     arms = prop.get("anyOf")
-    if not isinstance(arms, list):
-        return False
-    return any(isinstance(arm, dict) and arm.get("type") == "null" for arm in arms)
+    return arms if isinstance(arms, list) else [prop]
+
+
+def _is_array(prop: Any) -> bool:
+    """True iff every non-null arm of ``prop`` is an array."""
+    non_null = [
+        arm for arm in _arms(prop) if not (isinstance(arm, dict) and arm.get("type") == "null")
+    ]
+    return bool(non_null) and all(
+        isinstance(arm, dict) and arm.get("type") == "array" for arm in non_null
+    )
+
+
+def _allows_null(prop: Any) -> bool:
+    return any(isinstance(arm, dict) and arm.get("type") == "null" for arm in _arms(prop))
 
 
 def _prune_unreachable_defs(schema: dict[str, Any]) -> None:
@@ -164,14 +215,8 @@ def _prune_unreachable_defs(schema: dict[str, Any]) -> None:
 def _refs_in(node: Any) -> set[str]:
     """Every ``#/$defs/<name>`` target referenced anywhere under ``node``."""
     names: set[str] = set()
-    stack: list[Any] = [node]
-    while stack:
-        current = stack.pop()
-        if isinstance(current, dict):
-            ref = current.get("$ref")
-            if isinstance(ref, str) and ref.startswith(_REF_PREFIX):
-                names.add(ref[len(_REF_PREFIX) :])
-            stack.extend(current.values())
-        elif isinstance(current, list):
-            stack.extend(current)
+    for schema in _walk_schemas(node):
+        ref = schema.get("$ref")
+        if isinstance(ref, str) and ref.startswith(_REF_PREFIX):
+            names.add(ref[len(_REF_PREFIX) :])
     return names

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -56,6 +56,7 @@ from aios.services import sessions as sessions_service
 from aios.services import workflows as wf_service
 from aios.tools.input import tool_input
 from aios.tools.registry import registry
+from aios.tools.schema_diet import slim_tool_schema
 
 # Heavy snapshot fields the model already sent (or doesn't need echoed back); trimmed
 # from the returned dicts to keep tool results lean.
@@ -140,6 +141,12 @@ class _ListRunEventsArgs(BaseModel):
     run_id: str
     after_seq: int = Field(default=0, ge=0)
     limit: int = Field(default=200, ge=1, le=500)
+
+
+class _NoArgs(BaseModel):
+    """No arguments — the schema is ``{}`` with nothing accepted."""
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class _ResumeGateArgs(BaseModel):
@@ -289,6 +296,19 @@ async def list_run_events_handler(session_id: str, arguments: dict[str, Any]) ->
     return {"events": [e.model_dump(mode="json") for e in events]}
 
 
+async def get_workflow_script_contract_handler(
+    session_id: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """The on-demand half of the #2294 progressive disclosure.
+
+    Pure constant read — no pool, no account, no session state. This is the
+    surface the trimmed ``script`` field description points at, so the authoring
+    manual stays genuinely reachable while costing nothing per request.
+    """
+    tool_input(_NoArgs, arguments)
+    return {"contract": WORKFLOW_SCRIPT_CONTRACT}
+
+
 async def resume_gate_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
@@ -304,26 +324,78 @@ async def resume_gate_handler(session_id: str, arguments: dict[str, Any]) -> dic
     return run.model_dump(mode="json", exclude=_RUN_ECHO_EXCLUDE)
 
 
+# ─── model-facing schema diet (#2294) ────────────────────────────────────────
+#
+# The pydantic bodies stay exactly as they are — the HTTP/SDK plane and every
+# handler still validate against the full ``WorkflowCreate``/``WorkflowUpdate``/
+# ``InlineScriptBody``, so a malformed body still gets a field-precise error.
+# What changes is only what the MODEL is shown, because a tool schema ships in
+# every request whether or not the turn touches workflows. Two things are cut:
+# the inlined authoring manual (now on demand via ``get_workflow_script_contract``)
+# and the fully-expanded declared-surface config trees.
+
+#: The tools whose schemas used to carry the inlined authoring manual. An agent
+#: holding any of them is authoring workflow scripts, so the harness injects the
+#: contract reader alongside them (:func:`script_contract_tool_spec`) — the manual
+#: stays reachable for the fleet's already-provisioned agents without a re-grant.
+WORKFLOW_AUTHORING_TOOL_NAMES = frozenset({"create_workflow", "update_workflow", "call_workflow"})
+
+SCRIPT_CONTRACT_TOOL_NAME = "get_workflow_script_contract"
+
+SCRIPT_FIELD_DESCRIPTION = (
+    "Python defining `async def main(input)`; its return value is the run's output. "
+    "Call `get_workflow_script_contract` for the authoring contract; `get_workflow` "
+    "on an existing workflow for an example."
+)
+TOOLS_FIELD_DESCRIPTION = (
+    'Declared tool surface (agent-config envelope, e.g. [{"type": "bash"}]; a subset '
+    "of your own). Usually omitted."
+)
+MCP_SERVERS_FIELD_DESCRIPTION = (
+    "Declared MCP servers (agent-config envelope; a subset of your own). Usually omitted."
+)
+HTTP_SERVERS_FIELD_DESCRIPTION = (
+    'Declared HTTP servers: grant names (["github"]) or full specs; a subset of your '
+    "own. Usually omitted."
+)
+
+_OPAQUE_SURFACE_FIELDS = {
+    "tools": TOOLS_FIELD_DESCRIPTION,
+    "mcp_servers": MCP_SERVERS_FIELD_DESCRIPTION,
+    "http_servers": HTTP_SERVERS_FIELD_DESCRIPTION,
+}
+
+
+def slim_workflow_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Apply the #2294 diet to a rendered workflow-body schema (model-facing only)."""
+    return slim_tool_schema(
+        schema,
+        opaque_arrays=_OPAQUE_SURFACE_FIELDS,
+        redescribe={"script": SCRIPT_FIELD_DESCRIPTION},
+    )
+
+
 # ─── descriptions + registration ─────────────────────────────────────────────
 
 CREATE_WORKFLOW_DESCRIPTION = (
     "Author a new workflow (a deterministic Python orchestrator) under your account. "
     "Its declared tool/server surface must be a subset of your own — you cannot grant a "
-    "workflow a tool, MCP server, or HTTP server you don't yourself have. For HTTP "
-    'servers you may pass a bare name string (e.g. http_servers: ["github"]) to '
-    "reference one of your own grants by name — its base_url and routes are resolved "
-    "from you — or a full HttpServerSpec object. Returns the created workflow (id, name, "
-    "version).\n\n"
-    f"{WORKFLOW_SCRIPT_CONTRACT}"
+    "workflow a tool, MCP server, or HTTP server you don't yourself have. Returns the "
+    "created workflow (id, name, version). Read the script contract first with "
+    "`get_workflow_script_contract`."
 )
 UPDATE_WORKFLOW_DESCRIPTION = (
     "Update one of your workflows in place, bumping its version. Pass the current "
     "'version' as an optimistic-concurrency token (a stale token is rejected — re-read "
-    "with get_workflow and retry). Omitted fields are preserved. The resulting tool/server "
-    "surface must still be a subset of your own. Archived workflows cannot be updated; "
-    "unarchive first. In-flight runs are unaffected (a run pins its workflow's script + "
-    "surface at launch).\n\n"
-    f"{WORKFLOW_SCRIPT_CONTRACT}"
+    "with get_workflow and retry). Omitted fields are preserved; the resulting surface "
+    "must still be a subset of your own. Archived workflows must be unarchived first. "
+    "In-flight runs are unaffected (a run pins script + surface at launch)."
+)
+GET_WORKFLOW_SCRIPT_CONTRACT_DESCRIPTION = (
+    "Read the full workflow script-authoring contract: the `async def main(input)` entry "
+    "point, the injected capability API (agent/tool/call_llm/gate/parallel/log/…), shell "
+    "execution, crash and idempotency semantics, and the script sandbox's limits. Call "
+    "this before writing or editing a workflow script."
 )
 ARCHIVE_WORKFLOW_DESCRIPTION = (
     "Archive one of your workflows. Archived workflows disappear from list_workflows and "
@@ -380,18 +452,25 @@ RESUME_GATE_DESCRIPTION = (
 )
 
 
+def script_contract_tool_spec() -> dict[str, Any]:
+    """The chat-completions entry for the contract reader, for harness injection."""
+    from aios.tools.registry import openai_tool_entry
+
+    return openai_tool_entry(registry.get(SCRIPT_CONTRACT_TOOL_NAME))
+
+
 def _register() -> None:
     registry.register(
         name="create_workflow",
         description=CREATE_WORKFLOW_DESCRIPTION,
-        parameters_schema=WorkflowCreate.model_json_schema(),
+        parameters_schema=slim_workflow_schema(WorkflowCreate.model_json_schema()),
         handler=create_workflow_handler,
         transport="agent_tool",
     )
     registry.register(
         name="update_workflow",
         description=UPDATE_WORKFLOW_DESCRIPTION,
-        parameters_schema=_UpdateWorkflowArgs.model_json_schema(),
+        parameters_schema=slim_workflow_schema(_UpdateWorkflowArgs.model_json_schema()),
         handler=update_workflow_handler,
         transport="agent_tool",
     )
@@ -414,6 +493,17 @@ def _register() -> None:
         description=GET_WORKFLOW_DESCRIPTION,
         parameters_schema=_GetWorkflowArgs.model_json_schema(),
         handler=get_workflow_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name=SCRIPT_CONTRACT_TOOL_NAME,
+        description=GET_WORKFLOW_SCRIPT_CONTRACT_DESCRIPTION,
+        # Slimmed for the same reason as its siblings: the raw render carries a
+        # `title` naming the private arg class, which the model has no use for.
+        parameters_schema=slim_tool_schema(
+            _NoArgs.model_json_schema(), opaque_arrays={}, redescribe={}
+        ),
+        handler=get_workflow_script_contract_handler,
         transport="agent_tool",
     )
     registry.register(

--- a/tests/unit/test_schema_diet.py
+++ b/tests/unit/test_schema_diet.py
@@ -1,0 +1,120 @@
+"""The generic model-facing schema transform (:mod:`aios.tools.schema_diet`, #2294).
+
+``test_workflow_tool_schema_budget`` pins the *outcome* on the real workflow
+tools; these pin the *mechanism*, including the two properties that make the
+transform safe to point at any fat tool schema: it only ever loosens the
+dispatch-time check, and it never touches ``additionalProperties: false``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from aios.tools.schema_diet import slim_tool_schema
+
+
+class _Nested(BaseModel):
+    """A developer-facing docstring that the model should never see."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transport: str = "stdio"
+    permission: str | None = None
+
+
+class _Body(BaseModel):
+    """Another developer-facing docstring."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    script: str = Field(description="A very long authoring manual." * 20)
+    servers: list[_Nested] = Field(default_factory=list)
+    keep_me: str | None = Field(default=None, description="Real model guidance.")
+
+
+def _slim(**kwargs: Any) -> dict[str, Any]:
+    defaults: dict[str, Any] = {
+        "opaque_arrays": {"servers": "Opaque."},
+        "redescribe": {"script": "Short."},
+    }
+    return slim_tool_schema(_Body.model_json_schema(), **{**defaults, **kwargs})
+
+
+def test_opaque_field_collapses_to_a_bare_array() -> None:
+    slim = _slim()
+    assert slim["properties"]["servers"] == {"type": "array", "description": "Opaque."}
+
+
+def test_collapsing_the_opaque_field_prunes_its_defs() -> None:
+    assert "$defs" in _Body.model_json_schema()
+    assert "$defs" not in _slim()
+
+
+def test_nullable_opaque_field_keeps_its_null_arm() -> None:
+    class _Nullable(BaseModel):
+        servers: list[_Nested] | None = None
+
+    slim = slim_tool_schema(
+        _Nullable.model_json_schema(), opaque_arrays={"servers": "Opaque."}, redescribe={}
+    )
+    assert slim["properties"]["servers"]["anyOf"] == [{"type": "array"}, {"type": "null"}]
+
+
+def test_redescribe_replaces_only_the_description() -> None:
+    slim = _slim()
+    assert slim["properties"]["script"] == {"type": "string", "description": "Short."}
+
+
+def test_field_descriptions_are_preserved() -> None:
+    assert _slim()["properties"]["keep_me"]["description"] == "Real model guidance."
+
+
+def test_model_docstrings_and_titles_are_dropped() -> None:
+    slim = slim_tool_schema(
+        _Body.model_json_schema(), opaque_arrays={}, redescribe={"script": "Short."}
+    )
+    assert "description" not in slim
+    assert "title" not in slim
+    assert "description" not in slim["$defs"]["_Nested"]
+    assert "title" not in slim["properties"]["script"]
+
+
+def test_null_defaults_dropped_but_real_defaults_kept() -> None:
+    slim = slim_tool_schema(
+        _Body.model_json_schema(), opaque_arrays={}, redescribe={"script": "Short."}
+    )
+    assert "default" not in slim["properties"]["keep_me"]
+    assert slim["$defs"]["_Nested"]["properties"]["transport"]["default"] == "stdio"
+
+
+def test_additional_properties_false_is_never_stripped() -> None:
+    """The invariant that keeps trusted ids out of a tool schema."""
+    slim = _slim()
+    assert slim["additionalProperties"] is False
+
+
+def test_transform_does_not_mutate_its_input() -> None:
+    original = _Body.model_json_schema()
+    before = dict(original)
+    slim_tool_schema(original, opaque_arrays={"servers": "Opaque."}, redescribe={})
+    assert original == before
+    assert "$defs" in original
+
+
+def test_nested_properties_are_reached_through_a_ref() -> None:
+    """A body reachable only via ``$ref`` gets the same treatment (call_workflow)."""
+
+    class _Outer(BaseModel):
+        body: _Body | None = None
+
+    slim = slim_tool_schema(
+        _Outer.model_json_schema(),
+        opaque_arrays={"servers": "Opaque."},
+        redescribe={"script": "Short."},
+    )
+    nested = slim["$defs"]["_Body"]["properties"]
+    assert nested["servers"] == {"type": "array", "description": "Opaque."}
+    assert nested["script"]["description"] == "Short."
+    assert "_Nested" not in slim["$defs"]

--- a/tests/unit/test_schema_diet.py
+++ b/tests/unit/test_schema_diet.py
@@ -103,6 +103,36 @@ def test_transform_does_not_mutate_its_input() -> None:
     assert "$defs" in original
 
 
+def test_a_field_named_like_a_schema_keyword_survives() -> None:
+    """Inside ``properties`` the keys are FIELD names, not schema keywords.
+
+    A blind dict walk strips ``title`` wherever it appears, which would delete a
+    property literally named ``title`` while ``required`` still demands it — an
+    unsatisfiable schema that rejects every call.
+    """
+
+    class _Keywordy(BaseModel):
+        title: str
+        default: str | None = None
+        additionalProperties: bool = True
+
+    slim = slim_tool_schema(_Keywordy.model_json_schema(), opaque_arrays={}, redescribe={})
+    assert set(slim["properties"]) == {"title", "default", "additionalProperties"}
+    assert set(slim["required"]) <= set(slim["properties"])
+
+
+def test_a_non_array_property_is_never_collapsed() -> None:
+    """Name-only matching would be the one way this module could TIGHTEN."""
+
+    class _Odd(BaseModel):
+        tools: str = "not-a-list"
+
+    slim = slim_tool_schema(
+        _Odd.model_json_schema(), opaque_arrays={"tools": "Opaque."}, redescribe={}
+    )
+    assert slim["properties"]["tools"]["type"] == "string"
+
+
 def test_nested_properties_are_reached_through_a_ref() -> None:
     """A body reachable only via ``$ref`` gets the same treatment (call_workflow)."""
 

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -16,6 +16,7 @@ attenuation/depth behavior is covered by the integration tests.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock
@@ -110,11 +111,23 @@ class TestWorkflowScriptContractDiscovery:
         description = WorkflowUpdate.model_json_schema()["properties"]["script"].get("description")
         _assert_script_contract_present(description)
 
-    def test_registered_create_workflow_description_contains_contract(self) -> None:
-        _assert_script_contract_present(registry.get("create_workflow").description)
+    # The registered (model-facing) tools deliberately do NOT inline the contract
+    # any more (#2294) — it rode along in every request at ~4KB per tool. They
+    # point at ``get_workflow_script_contract``, which serves it on demand; the
+    # HTTP/SDK schemas above are unchanged. See test_workflow_tool_schema_budget.
 
-    def test_registered_update_workflow_description_contains_contract(self) -> None:
-        _assert_script_contract_present(registry.get("update_workflow").description)
+    @pytest.mark.parametrize("name", ["create_workflow", "update_workflow"])
+    def test_registered_tool_defers_the_contract(self, name: str) -> None:
+        tool = registry.get(name)
+        script_field = tool.parameters_schema["properties"]["script"]
+        assert "get_workflow_script_contract" in script_field["description"]
+        assert "Injected capability API" not in tool.description
+        assert "Injected capability API" not in json.dumps(tool.parameters_schema)
+
+    async def test_contract_tool_serves_the_contract(self) -> None:
+        result = await invoke_builtin("ses_1", "get_workflow_script_contract", {})
+        assert isinstance(result, dict)
+        _assert_script_contract_present(result["contract"])
 
 
 class TestSchemaRejectsInjectedTrustedIds:

--- a/tests/unit/test_workflow_tool_schema_budget.py
+++ b/tests/unit/test_workflow_tool_schema_budget.py
@@ -1,0 +1,174 @@
+"""The model-facing schema budget for the workflow-authoring trio (#2294).
+
+``create_workflow`` / ``update_workflow`` / ``call_workflow`` used to render at
+~69KB combined — the fattest schemas on the tool surface — and that payload rode
+along in EVERY request of every agent holding them, workflow turn or not. The
+diet (:mod:`aios.tools.schema_diet`) cut it to ~6KB by moving the authoring
+manual to an on-demand tool and collapsing the declared-surface config trees.
+
+These tests pin all three halves of that trade, because each can silently rot:
+
+* the **budget** — a future field description, or a re-inlined ``$ref``, quietly
+  reinflates the always-on cost; the byte assertion is the only thing that
+  notices;
+* the **reachability** — the trimmed ``script`` description promises a tool that
+  serves the contract, so that tool must exist, be offered alongside the
+  authoring tools, and return the real contract; and
+* the **validation** — the diet loosens what the dispatch-time jsonschema check
+  enforces, so the pydantic models behind the handlers must still reject a
+  malformed body with a field-precise error, and the HTTP/SDK schema must be
+  entirely untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import aios.tools  # noqa: F401 - trigger built-in registration side effects
+from aios.harness.step_context import _inject_workflow_script_contract
+from aios.models.workflows import WORKFLOW_SCRIPT_CONTRACT, WorkflowCreate
+from aios.tools.input import tool_input
+from aios.tools.invoke import ToolBail, prepare_builtin
+from aios.tools.registry import openai_tool_entry, registry
+from aios.tools.workflow_management import (
+    SCRIPT_CONTRACT_TOOL_NAME,
+    WORKFLOW_AUTHORING_TOOL_NAMES,
+    get_workflow_script_contract_handler,
+)
+
+#: Per-tool ceiling on the rendered chat-completions entry (description +
+#: schema), from #2294's acceptance criteria. Deliberately tight: crossing it is
+#: a decision to re-spend always-on context, and should be made consciously —
+#: trim the prose, or move it behind ``get_workflow_script_contract``.
+MAX_RENDERED_BYTES = 2_500
+
+#: The trio's combined ceiling, benchmarked against Claude Code's own
+#: ``Workflow`` tool (5,473 bytes for the same conceptual surface).
+MAX_TRIO_BYTES = 6_500
+
+
+def _rendered_size(name: str) -> int:
+    return len(json.dumps(openai_tool_entry(registry.get(name)), separators=(",", ":")))
+
+
+@pytest.mark.parametrize("name", sorted(WORKFLOW_AUTHORING_TOOL_NAMES))
+def test_authoring_tool_schema_within_budget(name: str) -> None:
+    size = _rendered_size(name)
+    assert size <= MAX_RENDERED_BYTES, (
+        f"{name} renders at {size} bytes (budget {MAX_RENDERED_BYTES}). This ships in "
+        "every request of every agent holding the tool. Trim the prose, or move it "
+        f"behind {SCRIPT_CONTRACT_TOOL_NAME} (#2294)."
+    )
+
+
+def test_authoring_trio_within_combined_budget() -> None:
+    total = sum(_rendered_size(name) for name in WORKFLOW_AUTHORING_TOOL_NAMES)
+    assert total <= MAX_TRIO_BYTES, f"trio renders at {total} bytes (budget {MAX_TRIO_BYTES})"
+
+
+@pytest.mark.parametrize("name", sorted(WORKFLOW_AUTHORING_TOOL_NAMES))
+def test_authoring_manual_is_not_inlined(name: str) -> None:
+    """The contract's own prose must not reappear in any always-on schema."""
+    rendered = json.dumps(openai_tool_entry(registry.get(name)))
+    # A distinctive line from the contract body — present iff it got re-inlined.
+    assert "Injected capability API" not in rendered
+    assert len(WORKFLOW_SCRIPT_CONTRACT) > len(rendered)
+
+
+@pytest.mark.parametrize("name", sorted(WORKFLOW_AUTHORING_TOOL_NAMES))
+def test_declared_surface_fields_are_schema_opaque(name: str) -> None:
+    """No ToolSpec / McpServerSpec / HttpServerSpec tree survives in the schema."""
+    schema = registry.get(name).parameters_schema
+    rendered = json.dumps(schema)
+    for model_name in ("ToolSpec", "McpServerSpec", "HttpServerSpec", "McpToolsetConfig"):
+        assert model_name not in rendered, f"{name} still expands {model_name}"
+
+
+@pytest.mark.parametrize("name", sorted(WORKFLOW_AUTHORING_TOOL_NAMES))
+def test_trusted_id_injection_still_refused(name: str) -> None:
+    """``additionalProperties: false`` is load-bearing and survives the diet."""
+    schema = registry.get(name).parameters_schema
+    assert schema["additionalProperties"] is False
+    with pytest.raises(ToolBail):
+        prepare_builtin(name, {"creator_session_id": "sess_evil"})
+
+
+# ── the on-demand half ─────────────────────────────────────────────────────
+
+
+def test_script_field_points_at_a_real_tool() -> None:
+    """The trimmed ``script`` description names a tool that actually exists."""
+    schema = registry.get("create_workflow").parameters_schema
+    description = schema["properties"]["script"]["description"]
+    assert SCRIPT_CONTRACT_TOOL_NAME in description
+    assert registry.has(SCRIPT_CONTRACT_TOOL_NAME)
+    assert registry.get(SCRIPT_CONTRACT_TOOL_NAME).transport == "agent_tool"
+
+
+async def test_contract_tool_returns_the_whole_contract() -> None:
+    result = await get_workflow_script_contract_handler("sess_x", {})
+    assert result == {"contract": WORKFLOW_SCRIPT_CONTRACT}
+
+
+def _offered(*names: str) -> list[dict[str, Any]]:
+    return [{"type": "function", "function": {"name": name}} for name in names]
+
+
+def _names(tools: list[dict[str, Any]]) -> list[str]:
+    return [entry["function"]["name"] for entry in tools]
+
+
+def test_contract_tool_is_injected_alongside_the_authoring_tools() -> None:
+    tools = _offered("create_workflow")
+    _inject_workflow_script_contract(tools)
+    assert _names(tools) == ["create_workflow", SCRIPT_CONTRACT_TOOL_NAME]
+
+
+def test_contract_tool_injection_is_idempotent() -> None:
+    """An agent that also declares the tool gets exactly one entry."""
+    tools = _offered("create_workflow", SCRIPT_CONTRACT_TOOL_NAME)
+    _inject_workflow_script_contract(tools)
+    assert _names(tools).count(SCRIPT_CONTRACT_TOOL_NAME) == 1
+
+
+def test_contract_tool_not_injected_without_an_authoring_tool() -> None:
+    tools = _offered("list_workflows")
+    _inject_workflow_script_contract(tools)
+    assert _names(tools) == ["list_workflows"]
+
+
+# ── validation and the HTTP/SDK contract are untouched ─────────────────────
+
+
+def test_malformed_declared_surface_still_gets_a_field_precise_error() -> None:
+    """The schema is opaque; pydantic is not. A bad entry names its own field."""
+    with pytest.raises(ToolBail) as excinfo:
+        tool_input(
+            WorkflowCreate,
+            {"name": "wf", "script": "async def main(input): ...", "tools": [{"type": "nope"}]},
+        )
+    message = str(excinfo.value)
+    assert "tools" in message
+    assert "nope" in message
+
+
+def test_valid_declared_surface_still_admitted_through_dispatch() -> None:
+    """Positive control: the diet loosens, so a well-formed surface still passes."""
+    arguments = {
+        "name": "wf",
+        "script": "async def main(input): ...",
+        "tools": [{"type": "bash"}],
+    }
+    assert prepare_builtin("create_workflow", arguments) == arguments
+    assert tool_input(WorkflowCreate, arguments).tools[0].type == "bash"
+
+
+def test_http_sdk_schema_keeps_the_full_models() -> None:
+    """#2294 is a model-facing change only — openapi.json must not move."""
+    schema = WorkflowCreate.model_json_schema()
+    assert "ToolSpec" in schema["$defs"]
+    assert "McpServerSpec" in schema["$defs"]
+    assert schema["properties"]["script"]["description"] == WORKFLOW_SCRIPT_CONTRACT


### PR DESCRIPTION
## Summary

The three workflow-authoring tool schemas were the fattest on the tool surface — `update_workflow` 23.6KB, `create_workflow` 23.1KB, `call_workflow` 21.1KB, **67.8KB combined** — and shipped in *every* request of every agent holding them, workflow turn or not. This applies the progressive-disclosure fix from #2294: the script-authoring manual moves behind a new on-demand `get_workflow_script_contract` builtin, and the declared tool/MCP/HTTP surface renders as opaque arrays instead of expanding the whole `ToolSpec`/`McpServerSpec`/`HttpServerSpec` trees into `$defs`.

**67,788 → 5,786 bytes (−91.5%).** Even counting the new reader tool that every one of those agents now also carries, the offered surface is 6,253 bytes — a **61.5KB saving per request, per agent**.

| tool | before | after | |
|---|---:|---:|---|
| `create_workflow` | 23,125 | **1,526** | −93% |
| `update_workflow` | 23,565 | **1,778** | −92% |
| `call_workflow` | 21,098 | **2,482** | −88% |
| **trio** | **67,788** | **5,786** | **−91.5%** |
| *(+ new `get_workflow_script_contract`)* | — | *467* | |

Bytes are the rendered chat-completions entry (`description` + `parameters`), `json.dumps` compact — the same thing #2289 measured. For scale: Claude Code's own `Workflow` tool, same conceptual surface, measures 5,473 bytes for *one* tool.

## Where the authoring contract lives

`WORKFLOW_SCRIPT_CONTRACT` is now served by a **new zero-arg builtin, `get_workflow_script_contract`** — a pure constant read, no pool, no account, no session state.

I chose a tool over a `docs/` page or a skill because those aren't *genuinely* reachable: a docs page in the repo is invisible to a deployed agent, and a skill has to be provisioned per account and attached per agent, so today's fleet would be pointed at a manual it cannot open. To close that gap for **already-provisioned** agents, the harness **auto-injects** the reader whenever an authoring tool is offered (`step_context._inject_workflow_script_contract`) — exactly the `switch_channel` precedent, and it lands in `step_ctx.tools`, so the #1683/#1773 offered-set default-deny admits the call by construction. No re-provisioning, no agent edits, no migration. It's also in `BuiltinToolType`, so it can be granted explicitly; injection is idempotent, so that's a no-op.

The trimmed `script` field description names it, and points at `get_workflow` on an existing workflow for a worked example.

## How the diet is applied

`src/aios/tools/schema_diet.py` — a post-render transform on the JSON Schema, applied **only** where the registry renders a tool for the model. Deliberately *not* a second set of parallel pydantic models:

- the **HTTP/SDK contract is untouched** — `openapi.json` and the SDK still render the full `WorkflowCreate` / `WorkflowUpdate` / `InlineScriptBody`, script contract and `$defs` included;
- **validation is untouched** — handlers still parse the real models, so a malformed body still gets a field-precise error; and
- there is **no parallel model to drift** out of sync.

It collapses named list-of-model fields to bare arrays (pruning the `$defs` they referenced, transitively), replaces named field descriptions, and drops four kinds of pydantic boilerplate the model never benefits from: every `title`, every `"default": null` (a restatement of "absent from `required`"), every `"additionalProperties": true` (the JSON Schema default), and every **model-level** `description` — which pydantic sources from the class docstring. That last one was leaking developer prose into the model's context, including `_UpdateWorkflowArgs`'s note naming the trusted `actor_session_id` kwarg the model must never see. Field-level descriptions are untouched; `additionalProperties: false` is never touched.

The transform only ever **loosens** the dispatch-time jsonschema check (`invoke.validate_arguments`), never tightens it — so no previously-valid call can start failing. What it stops catching there, `tool_input`'s pydantic parse catches immediately after, with a *better* error. `tools/input.py`'s docstring records this as the one sanctioned divergence from "one schema, seen and enforced".

## The tradeoff, stated plainly

**Less in-schema guidance means a higher first-attempt error rate for workflow authoring.** A model that writes a script without reading the contract will get the capability API wrong more often than one that had the manual inlined. Two things mitigate it, and neither is free:

1. the tool descriptions and the `script` field both say to read the contract first, and the reader is always offered alongside them; and
2. a malformed `tools`/`mcp_servers`/`http_servers` entry now produces a **field-precise pydantic 422** rather than a jsonschema shape error — which is the better teacher, and the reason the issue insisted validation stay put.

The bet is the same one the spill/RLM design makes: pay a bounded retry cost on the rare authoring turn instead of 67.8KB on every turn of every agent. On the 121-tool jarbot bots this trio alone was ~24% of the 286KB schema payload behind the 2026-08-28 windowing incident (#2289).

## Deviations from the issue

- **`call_workflow` needed prose trimming to hit budget, not just de-inlining.** Removing the manual and the config trees got it to ~3.6KB; the rest was its own per-field prose restating the "exactly one source arm" rule three times (tool description + both arms). I de-duplicated that to one statement and tightened the rest. I deliberately **kept the safety-bearing content verbatim in substance** — `shared` hands the run LIVE WRITE ACCESS to this session's workspace; the vault-subset semantics. Those are guidance, not manual, and shaving them to hit a round number would be a safety regression dressed as a diet.
- **`openapi.json` and the SDK do change by exactly one line each** — an additive enum value for the new grantable builtin (`ToolSpecTypeType0.GET_WORKFLOW_SCRIPT_CONTRACT`). The workflow request bodies are byte-identical. Both regenerated via `scripts/regen-client.sh` and committed, as the snapshot tests require. This is the intended "new tool is grantable", not a change to the workflow contract the issue asked me to protect.
- **Two existing assertions in `test_workflow_management.py` were inverted on purpose.** `test_registered_{create,update}_workflow_description_contains_contract` asserted the very inlining this issue removes. They now assert the tools *defer* the contract, and a new test proves the reader serves it in full. The two tests asserting the contract is in `WorkflowCreate`/`WorkflowUpdate`'s **HTTP** schema are untouched and still pass — that's criterion 4 holding.

## Substrate state changes

None — code-only change.

## Test plan

- **New `tests/unit/test_workflow_tool_schema_budget.py`** (the regression guard #2294 asked for): per-tool budget ≤2,500 bytes and trio ≤6,500 against the registry's *rendered* specs; the manual is not re-inlined; no `ToolSpec`/`McpServerSpec`/`HttpServerSpec` survives in the schema; `additionalProperties: false` still refuses an injected `creator_session_id` through the real `prepare_builtin` dispatch path; the reader exists, is `agent_tool`, and returns the whole contract; injection fires / is idempotent / doesn't fire without an authoring tool; a malformed `tools` entry still names its own field in the error; a **valid** surface still passes dispatch (positive control); and the HTTP schema still carries the full models.
- **New `tests/unit/test_schema_diet.py`** — the transform's mechanism, including no-input-mutation, transitive `$defs` pruning, nullable arms, nested-through-`$ref` reach, that `additionalProperties: false` is never stripped, that a field *named* like a schema keyword survives, and that a non-array property is never collapsed.
- `uv run mypy src tests` — clean (1045 files).
- `uv run ruff check src tests && uv run ruff format --check src tests` — clean.
- `uv run pytest tests/unit -q -n 4` — **5,590 passed**.
- `uv run pytest tests/integration -q` (Docker) — **1,126 passed**. One deselected: `test_invoke_session.py::test_call_agent_shares_live_workspace_only_when_explicitly_asked`, verified failing identically on a pristine `origin/master` worktree (macOS `/private/var` symlink, unrelated).
- `uv run pytest tests/e2e -q` (Docker) — **849 passed, 28 skipped**, 1 failure (`test_read_path_complexity.py::test_retained_window_read_scales_sublinearly`) likewise verified failing on pristine `origin/master`. `test_workflows_api.py` and `test_workflow_workspace_contract.py` both pass.

### Second commit: adversarial-review fix

An adversarial review pass found one latent bug and one latent tightening vector in the new module; both are fixed in `cbc2bbf` with tests, and rendered sizes are unchanged.

- `_strip_boilerplate` walked *every* dict and popped `title`. But inside a `properties` mapping the keys are **field names**, not schema keywords — a model with a field literally named `title` would have that property deleted while `required` still demanded it, i.e. an unsatisfiable schema. Not live (no workflow body has such a field), but the module advertises itself as generic, and `_iter_properties` already got the distinction right while `_strip_boilerplate` didn't. Both now share one structural `_walk_schemas` that descends only through JSON Schema keywords.
- `_opaque_array` collapsed by field **name** regardless of the property's actual type — the module's only way to *tighten* rather than loosen. It now fires only when every non-null arm is genuinely an array.

The review confirmed the load-bearing properties empirically: `required` is byte-identical raw vs. slim on all three tools, every property is identical-minus-boilerplate or strictly relaxed, `additionalProperties: false` survives on all three roots and the nested `InlineScriptBody`, the injected reader is admitted by the offered-set guard rather than bypassing it, and there's no import cycle.

## Risk / rollback

Low and self-contained: no schema, no migration, no substrate. The blast radius is what the model is *shown* — the enforcing pydantic models, the HTTP plane, and every handler are unchanged. If first-attempt authoring quality regresses in practice, the fix is to move prose back into the field descriptions (and the budget test will tell you what it costs); a full rollback is a plain revert.

Closes #2294.

