### PR TITLE
eumemic-bot PR reviews via aios dev-review

### DIFF
--- a/.github/workflows/eumemic-bot-review.yml
+++ b/.github/workflows/eumemic-bot-review.yml
@@ -19,7 +19,7 @@ env:
   AIOS_URL: https://api.aios.eumemic.ai
 
 jobs:
-  aios-review:
+  review:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/eumemic-bot-review.yml
+++ b/.github/workflows/eumemic-bot-review.yml
@@ -1,10 +1,6 @@
-# eumemic-bot PR reviews — kick the live aios ``dev-review`` agent as the
-# GitHub App (not as the eumemic user). The workflow mints a 1-hour
-# installation token from the App private key, then scripts/eumemic_bot_review.py
-# starts a one-shot aios session that posts ``### Code review``.
-#
-# Secrets (repo): AIOS_API_KEY, EUMEMIC_BOT_PRIVATE_KEY
-# Variable (repo): EUMEMIC_BOT_APP_ID
+# eumemic-bot PR reviews — kick the live aios reviewer as the GitHub App.
+# This job must not gate merge: aios agent/account misses are an ops
+# problem, not a PR defect.
 name: eumemic-bot review
 
 on:
@@ -26,6 +22,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -36,9 +33,10 @@ jobs:
           app-id: ${{ vars.EUMEMIC_BOT_APP_ID }}
           private-key: ${{ secrets.EUMEMIC_BOT_PRIVATE_KEY }}
 
-      - name: Start aios dev-review session
+      - name: Start aios review session
         env:
           AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
+          AGENT_ID: ${{ secrets.DEV_REVIEW_AGENT_ID }}
           GH_TOKEN: ${{ steps.app.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/eumemic-bot-review.yml
+++ b/.github/workflows/eumemic-bot-review.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           app-id: ${{ vars.EUMEMIC_BOT_APP_ID }}
           private-key: ${{ secrets.EUMEMIC_BOT_PRIVATE_KEY }}
+          # Session outlives this job and POSTs ### Code review with GH_TOKEN.
+          # Default post-step revoke made sess_01M156PTBDBE7PQGXEEYVR4RRG 401.
+          skip-token-revoke: true
 
       - name: Start aios review session
         if: steps.app.outcome == 'success'

--- a/.github/workflows/eumemic-bot-review.yml
+++ b/.github/workflows/eumemic-bot-review.yml
@@ -1,0 +1,47 @@
+# eumemic-bot PR reviews — kick the live aios ``dev-review`` agent as the
+# GitHub App (not as the eumemic user). The workflow mints a 1-hour
+# installation token from the App private key, then scripts/eumemic_bot_review.py
+# starts a one-shot aios session that posts ``### Code review``.
+#
+# Secrets (repo): AIOS_API_KEY, EUMEMIC_BOT_PRIVATE_KEY
+# Variable (repo): EUMEMIC_BOT_APP_ID
+name: eumemic-bot review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: eumemic-bot-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  AIOS_URL: https://api.aios.eumemic.ai
+
+jobs:
+  review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Mint eumemic-bot installation token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.EUMEMIC_BOT_APP_ID }}
+          private-key: ${{ secrets.EUMEMIC_BOT_PRIVATE_KEY }}
+
+      - name: Start aios dev-review session
+        env:
+          AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+        run: python3 scripts/eumemic_bot_review.py

--- a/.github/workflows/eumemic-bot-review.yml
+++ b/.github/workflows/eumemic-bot-review.yml
@@ -1,6 +1,7 @@
 # eumemic-bot PR reviews — kick the live aios reviewer as the GitHub App.
-# This job must not gate merge: aios agent/account misses are an ops
-# problem, not a PR defect.
+# Must never fail the PR check: aios account/agent misses are ops, not a
+# code defect. The job is named "aios-review" so it does not collide with
+# other "review" required checks.
 name: eumemic-bot review
 
 on:
@@ -18,22 +19,24 @@ env:
   AIOS_URL: https://api.aios.eumemic.ai
 
 jobs:
-  review:
+  aios-review:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
       - name: Mint eumemic-bot installation token
         id: app
+        continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.EUMEMIC_BOT_APP_ID }}
           private-key: ${{ secrets.EUMEMIC_BOT_PRIVATE_KEY }}
 
       - name: Start aios review session
+        if: steps.app.outcome == 'success'
+        continue-on-error: true
         env:
           AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
           AGENT_ID: ${{ secrets.DEV_REVIEW_AGENT_ID }}

--- a/docs/eumemic-bot-review.md
+++ b/docs/eumemic-bot-review.md
@@ -1,0 +1,17 @@
+# eumemic-bot PR reviews
+
+On each non-draft pull request, [`.github/workflows/eumemic-bot-review.yml`](../.github/workflows/eumemic-bot-review.yml) mints a short-lived GitHub App installation token for **eumemic-bot** and starts a one-shot aios session on the live `dev-review` agent. The agent posts a comment that begins with `### Code review`.
+
+The App private key never enters git. aios remints nothing here — GitHub Actions mints the hour-long token at the start of the job.
+
+## Required repo config
+
+| Kind | Name | Notes |
+|---|---|---|
+| Variable | `EUMEMIC_BOT_APP_ID` | `4752589` |
+| Secret | `EUMEMIC_BOT_PRIVATE_KEY` | PEM for the App |
+| Secret | `AIOS_API_KEY` | already used by reconcile-agents |
+
+## Identity
+
+Reviews post as `eumemic-bot[bot]`, not as `eumemic`. The clone resource uses `4752589+eumemic-bot[bot]@users.noreply.github.com`.

--- a/scripts/eumemic_bot_review.py
+++ b/scripts/eumemic_bot_review.py
@@ -30,6 +30,11 @@ def _die(msg: str, code: int = 1) -> None:
     raise SystemExit(code)
 
 
+def _skip(msg: str) -> None:
+    print(f"SKIP: {msg}", file=sys.stderr)
+    raise SystemExit(0)
+
+
 def _env(name: str) -> str:
     val = os.environ.get(name, "").strip()
     if not val:
@@ -75,9 +80,9 @@ def resolve_agent(base: str, api_key: str) -> str:
     if len(exact) == 1:
         return str(exact[0]["id"])
     visible = [f"{r.get('name')}:{r.get('id')}" for r in _list_agents(base, api_key)]
-    _die(
+    _skip(
         f"no live agent named {AGENT_NAME!r} on this API key's account "
-        f"(visible: {visible or 'none'}). Set AGENT_ID to a reviewer on this account."
+        f"(visible: {visible or 'none'}). Set DEV_REVIEW_AGENT_ID to a reviewer on this account."
     )
 
 

--- a/scripts/eumemic_bot_review.py
+++ b/scripts/eumemic_bot_review.py
@@ -9,9 +9,15 @@ Resolution order for the reviewer agent:
   2. exact name match for AGENT_NAME (default: dev-review)
   3. fail with the names visible to this API key (account-scoped)
 
+Resolution order for the sandbox environment (required by POST /v1/sessions):
+  1. ENVIRONMENT_ID if set
+  2. exact name match for ENVIRONMENT_NAME (default: dev-pipeline-real)
+  3. fail with the names visible to this API key (account-scoped)
+
 Env:
   AIOS_URL, AIOS_API_KEY, GH_TOKEN, REPO, PR_NUMBER, HEAD_SHA, CLONE_URL
   AGENT_NAME (default: dev-review), AGENT_ID (optional)
+  ENVIRONMENT_NAME (default: dev-pipeline-real), ENVIRONMENT_ID (optional)
 """
 from __future__ import annotations
 
@@ -23,6 +29,7 @@ import urllib.parse
 import urllib.request
 
 AGENT_NAME = os.environ.get("AGENT_NAME", "dev-review")
+ENVIRONMENT_NAME = os.environ.get("ENVIRONMENT_NAME", "dev-pipeline-real")
 
 
 def _die(msg: str, code: int = 1) -> None:
@@ -72,6 +79,15 @@ def _list_agents(base: str, api_key: str, name: str | None = None) -> list[dict]
     return rows
 
 
+def _list_environments(base: str, api_key: str) -> list[dict]:
+    url = f"{base}/v1/environments?{urllib.parse.urlencode({'limit': '100'})}"
+    payload = _request("GET", url, api_key)
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        _die(f"GET /v1/environments missing data: {json.dumps(payload)[:400]}")
+    return rows
+
+
 def resolve_agent(base: str, api_key: str) -> str:
     pinned = os.environ.get("AGENT_ID", "").strip()
     if pinned:
@@ -86,6 +102,20 @@ def resolve_agent(base: str, api_key: str) -> str:
     )
 
 
+def resolve_environment(base: str, api_key: str) -> str:
+    pinned = os.environ.get("ENVIRONMENT_ID", "").strip()
+    if pinned:
+        return pinned
+    exact = [r for r in _list_environments(base, api_key) if r.get("name") == ENVIRONMENT_NAME]
+    if len(exact) == 1:
+        return str(exact[0]["id"])
+    visible = [f"{r.get('name')}:{r.get('id')}" for r in _list_environments(base, api_key)]
+    _die(
+        f"no environment named {ENVIRONMENT_NAME!r} on this API key's account "
+        f"(visible: {visible or 'none'}). Set ENVIRONMENT_ID."
+    )
+
+
 def main() -> None:
     base = _env("AIOS_URL").rstrip("/")
     api_key = _env("AIOS_API_KEY")
@@ -96,6 +126,7 @@ def main() -> None:
     clone_url = _env("CLONE_URL")
 
     agent_id = resolve_agent(base, api_key)
+    environment_id = resolve_environment(base, api_key)
     prompt = (
         f"Review pull request {repo}#{pr_number} at {head_sha}. "
         f"The repository is cloned at /mnt/review. "
@@ -109,6 +140,7 @@ def main() -> None:
     )
     body = {
         "agent_id": agent_id,
+        "environment_id": environment_id,
         "title": f"eumemic-bot review {repo}#{pr_number}",
         "archive_when_idle": True,
         "initial_message": prompt,
@@ -134,7 +166,10 @@ def main() -> None:
     sid = session.get("id")
     if not sid:
         _die(f"create session returned no id: {json.dumps(session)[:400]}")
-    print(f"started session {sid} on agent {agent_id} for {repo}#{pr_number}@{head_sha}")
+    print(
+        f"started session {sid} on agent {agent_id} env {environment_id} "
+        f"for {repo}#{pr_number}@{head_sha}"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/eumemic_bot_review.py
+++ b/scripts/eumemic_bot_review.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 """Start an aios dev-review session for a GitHub pull request.
 
-Used by .github/workflows/eumemic-bot-review.yml. Mints nothing itself —
-the workflow hands in a short-lived eumemic-bot installation token as
-GH_TOKEN. This script looks up the live ``dev-review`` agent by name and
-creates a one-shot session that clones the PR head and asks the agent to
-post ``### Code review`` as the App.
+Used by .github/workflows/eumemic-bot-review.yml. The workflow hands in a
+short-lived eumemic-bot installation token as GH_TOKEN.
 
-Env (all required unless noted):
+Resolution order for the reviewer agent:
+  1. AGENT_ID if set
+  2. exact name match for AGENT_NAME (default: dev-review)
+  3. fail with the names visible to this API key (account-scoped)
+
+Env:
   AIOS_URL, AIOS_API_KEY, GH_TOKEN, REPO, PR_NUMBER, HEAD_SHA, CLONE_URL
-  AGENT_NAME (default: dev-review)
+  AGENT_NAME (default: dev-review), AGENT_ID (optional)
 """
 from __future__ import annotations
 
@@ -53,17 +55,30 @@ def _request(method: str, url: str, api_key: str, body: dict | None = None) -> d
         _die(f"{method} {url} failed: {exc}")
 
 
-def lookup_agent(base: str, api_key: str, name: str) -> str:
-    url = f"{base}/v1/agents?name={urllib.parse.quote(name)}"
+def _list_agents(base: str, api_key: str, name: str | None = None) -> list[dict]:
+    q = {"limit": "50"}
+    if name:
+        q["name"] = name
+    url = f"{base}/v1/agents?{urllib.parse.urlencode(q)}"
     payload = _request("GET", url, api_key)
     rows = payload.get("data")
     if not isinstance(rows, list):
-        _die(f"GET agents?name={name} missing data: {json.dumps(payload)[:400]}")
-    exact = [r for r in rows if r.get("name") == name]
-    if len(exact) != 1:
-        ids = [r.get("id") for r in exact]
-        _die(f"expected one live agent named {name!r}, found {len(exact)} ({ids})")
-    return str(exact[0]["id"])
+        _die(f"GET /v1/agents missing data: {json.dumps(payload)[:400]}")
+    return rows
+
+
+def resolve_agent(base: str, api_key: str) -> str:
+    pinned = os.environ.get("AGENT_ID", "").strip()
+    if pinned:
+        return pinned
+    exact = [r for r in _list_agents(base, api_key, AGENT_NAME) if r.get("name") == AGENT_NAME]
+    if len(exact) == 1:
+        return str(exact[0]["id"])
+    visible = [f"{r.get('name')}:{r.get('id')}" for r in _list_agents(base, api_key)]
+    _die(
+        f"no live agent named {AGENT_NAME!r} on this API key's account "
+        f"(visible: {visible or 'none'}). Set AGENT_ID to a reviewer on this account."
+    )
 
 
 def main() -> None:
@@ -75,7 +90,7 @@ def main() -> None:
     head_sha = _env("HEAD_SHA")
     clone_url = _env("CLONE_URL")
 
-    agent_id = lookup_agent(base, api_key, AGENT_NAME)
+    agent_id = resolve_agent(base, api_key)
     prompt = (
         f"Review pull request {repo}#{pr_number} at {head_sha}. "
         f"The repository is cloned at /mnt/review. "

--- a/scripts/eumemic_bot_review.py
+++ b/scripts/eumemic_bot_review.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Start an aios dev-review session for a GitHub pull request.
+
+Used by .github/workflows/eumemic-bot-review.yml. Mints nothing itself —
+the workflow hands in a short-lived eumemic-bot installation token as
+GH_TOKEN. This script looks up the live ``dev-review`` agent by name and
+creates a one-shot session that clones the PR head and asks the agent to
+post ``### Code review`` as the App.
+
+Env (all required unless noted):
+  AIOS_URL, AIOS_API_KEY, GH_TOKEN, REPO, PR_NUMBER, HEAD_SHA, CLONE_URL
+  AGENT_NAME (default: dev-review)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+AGENT_NAME = os.environ.get("AGENT_NAME", "dev-review")
+
+
+def _die(msg: str, code: int = 1) -> None:
+    print(f"FATAL: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _env(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        _die(f"{name} is not set")
+    return val
+
+
+def _request(method: str, url: str, api_key: str, body: dict | None = None) -> dict:
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Accept", "application/json")
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:800]
+        _die(f"{method} {url} returned {exc.code}: {detail}")
+    except urllib.error.URLError as exc:
+        _die(f"{method} {url} failed: {exc}")
+
+
+def lookup_agent(base: str, api_key: str, name: str) -> str:
+    url = f"{base}/v1/agents?name={urllib.parse.quote(name)}"
+    payload = _request("GET", url, api_key)
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        _die(f"GET agents?name={name} missing data: {json.dumps(payload)[:400]}")
+    exact = [r for r in rows if r.get("name") == name]
+    if len(exact) != 1:
+        ids = [r.get("id") for r in exact]
+        _die(f"expected one live agent named {name!r}, found {len(exact)} ({ids})")
+    return str(exact[0]["id"])
+
+
+def main() -> None:
+    base = _env("AIOS_URL").rstrip("/")
+    api_key = _env("AIOS_API_KEY")
+    token = _env("GH_TOKEN")
+    repo = _env("REPO")
+    pr_number = _env("PR_NUMBER")
+    head_sha = _env("HEAD_SHA")
+    clone_url = _env("CLONE_URL")
+
+    agent_id = lookup_agent(base, api_key, AGENT_NAME)
+    prompt = (
+        f"Review pull request {repo}#{pr_number} at {head_sha}. "
+        f"The repository is cloned at /mnt/review. "
+        f"Fetch the PR diff via the github http_request server "
+        f"(GET /repos/{repo}/pulls/{pr_number} and /repos/{repo}/pulls/{pr_number}/files). "
+        f"If http_request is unauthorized, use GH_TOKEN from the environment with gh or curl. "
+        f"Post a review-artifact comment whose body begins with the line `### Code review` "
+        f"(POST /repos/{repo}/issues/{pr_number}/comments). "
+        f"Return ONLY via return a value conforming to "
+        f"{{verdict:'pass'|'fail', issues:[...], artifact_posted:true}}."
+    )
+    body = {
+        "agent_id": agent_id,
+        "title": f"eumemic-bot review {repo}#{pr_number}",
+        "archive_when_idle": True,
+        "initial_message": prompt,
+        "env": {"GH_TOKEN": token, "GH_REPO": repo, "PR_NUMBER": pr_number},
+        "resources": [
+            {
+                "type": "github_repository",
+                "url": clone_url,
+                "mount_path": "/mnt/review",
+                "authorization_token": token,
+                "git_user_name": "eumemic-bot[bot]",
+                "git_user_email": "4752589+eumemic-bot[bot]@users.noreply.github.com",
+            }
+        ],
+        "metadata": {
+            "source": "eumemic-bot-review",
+            "repo": repo,
+            "pr_number": pr_number,
+            "head_sha": head_sha,
+        },
+    }
+    session = _request("POST", f"{base}/v1/sessions", api_key, body)
+    sid = session.get("id")
+    if not sid:
+        _die(f"create session returned no id: {json.dumps(session)[:400]}")
+    print(f"started session {sid} on agent {agent_id} for {repo}#{pr_number}@{head_sha}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- On each non-draft PR, mint an `eumemic-bot` installation token and start a one-shot aios `dev-review` session at `api.aios.eumemic.ai`.
- The agent clones the PR head and posts `### Code review` as the App, not as `eumemic`.
- App PEM is a repo secret (`EUMEMIC_BOT_PRIVATE_KEY`); App ID is repo variable `4752589`. Reuses existing `AIOS_API_KEY`.

## Test plan
- [ ] Confirm repo variable `EUMEMIC_BOT_APP_ID` and secrets `EUMEMIC_BOT_PRIVATE_KEY` + `AIOS_API_KEY` are set
- [ ] Open/push this PR (or a follow-up) and check the `eumemic-bot review` workflow starts a session
- [ ] Confirm a `### Code review` comment lands from `eumemic-bot[bot]`
- [ ] Confirm the PEM is not in the diff