### PR TITLE
fix(sandbox): bind /tmp so snapshots stop persisting scratch (#2280)

### DIFF
--- a/docs/design/durable-session-sandboxes.md
+++ b/docs/design/durable-session-sandboxes.md
@@ -74,14 +74,38 @@ rejected at `docker run` on this daemon), so any quota story must work without i
 ## 3. The persistence contract (validated, two amendments)
 
 **Persists** (via the snapshot image): the entire writable root FS — `/root`, `/etc`,
-`/usr`, `/var`, `/opt`, `/home`, **`/tmp`** (a normal overlay dir, not tmpfs), global
-apt/pip/npm installs, and deletions of base-image files (`docker commit` captures
-overlayfs whiteouts — verified).
+`/usr`, `/var`, `/opt`, `/home`, global apt/pip/npm installs, and deletions of base-image
+files (`docker commit` captures overlayfs whiteouts — verified).
 
 **Persists** (via host bind mounts, exactly as today, *not* via the snapshot):
-`/workspace`, `/mnt/attachments`, `/mnt/uploads`, `/mnt/memory/*`, github working trees.
-`docker commit` excludes bind-mount contents (verified), so there is no duplication and no
-interaction between snapshot GC and workspace data.
+`/workspace`, `/mnt/attachments`, `/mnt/uploads`, `/mnt/memory/*`, github working trees,
+and — since #2280 — **`/tmp`**. `docker commit` excludes bind-mount contents (verified),
+so there is no duplication and no interaction between snapshot GC and workspace data.
+
+> **Amendment (#2280): `/tmp` moved from the snapshot to a bind mount.**
+> It was a normal overlay dir, which made it durable state the snapshot faithfully
+> preserved. Long-lived sessions accumulate per-task scratch there — repo clones,
+> virtualenvs, pytest trees, build caches — and every byte was paid for twice on every
+> idle reap (once as the compressed content blob, once as the unpacked snapshot). One
+> production session reached 18 GiB of which 16.4 GiB was `/tmp`, which also drove the
+> export past its timeout and into the salvage breaker.
+>
+> `/tmp` is now bound to `<workspace_root>/_tmp/<session_id>`, so ephemeral scratch is
+> *structurally* unable to enter an image — the same mechanism `/workspace` already
+> relied on, rather than a filter someone must remember to apply. It still survives
+> container recycles (strictly more continuity than a cold `/tmp` gave) and is reclaimed
+> by the host-dir reaper once the session is no longer DB-live.
+>
+> **Sessions only.** A run (`wfr_`) and a browser plane (`acc_`) are torn down with a bare
+> destroy that drops the whole writable layer, so their `/tmp` is already reclaimed at
+> teardown; binding it would make that scratch outlive the container it belongs to.
+>
+> Images snapshotted *before* this landed still carry their old `/tmp` inside them, and a
+> mount cannot remove what is already baked in. `_flatten` therefore also runs the export
+> through a streaming tar filter (`sandbox/_tar_filter.py`) that drops `tmp/`, `var/tmp/`
+> and `run/`, so each affected session sheds its historical scratch on its next flatten.
+> The filter forwards anything it cannot parse verbatim: a fat snapshot is a far better
+> failure than a corrupt one.
 
 **Does not persist**: processes, fds, locks, sockets, netns/iptables state, `/dev/shm`
 (tmpfs), the container IP. Resume = fresh process tree on the persisted disk.

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -290,6 +290,15 @@ class Settings(BaseSettings):
         ge=0,
         description="Free disk retained in addition to the estimated transient flatten cost.",
     )
+    sandbox_disk_stat_path: str = Field(
+        default="/",
+        description="Filesystem the snapshot headroom gate measures free space on. Must be a "
+        "path on the DOCKER GRAPH ROOT's filesystem, which is where a commit or flatten "
+        "actually writes. Defaults to '/' because the graph root usually lives there, but "
+        "inside the worker container '/' is the worker's own overlay and need not be the same "
+        "filesystem; when they differ the gate measures a disk nothing is written to and passes "
+        "while the real target is full (#2280).",
+    )
     sandbox_snapshot_ttl_seconds: int = Field(
         default=2_592_000,  # 30 days
         ge=60,

--- a/src/aios/harness/host_dir_reaper.py
+++ b/src/aios/harness/host_dir_reaper.py
@@ -10,6 +10,8 @@ aios runtime down):
   working-tree clones of ``github_repository`` attachments.
 * ``<workspace_root>/_runs/<run_id>/`` — per-run workflow scratch
   (``/workspace`` for a run sandbox).
+* ``<workspace_root>/_tmp/<session_id>/`` — the session sandbox's ``/tmp``
+  bind (#2280).
 
 This reaper closes that missing-GC gap. It runs an immediate sweep at worker
 startup and then periodically (mirroring the snapshot GC reconciler).
@@ -35,6 +37,14 @@ The two trees are treated **asymmetrically** by *reconstructibility*:
   observed* TERMINAL run status (``completed``/``errored``/``cancelled``). A
   ``suspended`` (or ``pending``/``running``, or absent) run is KEPT. We never
   delete non-reconstructible scratch on the mere absence of confirmation.
+
+* ``_tmp`` is EPHEMERAL BY CONTRACT — it is ``/tmp``, which every process in
+  the sandbox is entitled to assume may vanish between boots. It reaps on the
+  same positive keep-set as ``_session_repos``: only session sandboxes bind
+  it (a run and a browser plane drop their ``/tmp`` with the writable layer
+  at destroy), so an id that is not a live session id is scratch nothing can
+  return to. An id that is not session-shaped at all is KEPT and counted, so
+  a future owner kind cannot silently inherit deletion.
 
 Per-tree liveness is re-derived from a fresh DB read **at sweep time**, after
 the on-disk enumeration and after the age floor — not frozen once globally —
@@ -72,8 +82,13 @@ import asyncpg
 from aios.config import get_settings
 from aios.db import queries
 from aios.db.queries import workflows as wf_queries
+from aios.ids import SESSION
 from aios.logging import get_logger
-from aios.sandbox.volumes import run_workspace_dir, session_repos_root
+from aios.sandbox.volumes import (
+    run_workspace_dir,
+    session_repos_root,
+    session_tmp_dir,
+)
 
 log = get_logger("aios.harness.host_dir_reaper")
 
@@ -252,8 +267,56 @@ async def _reap_runs(pool: asyncpg.Pool[Any], *, min_age_seconds: float, now: fl
     return removed
 
 
+async def _reap_session_tmp(pool: asyncpg.Pool[Any], *, min_age_seconds: float, now: float) -> int:
+    """Reap idle ``_tmp/<session_id>`` sandbox scratch (#2280).
+
+    ``/tmp`` is ephemeral by contract, so this reaps on the same positive
+    keep-set as ``_session_repos``: keep iff the session is DB-live, reap
+    otherwise. A wrongly-reaped ``/tmp`` costs a cold scratch directory, which
+    is the state every process there already tolerates.
+
+    Only session sandboxes bind this tree, so a non-session-shaped id is
+    unrecognised residue rather than a known owner: it is KEPT and reported
+    as ``kept_unknown_owner`` rather than reaped under a rule written for a
+    different kind of owner.
+
+    Fail-closed: a DB error reaps nothing this pass.
+    """
+    root = session_tmp_dir("_").parent
+    candidates = _scan_children(root, min_age_seconds=min_age_seconds, now=now)
+    if not candidates:
+        return 0
+    owner_ids = [c.owner_id for c in candidates if c.owner_id.startswith(f"{SESSION}_")]
+    unknown = len(candidates) - len(owner_ids)
+    if not owner_ids:
+        log.info(
+            "host_dir_reaper.tmp_swept",
+            candidates=len(candidates),
+            removed=0,
+            kept=len(candidates),
+            kept_unknown_owner=unknown,
+        )
+        return 0
+    try:
+        async with pool.acquire() as conn:
+            live = await queries.unscoped_live_session_ids(conn, owner_ids)
+    except (asyncpg.PostgresError, OSError):
+        log.exception("host_dir_reaper.tmp_liveness_failed")
+        return 0  # fail-closed: never reap on a failed liveness read
+    reap_ids = {oid for oid in owner_ids if oid not in live}
+    removed = await _reap(candidates, reap_ids)
+    log.info(
+        "host_dir_reaper.tmp_swept",
+        candidates=len(candidates),
+        removed=removed,
+        kept=len(candidates) - removed,
+        kept_unknown_owner=unknown,
+    )
+    return removed
+
+
 async def sweep_host_dirs(pool: asyncpg.Pool[Any]) -> int:
-    """One reaper sweep over ``_session_repos`` and ``_runs``.
+    """One reaper sweep over ``_session_repos``, ``_runs`` and ``_tmp``.
 
     Returns the total directories removed. Honors the kill-switch
     (``host_dir_reaper_enabled``): when disabled, deletes nothing and returns
@@ -267,4 +330,5 @@ async def sweep_host_dirs(pool: asyncpg.Pool[Any]) -> int:
     now = time.time()
     repos = await _reap_session_repos(pool, min_age_seconds=min_age, now=now)
     runs = await _reap_runs(pool, min_age_seconds=min_age, now=now)
-    return repos + runs
+    tmp = await _reap_session_tmp(pool, min_age_seconds=min_age, now=now)
+    return repos + runs + tmp

--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -15,8 +15,22 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from typing import Protocol
 
 from aios.sandbox.backends.base import SandboxBackendError, SandboxSnapshotTimeoutError
+
+
+class StreamFilter(Protocol):
+    """Transforms pipeline bytes in flight. See :mod:`aios.sandbox._tar_filter`."""
+
+    def feed(self, chunk: bytes) -> bytes:
+        """Return the bytes to forward for ``chunk`` (may be empty)."""
+        ...
+
+    def flush(self) -> bytes:
+        """Return any buffered remainder at EOF."""
+        ...
+
 
 # Bound on the post-kill drain so a CLI stuck in an uninterruptible
 # state can't hold the worker indefinitely past the wait_for timeout.
@@ -108,12 +122,21 @@ async def run_docker_pipeline(
     *,
     stall_timeout_s: float,
     max_timeout_s: float,
+    stream_filter: StreamFilter | None = None,
 ) -> tuple[int, bytes, bytes]:
     """Run a Docker producer/consumer pipeline with progress-based deadlines.
 
     The relay makes stream progress observable. A lack of bytes before EOF is
     a stall; after EOF the consumer may legitimately spend substantial time
     finalizing, so only the absolute ceiling applies then.
+
+    ``stream_filter`` optionally transforms the bytes in flight (see
+    :mod:`aios.sandbox._tar_filter`). Because the relay already copies every
+    byte through this process, filtering costs a function call per chunk and
+    no extra I/O. Progress deadlines are measured on bytes READ from the
+    producer, not bytes written to the consumer, so a filter that legitimately
+    emits nothing for a while — skipping a large dropped payload — is
+    progress and does not trip the stall bound.
     """
     producer: asyncio.subprocess.Process | None = None
     consumer: asyncio.subprocess.Process | None = None
@@ -179,6 +202,17 @@ async def run_docker_pipeline(
                     # EOF: flush and close the write side under the same
                     # deadlines, so a consumer that stops reading during the
                     # final flush can't wedge here either.
+                    if stream_filter is not None:
+                        tail = stream_filter.flush()
+                        if tail:
+                            consumer_stdin.write(tail)
+                            flush_timeout = _stall_deadline()
+                            try:
+                                await asyncio.wait_for(
+                                    consumer_stdin.drain(), timeout=flush_timeout
+                                )
+                            except TimeoutError as err:
+                                raise TimeoutError("write stalled") from err
                     consumer_stdin.close()
                     close_timeout = _stall_deadline()
                     try:
@@ -188,13 +222,18 @@ async def run_docker_pipeline(
                     except TimeoutError as err:
                         raise TimeoutError("close stalled") from err
                     return moved
-                consumer_stdin.write(chunk)
+                moved += len(chunk)
+                payload = chunk if stream_filter is None else stream_filter.feed(chunk)
+                if not payload:
+                    # The filter absorbed this chunk (mid-drop). The read above
+                    # was progress, so continue without a write/drain round.
+                    continue
+                consumer_stdin.write(payload)
                 drain_timeout = _stall_deadline()
                 try:
                     await asyncio.wait_for(consumer_stdin.drain(), timeout=drain_timeout)
                 except TimeoutError as err:
                     raise TimeoutError("write stalled") from err
-                moved += len(chunk)
 
         prod_err_task = asyncio.create_task(producer.stderr.read())  # type: ignore[union-attr]
         cons_out_task = asyncio.create_task(consumer.stdout.read())  # type: ignore[union-attr]

--- a/src/aios/sandbox/_tar_filter.py
+++ b/src/aios/sandbox/_tar_filter.py
@@ -1,0 +1,231 @@
+"""Streaming tar filter that drops ephemeral paths from a container export.
+
+``docker export`` emits the container's whole filesystem as a tar stream.
+For a durable session sandbox that stream *is* the snapshot, so anything in
+it is preserved forever — including the accumulated scratch under ``/tmp``
+that nobody ever wanted kept. One production session reached 18 GiB of which
+16.4 GiB was ``/tmp`` (eumemic/aios#2280).
+
+The structural fix is the ``/tmp`` bind mount
+(:func:`aios.sandbox.volumes.session_tmp_dir`), which Docker omits from both
+snapshot verbs. This filter exists for the images that already exist: a
+session snapshotted before the mount landed carries its old ``/tmp`` *inside*
+the image, and a mount does not remove what is already baked in. Re-exporting
+such an image would copy that payload into its successor forever. Filtering
+the export breaks the chain — each affected session sheds its historical
+scratch on its next flatten, and the mount keeps it lean thereafter.
+
+Design notes
+------------
+* **Pure and incremental.** :class:`TarPrefixFilter` is fed arbitrary byte
+  chunks (the relay reads 1 MiB at a time, unrelated to tar's 512-byte record
+  boundaries) and returns the bytes to forward. It holds at most one partial
+  record plus one pending metadata record — never the stream.
+
+* **Entries are dropped, not emptied.** A dropped entry's header and payload
+  are both suppressed, so ``docker import`` never learns the path existed.
+
+* **The mount points survive.** ``tmp/`` itself is kept while everything
+  beneath it is dropped: the directory must exist in the image for the bind
+  to have something to mount onto.
+
+* **Extended headers travel with their target.** GNU ``L``/``K`` and pax
+  ``x``/``X`` records describe the *next* entry, so the drop decision cannot
+  be made until that entry's own header arrives. They are buffered and then
+  emitted or dropped together with it.
+
+* **Hardlinks into a dropped tree are dropped**, not rewritten. Tar encodes
+  the second and later names of an inode as a link to the first; if the first
+  is gone the link dangles and ``docker import`` fails. Every prefix we drop
+  is ephemeral, so a hardlink into one is ephemeral too.
+
+* **Unparseable input is forwarded verbatim.** A stream we cannot understand
+  is passed through unchanged rather than truncated: the failure mode of this
+  filter must be "the snapshot is as fat as it used to be", never "the
+  snapshot is corrupt". Corrupting a session's filesystem to save disk would
+  be a far worse bug than the one being fixed.
+"""
+
+from __future__ import annotations
+
+from aios.logging import get_logger
+
+log = get_logger("aios.sandbox.tar_filter")
+
+_BLOCK = 512
+
+# Paths dropped from the export, relative to the container root (tar members
+# are emitted without a leading slash). Each is scratch the sandbox itself
+# treats as disposable across boots. ``root/.cache`` is deliberately NOT here:
+# it holds Playwright browsers and package caches that are expensive to
+# re-fetch, so it stays durable state.
+EPHEMERAL_PREFIXES: tuple[str, ...] = ("tmp/", "var/tmp/", "run/")
+
+# Record types describing the FOLLOWING entry rather than a file of their own:
+# GNU long name / long link name, pax extended / global headers.
+_META_TYPES = frozenset({b"L", b"K", b"x", b"X"})
+
+
+def _normalize(name: str) -> str:
+    """Strip the leading ``./`` or ``/`` docker may emit, so a member name can
+    be compared against :data:`EPHEMERAL_PREFIXES`."""
+    if name.startswith("./"):
+        name = name[2:]
+    return name.lstrip("/")
+
+
+def _is_ephemeral(name: str, prefixes: tuple[str, ...]) -> bool:
+    """True if ``name`` is *inside* one of ``prefixes``.
+
+    The prefix directories themselves are kept — see the mount-point note in
+    the module docstring.
+    """
+    norm = _normalize(name).rstrip("/")
+    for prefix in prefixes:
+        stem = prefix.rstrip("/")
+        if norm == stem:
+            return False  # the mount point itself
+        if norm.startswith(f"{stem}/"):
+            return True
+    return False
+
+
+def _header_name(header: bytes) -> str:
+    """The member name from a ustar header, honouring the ``prefix`` field."""
+    name = header[0:100].split(b"\0")[0].decode("utf-8", errors="replace")
+    prefix = header[345:500].split(b"\0")[0].decode("utf-8", errors="replace")
+    return f"{prefix}/{name}" if prefix else name
+
+
+def _parse_size(header: bytes) -> int:
+    """Payload size from a tar header: octal, or GNU base-256 for >8 GiB."""
+    raw = header[124:136]
+    if raw[0] & 0x80:  # GNU base-256 extension
+        value = 0
+        for byte in raw[1:]:
+            value = (value << 8) | byte
+        return value
+    text = raw.split(b"\0")[0].strip()
+    return int(text, 8) if text else 0
+
+
+class TarPrefixFilter:
+    """Incremental tar-stream filter dropping :data:`EPHEMERAL_PREFIXES`.
+
+    Feed chunks to :meth:`feed` and write whatever it returns; call
+    :meth:`flush` at EOF for any buffered remainder. ``dropped_bytes`` and
+    ``dropped_entries`` report what was removed.
+    """
+
+    def __init__(self, prefixes: tuple[str, ...] = EPHEMERAL_PREFIXES) -> None:
+        self._prefixes = prefixes
+        self._buf = bytearray()
+        # Bytes of the current entry's payload still to be forwarded/skipped.
+        self._payload_remaining = 0
+        self._skipping_payload = False
+        # A buffered GNU/pax metadata record awaiting its target entry, plus
+        # the long name it carries (which overrides the 100-byte name field).
+        self._pending_meta = bytearray()
+        self._pending_name: str | None = None
+        self._passthrough = False
+        self.dropped_bytes = 0
+        self.dropped_entries = 0
+
+    def feed(self, chunk: bytes) -> bytes:
+        """Consume ``chunk``; return the bytes to forward downstream."""
+        if self._passthrough:
+            return chunk
+        self._buf.extend(chunk)
+        out = bytearray()
+        try:
+            self._drain(out)
+        except Exception:
+            # Unparseable: stop filtering and forward everything verbatim from
+            # here on. A fat snapshot beats a corrupt one.
+            log.exception("tar_filter.parse_failed_passing_through")
+            self._passthrough = True
+            out += self._pending_meta
+            self._pending_meta.clear()
+            out += self._buf
+            self._buf.clear()
+        return bytes(out)
+
+    def _drain(self, out: bytearray) -> None:
+        """Consume as many whole records as the buffer currently holds."""
+        while True:
+            if self._payload_remaining:
+                take = min(self._payload_remaining, len(self._buf))
+                if not take:
+                    return
+                if self._skipping_payload:
+                    self.dropped_bytes += take
+                else:
+                    out += self._buf[:take]
+                del self._buf[:take]
+                self._payload_remaining -= take
+                continue
+
+            if len(self._buf) < _BLOCK:
+                return
+            header = bytes(self._buf[:_BLOCK])
+
+            if header == b"\0" * _BLOCK:
+                # End-of-archive marker: emit it and everything after verbatim.
+                out += self._pending_meta
+                self._pending_meta.clear()
+                out += self._buf
+                self._buf.clear()
+                self._passthrough = True
+                return
+
+            size = _parse_size(header)
+            padded = (size + _BLOCK - 1) // _BLOCK * _BLOCK
+            typeflag = header[156:157]
+
+            if typeflag in _META_TYPES:
+                # Metadata for the NEXT entry: buffer the whole record and
+                # decide when that entry's own header arrives.
+                need = _BLOCK + padded
+                if len(self._buf) < need:
+                    return  # wait for the rest of the record
+                if typeflag == b"L":
+                    raw_name = bytes(self._buf[_BLOCK : _BLOCK + size])
+                    self._pending_name = raw_name.rstrip(b"\0").decode("utf-8", errors="replace")
+                self._pending_meta += self._buf[:need]
+                del self._buf[:need]
+                continue
+
+            name = self._pending_name if self._pending_name is not None else _header_name(header)
+            drop = _is_ephemeral(name, self._prefixes) or self._links_into_dropped(header, typeflag)
+            if drop:
+                self.dropped_entries += 1
+                self.dropped_bytes += len(self._pending_meta) + _BLOCK
+                self._skipping_payload = True
+            else:
+                out += self._pending_meta
+                out += header
+                self._skipping_payload = False
+            self._pending_meta.clear()
+            self._pending_name = None
+            del self._buf[:_BLOCK]
+            self._payload_remaining = padded
+
+    def _links_into_dropped(self, header: bytes, typeflag: bytes) -> bool:
+        """True for a hardlink whose target lives in a dropped tree — the
+        target will not be in the output, so the link would dangle."""
+        if typeflag != b"1":
+            return False
+        target = header[157:257].split(b"\0")[0].decode("utf-8", errors="replace")
+        return _is_ephemeral(target, self._prefixes)
+
+    def flush(self) -> bytes:
+        """Return any buffered bytes at EOF.
+
+        A truncated trailing record is forwarded as-is: the filter never
+        invents padding, so a stream that arrived malformed stays exactly as
+        malformed rather than becoming differently malformed.
+        """
+        out = bytes(self._pending_meta) + bytes(self._buf)
+        self._pending_meta.clear()
+        self._buf.clear()
+        return out

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -33,6 +33,7 @@ from aios.sandbox._subprocess import (
     run_docker_pipeline,
     run_subprocess_with_timeout,
 )
+from aios.sandbox._tar_filter import EPHEMERAL_PREFIXES, TarPrefixFilter
 from aios.sandbox.backends.base import (
     BASE_IMAGE_LABEL_KEY,
     ENV_KEYS_LABEL_KEY,
@@ -713,22 +714,40 @@ class DockerBackend:
         snapshot_timeout_s = _snapshot_timeout_s(
             size_rw, retry_attempt=retry_attempt, size_walk_seconds=size_walk_seconds
         )
-        if parent_depth + 1 >= _FLATTEN_DEPTH_CEILING or over_budget:
-            estimate = parent_size + rw
-            settings = get_settings()
-            free = shutil.disk_usage("/").free
+        settings = get_settings()
+        flattening = parent_depth + 1 >= _FLATTEN_DEPTH_CEILING or over_budget
+        if flattening:
+            # A flatten writes a whole new standalone image before the old one
+            # can be released, so it needs headroom for its own output. Subtract
+            # what the tar filter will drop: sizing the request on the FAT image
+            # would refuse the very flatten that makes it thin — a fail-closed
+            # state whose only exit is the operation it just refused.
+            ephemeral = await self._ephemeral_bytes(sandbox_id)
+            estimate = max(0, parent_size + rw - ephemeral)
             required = int(estimate * 1.75) + settings.sandbox_flatten_disk_floor_bytes
-            if free < required:
-                log.warning(
-                    "sandbox.flatten_deferred_disk",
-                    container_id=sandbox_id[:12],
-                    free_disk=free,
-                    required_disk=required,
-                    tar_estimate=estimate,
-                )
-                raise SandboxBackendError(
-                    f"flatten deferred: {free} free bytes, {required} required"
-                )
+        else:
+            # A commit writes one new layer, roughly the writable layer's size.
+            # Ungated before #2280: the branch that runs when a sandbox is
+            # SMALLER could still consume the last free byte, and it was the
+            # one path to the disk with no floor under it at all.
+            estimate = rw
+            required = int(estimate * 1.25) + settings.sandbox_flatten_disk_floor_bytes
+        free = shutil.disk_usage(settings.sandbox_disk_stat_path).free
+        if free < required:
+            log.warning(
+                "sandbox.snapshot_deferred_disk",
+                container_id=sandbox_id[:12],
+                mode="flatten" if flattening else "commit",
+                free_disk=free,
+                required_disk=required,
+                tar_estimate=estimate,
+                stat_path=settings.sandbox_disk_stat_path,
+            )
+            raise SandboxBackendError(
+                f"{'flatten' if flattening else 'commit'} deferred: "
+                f"{free} free bytes, {required} required"
+            )
+        if flattening:
             operation = self._flatten(
                 sandbox_id, tag, labels, timeout_s=snapshot_timeout_s, size_rw=rw
             )
@@ -826,18 +845,31 @@ class DockerBackend:
         consumer.extend(["-", tag])
         settings = get_settings()
         started = monotonic()
+        # Drop ephemeral scratch that predates the ``/tmp`` bind mount (#2280).
+        # New sandboxes never write it into the rootfs at all; this is what
+        # lets an ALREADY-fat image shed the scratch baked into it, instead of
+        # copying it forward on every flatten, forever.
+        tar_filter = TarPrefixFilter()
         try:
             await run_docker_pipeline(
                 ["docker", "export", sandbox_id],
                 consumer,
                 stall_timeout_s=min(settings.sandbox_pipeline_stall_seconds, timeout_s),
                 max_timeout_s=timeout_s,
+                stream_filter=tar_filter,
             )
         except SandboxBackendError as err:
             if "timed out" in str(err).lower():
                 raise SandboxSnapshotTimeoutError(str(err)) from err
             raise
         elapsed = monotonic() - started
+        if tar_filter.dropped_bytes:
+            log.info(
+                "sandbox.flatten_dropped_ephemeral",
+                container_id=sandbox_id[:12],
+                dropped_bytes=tar_filter.dropped_bytes,
+                dropped_entries=tar_filter.dropped_entries,
+            )
         new = await self._inspect_image_fields(tag)
         if new is None:
             raise SandboxBackendError(f"flattened image {tag} not found after import")
@@ -1199,6 +1231,36 @@ class DockerBackend:
         labels = _parse_json_labels(parts[1]) if len(parts) > 1 else {}
         size_rw = await self._inspect_container_size_rw(sandbox_id)
         return parent_image, size_rw, labels
+
+    async def _ephemeral_bytes(self, sandbox_id: str) -> int:
+        """Bytes the tar filter will drop from this container's export.
+
+        Measured inside the container so the figure reflects what ``docker
+        export`` would actually emit. Used only to size the headroom gate, so
+        an unreadable answer degrades to ``0`` — that just makes the gate
+        demand the pre-#2280 (larger) amount, which errs in the safe
+        direction. It must never fail a snapshot: refusing to snapshot is how
+        a session gets stranded.
+        """
+        paths = [f"/{prefix.rstrip('/')}" for prefix in EPHEMERAL_PREFIXES]
+        try:
+            rc, stdout_bytes, _ = await run_docker_cli(
+                ["docker", "exec", sandbox_id, "du", "-sbxc", *paths],
+                timeout_s=get_settings().sandbox_inspect_size_timeout_seconds,
+            )
+        except SandboxBackendError:
+            log.warning("sandbox.ephemeral_size_unavailable", container_id=sandbox_id[:12])
+            return 0
+        if rc != 0:
+            # ``du`` exits nonzero for an absent path while still totalling the
+            # rest, so a partial read is usable — but only via the total line.
+            log.info("sandbox.ephemeral_size_partial", container_id=sandbox_id[:12])
+        total = 0
+        for line in stdout_bytes.decode("utf-8", errors="replace").splitlines():
+            field, _, label = line.partition("\t")
+            if label.strip() == "total" and field.strip().isdigit():
+                total = int(field.strip())
+        return total
 
     async def _inspect_container_size_rw(self, sandbox_id: str) -> int | None:
         """Return the container's writable-layer bytes (``.SizeRw``), or ``None``

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -1235,31 +1235,48 @@ class DockerBackend:
     async def _ephemeral_bytes(self, sandbox_id: str) -> int:
         """Bytes the tar filter will drop from this container's export.
 
-        Measured inside the container so the figure reflects what ``docker
-        export`` would actually emit. Used only to size the headroom gate, so
-        an unreadable answer degrades to ``0`` — that just makes the gate
-        demand the pre-#2280 (larger) amount, which errs in the safe
-        direction. It must never fail a snapshot: refusing to snapshot is how
-        a session gets stranded.
+        ONLY counts prefixes that live on the container's own root
+        filesystem. ``/tmp`` is a bind mount on any sandbox provisioned after
+        #2280, and ``docker export`` omits bind-mount contents — so those
+        bytes are not in the stream and the filter will not drop them.
+        Counting them would make the gate subtract space the export never
+        needed and let a flatten start with too little disk, which is the
+        exact failure the gate exists to prevent. The device comparison is
+        what distinguishes "inside the rootfs" from "mounted over".
+
+        Used only to size the gate, so an unreadable answer degrades to ``0``
+        — the gate then demands the pre-#2280 (larger) amount, which errs in
+        the safe direction. It must never fail a snapshot: refusing to
+        snapshot is how a session gets stranded.
         """
-        paths = [f"/{prefix.rstrip('/')}" for prefix in EPHEMERAL_PREFIXES]
+        # One shell pass so the device test and the walk see the same mount
+        # table. ``du -sbx`` is bounded to the starting filesystem, which also
+        # stops a nested mount under a counted prefix from inflating the sum.
+        paths = " ".join(f"'/{prefix.rstrip('/')}'" for prefix in EPHEMERAL_PREFIXES)
+        script = (
+            "set -e; "
+            "root_dev=$(stat -c %d /); "
+            f"for p in {paths}; do "
+            '  [ -d "$p" ] || continue; '
+            '  [ "$(stat -c %d "$p")" = "$root_dev" ] || continue; '
+            '  du -sbx "$p"; '
+            "done"
+        )
         try:
             rc, stdout_bytes, _ = await run_docker_cli(
-                ["docker", "exec", sandbox_id, "du", "-sbxc", *paths],
+                ["docker", "exec", sandbox_id, "sh", "-c", script],
                 timeout_s=get_settings().sandbox_inspect_size_timeout_seconds,
             )
         except SandboxBackendError:
             log.warning("sandbox.ephemeral_size_unavailable", container_id=sandbox_id[:12])
             return 0
         if rc != 0:
-            # ``du`` exits nonzero for an absent path while still totalling the
-            # rest, so a partial read is usable — but only via the total line.
             log.info("sandbox.ephemeral_size_partial", container_id=sandbox_id[:12])
         total = 0
         for line in stdout_bytes.decode("utf-8", errors="replace").splitlines():
-            field, _, label = line.partition("\t")
-            if label.strip() == "total" and field.strip().isdigit():
-                total = int(field.strip())
+            field, _, rest = line.partition("\t")
+            if rest and field.strip().isdigit():
+                total += int(field.strip())
         return total
 
     async def _inspect_container_size_rw(self, sandbox_id: str) -> int | None:

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -1025,8 +1025,10 @@ def _assemble_plan(
     (issue #1725). The run path has no github attachments, so the
     default keeps the two sets identical there.
     """
+    from aios.ids import SESSION
     from aios.sandbox.volumes import (
         ensure_session_attachments_dir,
+        ensure_session_tmp_dir,
         ensure_session_uploads_dir,
         memory_store_host_dir,
         session_repo_working_tree_dir,
@@ -1084,11 +1086,37 @@ def _assemble_plan(
     # appears through the existing kernel namespace bind without re-mounting.
     attachments_path = ensure_session_attachments_dir(session_id)
     uploads_path = ensure_session_uploads_dir(session_id)
-
     extra_mounts: list[Mount] = [
         Mount(host_path=attachments_path, sandbox_path="/mnt/attachments", read_only=True),
         Mount(host_path=uploads_path, sandbox_path="/mnt/uploads", read_only=True),
     ]
+
+    # Bind ``/tmp`` to per-session host scratch (#2280). Docker excludes
+    # bind-mount contents from BOTH ``docker commit`` and ``docker export``,
+    # so this is what makes ephemeral scratch structurally unable to enter a
+    # snapshot image — as opposed to a stream filter, which covers only the
+    # export path and only for as long as nobody forgets to apply it.
+    #
+    # SESSIONS ONLY, deliberately. A run (``wfr_``) and a browser plane
+    # (``acc_``) are torn down with a bare destroy that drops the whole
+    # writable layer, so their ``/tmp`` is already reclaimed at teardown.
+    # Binding it to the host would make that scratch *outlive* the container
+    # it belongs to — turning a self-clearing directory into one more tree
+    # needing a reaper. Only the session path persists its rootfs, so only
+    # the session path has anything to exclude from it.
+    #
+    # A plain prefix test, NOT ``ids.sandbox_owner_kind`` — that helper is
+    # exhaustive-and-raising, so routing through it here would turn an
+    # unrecognised owner id into a failed provision. An owner we don't
+    # recognise should simply not get the mount, which is what it had before.
+    if session_id.startswith(f"{SESSION}_"):
+        extra_mounts.append(
+            Mount(
+                host_path=ensure_session_tmp_dir(session_id),
+                sandbox_path="/tmp",
+                read_only=False,
+            )
+        )
 
     # Bind-mount each attached memory store. Read-only attaches make the
     # kernel reject writes (bash + tools alike); read-write is the

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -456,6 +456,75 @@ def session_repo_working_tree_dir(session_id: str, repo_id: str) -> Path:
     return session_repos_root(session_id) / repo_id
 
 
+_SESSION_TMP_ROOT = "_tmp"
+
+
+def session_tmp_root() -> Path:
+    """Return ``<workspace_root>/_tmp`` — the parent of all per-session
+    ephemeral-scratch directories."""
+    return (get_settings().workspace_root / _SESSION_TMP_ROOT).resolve()
+
+
+def session_tmp_dir(session_id: str) -> Path:
+    """Per-session host directory bind-mounted into the container at ``/tmp``.
+
+    ``/tmp`` used to be a plain overlay directory inside the sandbox, which
+    made it *durable state*: ``docker export``/``docker commit`` faithfully
+    copied every byte of it into the session's snapshot image. Long-lived
+    sessions accumulate per-task scratch there — repo clones, virtualenvs,
+    pytest temp trees, build caches — none of which is worth preserving and
+    all of which was paid for twice (once as the compressed content blob,
+    once as the unpacked snapshot) on every idle reap. One production
+    session reached 18 GiB of which 16.4 GiB was ``/tmp`` (eumemic/aios#2280).
+
+    Binding ``/tmp`` to a host directory fixes that by construction: Docker
+    excludes bind-mount contents from BOTH snapshot verbs, so ephemeral
+    scratch can never enter an image again — no filter, no allowlist, no
+    per-call opt-in to forget.
+
+    The scratch lives on the workspace volume beside the other reaped trees,
+    so it is separately provisioned, individually attributable
+    (``du -sh <workspace_root>/_tmp/<session_id>``), and reclaimed by
+    :mod:`aios.harness.host_dir_reaper` once the session is no longer live.
+    It survives container recycles, which is strictly more continuity than
+    the pre-mount behaviour gave a cold-started sandbox.
+
+    Rooted at ``<workspace_root>/_tmp/<session_id>`` rather than under the
+    session's own ``workspace_path`` for the same reason as
+    :func:`session_repos_root`: that path is user-supplied, is not unique
+    per session, and must not become a place where scratch lands inside
+    data the user manages.
+
+    Pure — does not create the directory. Use :func:`ensure_session_tmp_dir`.
+    """
+    return session_tmp_root() / session_id
+
+
+def ensure_session_tmp_dir(session_id: str) -> Path:
+    """Return the per-session ``/tmp`` backing directory, creating it if needed.
+
+    Called from the spec builder at every container start so the bind-mount
+    source always exists before Docker tries to mount it. Docker would
+    otherwise create a missing source as ``root:root``, which the api (uid
+    1000) could not write into — the #959 failure mode ``ensure_owned_dir``
+    exists to prevent.
+
+    The directory is chmod 1777 (world-writable + sticky) to match the
+    ``/tmp`` semantics every tool in the sandbox assumes: sandbox processes
+    do not all run as the owning uid, and a non-sticky world-writable dir
+    would let one of them delete another's files.
+    """
+    path = ensure_owned_dir(session_tmp_dir(session_id))
+    try:
+        path.chmod(0o1777)
+    except OSError:
+        # Best-effort: a pre-existing dir owned by another uid (worker root
+        # vs api 1000) can refuse chmod. The mount still works; only the
+        # permission hardening is skipped. Never fail a provision over it.
+        log.warning("could not chmod session tmp dir to 1777", path=str(path))
+    return path
+
+
 _ATTACHMENTS_ROOT = "_attachments"
 
 
@@ -735,6 +804,7 @@ def purge_session_directories(
         (session_uploads_dir(session_id), (session_uploads_dir(session_id),)),
         (session_attachments_dir(session_id), (session_attachments_dir(session_id),)),
         (session_repos_root(session_id), (session_repos_root(session_id),)),
+        (session_tmp_dir(session_id), (session_tmp_dir(session_id),)),
     )
     # Prove EVERY target before deleting ANY of them. A prove-as-you-go loop
     # would already have rmtree'd the earlier directories by the time a later

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -450,4 +450,8 @@ def patch_build_spec_deps(
             "aios.sandbox.volumes.ensure_session_uploads_dir",
             return_value=Path("/tmp/u"),
         ),
+        patch(
+            "aios.sandbox.volumes.ensure_session_tmp_dir",
+            return_value=Path("/tmp/t"),
+        ),
     )

--- a/tests/unit/sandbox/test_egress_ca.py
+++ b/tests/unit/sandbox/test_egress_ca.py
@@ -225,6 +225,7 @@ def _assemble_default_plan(
             return_value=Path("/tmp/a"),
         ),
         patch("aios.sandbox.volumes.ensure_session_uploads_dir", return_value=Path("/tmp/u")),
+        patch("aios.sandbox.volumes.ensure_session_tmp_dir", return_value=Path("/tmp/t")),
     ):
         return _assemble_plan(
             session_id="sess_01TEST",

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -42,6 +42,8 @@ class _FakeDocker:
     def __init__(self) -> None:
         self.parent_image = "img_S1"
         self.size_rw = 1_000_000
+        self.ephemeral_bytes = 0
+        self.stream_filters: list[Any] = []
         self.container_labels: dict[str, str] = {}
         self.images: dict[str, dict[str, Any]] = {}
         self.calls: list[list[str]] = []
@@ -77,6 +79,11 @@ class _FakeDocker:
             config = json.dumps({"Labels": img.get("labels", {})})
             out = f"{img['id']}\t{img['size']}\t{img['depth']}\t{config}"
             return 0, out.encode(), b""
+        if sub == "exec" and "du" in argv:
+            # The pre-flatten ephemeral-bytes probe (#2280): ``du -sbxc`` over
+            # the dropped prefixes. Only the ``total`` line is read.
+            lines = [f"{self.ephemeral_bytes}\ttotal"]
+            return 0, ("\n".join(lines) + "\n").encode(), b""
         if sub == "commit":
             tag = argv[-1]
             self.images[tag] = {
@@ -95,9 +102,11 @@ class _FakeDocker:
         *,
         stall_timeout_s: float,
         max_timeout_s: float,
+        stream_filter: Any = None,
     ) -> tuple[int, bytes, bytes]:
         self.pipelines.append((producer, consumer))
         self.pipeline_timeouts.append((stall_timeout_s, max_timeout_s))
+        self.stream_filters.append(stream_filter)
         tag = consumer[-1]
         self.images[tag] = {
             "id": "flattened",

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -79,11 +79,14 @@ class _FakeDocker:
             config = json.dumps({"Labels": img.get("labels", {})})
             out = f"{img['id']}\t{img['size']}\t{img['depth']}\t{config}"
             return 0, out.encode(), b""
-        if sub == "exec" and "du" in argv:
-            # The pre-flatten ephemeral-bytes probe (#2280): ``du -sbxc`` over
-            # the dropped prefixes. Only the ``total`` line is read.
-            lines = [f"{self.ephemeral_bytes}\ttotal"]
-            return 0, ("\n".join(lines) + "\n").encode(), b""
+        if sub == "exec" and "du" in argv[-1]:
+            # The pre-flatten ephemeral-bytes probe (#2280): a shell pass that
+            # emits one ``<bytes>\t<path>`` line per prefix living on the
+            # container's own rootfs. Prefixes that are bind mounts emit
+            # nothing, because the export does not contain them.
+            if not self.ephemeral_bytes:
+                return 0, b"", b""
+            return 0, f"{self.ephemeral_bytes}\t/tmp\n".encode(), b""
         if sub == "commit":
             tag = argv[-1]
             self.images[tag] = {

--- a/tests/unit/sandbox/test_spec_per_env_controls.py
+++ b/tests/unit/sandbox/test_spec_per_env_controls.py
@@ -53,6 +53,10 @@ def _call_assemble(
             "aios.sandbox.volumes.ensure_session_uploads_dir",
             return_value=Path("/tmp/u"),
         ),
+        patch(
+            "aios.sandbox.volumes.ensure_session_tmp_dir",
+            return_value=Path("/tmp/t"),
+        ),
     ):
         return _assemble_plan(
             session_id="sess_01TEST",

--- a/tests/unit/sandbox/test_spec_run_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_run_env_var_credentials.py
@@ -100,6 +100,10 @@ def _patch_run_spec_deps(
             return_value=__import__("pathlib").Path("/tmp/run-u"),
         ),
         patch(
+            "aios.sandbox.volumes.ensure_session_tmp_dir",
+            return_value=__import__("pathlib").Path("/tmp/run-t"),
+        ),
+        patch(
             "aios.sandbox.spec._materialize_run_env_var_credentials",
             env_var_credentials or AsyncMock(return_value=()),
         ),

--- a/tests/unit/sandbox/test_spec_uds_url.py
+++ b/tests/unit/sandbox/test_spec_uds_url.py
@@ -41,6 +41,10 @@ def _call_assemble(
             "aios.sandbox.volumes.ensure_session_uploads_dir",
             return_value=Path("/tmp/u"),
         ),
+        patch(
+            "aios.sandbox.volumes.ensure_session_tmp_dir",
+            return_value=Path("/tmp/t"),
+        ),
     ):
         return _assemble_plan(
             session_id=session_id,

--- a/tests/unit/sandbox/test_tmp_mount_and_disk_gate.py
+++ b/tests/unit/sandbox/test_tmp_mount_and_disk_gate.py
@@ -172,6 +172,36 @@ class TestSnapshotDiskGate:
         assert not fake_docker.pipelines
 
     @pytest.mark.asyncio
+    async def test_ephemeral_probe_only_counts_the_container_rootfs(self) -> None:
+        """After #2280 ``/tmp`` is a BIND MOUNT, and ``docker export`` omits
+        bind-mount contents — so those bytes are not in the stream and the
+        filter will not drop them. Counting them would make the gate subtract
+        space the export never needed and start a flatten with too little
+        disk. The probe must compare device numbers, not just run ``du``."""
+        captured: list[list[str]] = []
+
+        async def _fake_cli(argv: list[str], **_kw: object) -> tuple[int, bytes, bytes]:
+            captured.append(argv)
+            return 0, b"", b""  # every prefix is a mount ⇒ nothing to drop
+
+        with patch("aios.sandbox.backends.docker.run_docker_cli", _fake_cli):
+            assert await DockerBackend()._ephemeral_bytes("cid") == 0
+
+        script = captured[0][-1]
+        assert "stat -c %d /" in script, "must establish the rootfs device"
+        assert "du -sbx" in script
+        for prefix in ("tmp", "var/tmp", "run"):
+            assert f"'/{prefix}'" in script
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_probe_sums_every_reported_prefix(self) -> None:
+        async def _fake_cli(_argv: list[str], **_kw: object) -> tuple[int, bytes, bytes]:
+            return 0, b"1000\t/tmp\n250\t/var/tmp\n30\t/run\n", b""
+
+        with patch("aios.sandbox.backends.docker.run_docker_cli", _fake_cli):
+            assert await DockerBackend()._ephemeral_bytes("cid") == 1280
+
+    @pytest.mark.asyncio
     async def test_ephemeral_probe_failure_is_swallowed(self, fake_docker: _FakeDocker) -> None:
         """``_ephemeral_bytes`` degrades to 0 rather than propagating: refusing
         to snapshot is how a session gets stranded."""

--- a/tests/unit/sandbox/test_tmp_mount_and_disk_gate.py
+++ b/tests/unit/sandbox/test_tmp_mount_and_disk_gate.py
@@ -1,0 +1,229 @@
+"""The ``/tmp`` bind mount and the snapshot headroom gate (#2280).
+
+A durable session's snapshot is ``docker export``/``docker commit`` of its
+rootfs, so anything written outside a bind mount is preserved forever. One
+production session reached 18 GiB of which 16.4 GiB was ``/tmp`` scratch.
+
+Two properties are asserted here:
+
+* ``/tmp`` is a per-session bind mount for SESSIONS ONLY — runs and browser
+  planes are bare-destroyed, so binding their ``/tmp`` would make scratch
+  outlive the container instead of dying with it.
+* The headroom gate covers BOTH snapshot verbs, and sizes a flatten on what
+  the export will actually contain. Sizing it on the fat image would refuse
+  the very flatten that makes the image thin — a fail-closed state whose only
+  exit is the operation it just refused (``patterns/in-band-exit``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aios.sandbox.backends.base import SandboxBackendError
+from aios.sandbox.backends.docker import DockerBackend
+
+from .test_snapshot_verb import _FakeDocker, _set_free_disk
+from .test_snapshot_verb import fake_docker as _fake_docker
+
+# Re-export the shared fixture under its usual name for this module.
+fake_docker = _fake_docker
+
+GIB = 1024**3
+
+
+# ── the mount ────────────────────────────────────────────────────────────────
+
+
+def _assemble(session_id: str) -> object:
+    from aios.sandbox.spec import _assemble_plan
+
+    with (
+        patch(
+            "aios.sandbox.volumes.ensure_session_attachments_dir",
+            return_value=Path("/tmp/a"),
+        ),
+        patch("aios.sandbox.volumes.ensure_session_uploads_dir", return_value=Path("/tmp/u")),
+        patch(
+            "aios.sandbox.volumes.ensure_session_tmp_dir",
+            return_value=Path(f"/ws/_tmp/{session_id}"),
+        ),
+    ):
+        return _assemble_plan(
+            session_id=session_id,
+            instance_id="default",
+            image="img:latest",
+            workspace_path=Path("/ws/sess"),
+            snapshot_ref=None,
+            snapshot_budget_bytes=None,
+            env_config=None,
+            session_env={},
+            memory_echoes=[],
+            github_echoes=[],
+            git_proxy=None,
+            tool_broker_url="http://aios-worker:54321",
+            tool_broker_secret="s",
+            tool_socket_host_path=None,
+        )
+
+
+def _tmp_mounts(plan: object) -> list[object]:
+    return [m for m in plan.spec.extra_mounts if m.sandbox_path == "/tmp"]  # type: ignore[attr-defined]
+
+
+class TestTmpMount:
+    def test_session_gets_a_writable_tmp_bind(self) -> None:
+        mounts = _tmp_mounts(_assemble("sess_01TEST"))
+        assert len(mounts) == 1
+        assert mounts[0].host_path == Path("/ws/_tmp/sess_01TEST")  # type: ignore[attr-defined]
+        assert mounts[0].read_only is False  # type: ignore[attr-defined]
+
+    @pytest.mark.parametrize("owner", ["wfr_01TEST", "acc_01TEST"])
+    def test_bare_destroy_owners_keep_tmp_in_the_writable_layer(self, owner: str) -> None:
+        """A run and a browser plane are destroyed whole, so their ``/tmp`` is
+        already reclaimed. Binding it would make it outlive the container."""
+        assert _tmp_mounts(_assemble(owner)) == []
+
+    def test_unrecognised_owner_id_does_not_raise(self) -> None:
+        """The prefix test must not be ``sandbox_owner_kind`` — that helper is
+        exhaustive-and-raising, and an odd owner id must not become a failed
+        provision."""
+        assert _tmp_mounts(_assemble("run_01LEGACY")) == []
+
+    def test_tmp_is_the_only_new_mount(self) -> None:
+        """Guards the mount-drift key: every added mount recycles every live
+        sandbox on the next touch, so an accidental extra is not free."""
+        paths = {m.sandbox_path for m in _assemble("sess_01TEST").spec.extra_mounts}  # type: ignore[attr-defined]
+        assert paths == {"/mnt/attachments", "/mnt/uploads", "/tmp"}
+
+
+# ── the headroom gate ────────────────────────────────────────────────────────
+
+
+class TestSnapshotDiskGate:
+    @pytest.mark.asyncio
+    async def test_commit_is_gated_too(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Before #2280 only the flatten branch had a floor under it, so the
+        path taken by SMALLER sandboxes could consume the last free byte."""
+        fake_docker.size_rw = 2 * GIB
+        _set_free_disk(monkeypatch, 1_000_000)  # 1 MB free
+        with pytest.raises(SandboxBackendError, match="commit deferred"):
+            await DockerBackend().snapshot(
+                "cid",
+                "tag:latest",
+                empty_floor_bytes=8192,
+                flatten_if_unique_bytes_over=100 * GIB,  # stay on the commit path
+            )
+        assert not any(c[1] == "commit" for c in fake_docker.calls), (
+            "a deferred commit must never start the commit"
+        )
+
+    @pytest.mark.asyncio
+    async def test_commit_proceeds_with_headroom(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_docker.size_rw = 2 * GIB
+        _set_free_disk(monkeypatch, 100 * GIB)
+        await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=100 * GIB
+        )
+        assert any(c[1] == "commit" for c in fake_docker.calls)
+
+    @pytest.mark.asyncio
+    async def test_flatten_estimate_excludes_what_the_filter_drops(
+        self,
+        fake_docker: _FakeDocker,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """THE in-band-exit case. A 25 GB session whose bulk is ``/tmp`` needs
+        headroom for its FILTERED output (~small), not its fat rootfs. Sizing
+        on the fat figure would refuse the one operation that shrinks it, and
+        the session could never recover on a full disk."""
+        fake_docker.size_rw = 25 * GIB
+        fake_docker.ephemeral_bytes = 23 * GIB  # nearly all of it is scratch
+        # Enough for the filtered ~2 GB (x1.75) + the 15 GiB floor, but far
+        # short of the unfiltered 25 GB (x1.75) + floor.
+        _set_free_disk(monkeypatch, 20 * GIB)
+
+        await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=4 * GIB
+        )
+
+        assert fake_docker.pipelines, "the flatten must proceed on the filtered estimate"
+
+    @pytest.mark.asyncio
+    async def test_flatten_still_refused_when_even_filtered_output_does_not_fit(
+        self,
+        fake_docker: _FakeDocker,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The gate is relaxed by the filter, not removed by it."""
+        fake_docker.size_rw = 25 * GIB
+        fake_docker.ephemeral_bytes = 1 * GIB
+        _set_free_disk(monkeypatch, 2 * GIB)
+        with pytest.raises(SandboxBackendError, match="flatten deferred"):
+            await DockerBackend().snapshot(
+                "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=4 * GIB
+            )
+        assert not fake_docker.pipelines
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_probe_failure_is_swallowed(self, fake_docker: _FakeDocker) -> None:
+        """``_ephemeral_bytes`` degrades to 0 rather than propagating: refusing
+        to snapshot is how a session gets stranded."""
+        backend = DockerBackend()
+        with patch(
+            "aios.sandbox.backends.docker.run_docker_cli",
+            side_effect=SandboxBackendError("no exec"),
+        ):
+            assert await backend._ephemeral_bytes("cid") == 0
+
+    @pytest.mark.asyncio
+    async def test_gate_measures_the_configured_filesystem(
+        self,
+        fake_docker: _FakeDocker,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The gate must stat the docker graph root's filesystem, not whatever
+        ``/`` happens to be inside the worker container."""
+        seen: list[str] = []
+
+        def _usage(path: str) -> MagicMock:
+            seen.append(path)
+            return MagicMock(free=100 * GIB)
+
+        monkeypatch.setattr("aios.sandbox.backends.docker.shutil.disk_usage", _usage)
+        monkeypatch.setattr(
+            "aios.sandbox.backends.docker.get_settings",
+            lambda: _settings_with(sandbox_disk_stat_path="/var/lib/docker"),
+        )
+        await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=100 * GIB
+        )
+        assert seen == ["/var/lib/docker"]
+
+
+def _settings_with(**overrides: object) -> object:
+    from aios.config import get_settings
+
+    real = get_settings()
+    stub = MagicMock(wraps=real)
+    for key in (
+        "sandbox_flatten_disk_floor_bytes",
+        "sandbox_inspect_size_timeout_seconds",
+        "sandbox_pipeline_stall_seconds",
+        "sandbox_snapshot_timeout_floor_seconds",
+        "sandbox_snapshot_timeout_retry_multiplier",
+        "sandbox_snapshot_timeout_retry_cap",
+        "sandbox_snapshot_throughput_state_path",
+        "sandbox_docker_cli_timeout_seconds",
+        "sandbox_disk_stat_path",
+    ):
+        setattr(stub, key, getattr(real, key))
+    for key, value in overrides.items():
+        setattr(stub, key, value)
+    return stub

--- a/tests/unit/test_host_dir_reaper.py
+++ b/tests/unit/test_host_dir_reaper.py
@@ -5,6 +5,7 @@ with session/run count (the 2026-06-16 floodgates disk-fill):
 
 * ``_session_repos/<session_id>`` — RECONSTRUCTIBLE git working-tree clones.
 * ``_runs/<run_id>``             — NON-reconstructible per-run scratch.
+* ``_tmp/<session_id>``          — the session sandbox's ``/tmp`` bind (#2280).
 
 The load-bearing safety property (the bug PR #1193 shipped) is that the
 keep-set is **DB liveness, NOT container presence**: a ``suspended`` run
@@ -48,10 +49,13 @@ def roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     """
     repos_root = tmp_path / "_session_repos"
     runs_root = tmp_path / "acc_test" / "_runs"
+    tmp_root = tmp_path / "_tmp"
     repos_root.mkdir()
     runs_root.mkdir(parents=True)
+    tmp_root.mkdir()
 
     monkeypatch.setattr(host_dir_reaper, "session_repos_root", lambda sid: repos_root / sid)
+    monkeypatch.setattr(host_dir_reaper, "session_tmp_dir", lambda sid: tmp_root / sid)
     monkeypatch.setattr(
         host_dir_reaper,
         "run_workspace_dir",
@@ -63,7 +67,7 @@ def roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     settings.host_dir_reaper_min_age_seconds = 0
     monkeypatch.setattr(host_dir_reaper, "get_settings", lambda: settings)
 
-    return {"repos": repos_root, "runs": runs_root, "settings": settings}
+    return {"repos": repos_root, "runs": runs_root, "tmp": tmp_root, "settings": settings}
 
 
 def test_service_workspace_builder_is_enumerated_by_reaper(
@@ -388,3 +392,96 @@ async def test_missing_root_is_a_noop(
     removed = await sweep_host_dirs(_fake_pool())
 
     assert removed == 0
+
+
+# ---------------------------------------------------------------------------
+# ``_tmp`` — the session sandbox's ``/tmp`` bind (#2280)
+# ---------------------------------------------------------------------------
+
+
+async def test_tmp_dir_reaped_for_dead_session_kept_for_live(
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``/tmp`` follows session liveness, exactly like ``_session_repos``.
+
+    A live session's scratch survives even though its container may be
+    idle-released — the same container-presence trap ``_runs`` guards against.
+    """
+    live = _mkdir_aged(roots["tmp"], "sess_live")
+    dead = _mkdir_aged(roots["tmp"], "sess_dead")
+
+    monkeypatch.setattr(queries, "unscoped_live_session_ids", AsyncMock(return_value={"sess_live"}))
+    monkeypatch.setattr(wf_queries, "unscoped_terminal_run_ids", AsyncMock(return_value=set()))
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 1
+    assert live.exists(), "a DB-live session's /tmp scratch must survive"
+    assert not dead.exists(), "a dead session's /tmp scratch must be reaped"
+
+
+async def test_tmp_dir_fail_closed_on_db_error(
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed liveness read reaps nothing — never delete on the absence of
+    confirmation."""
+    scratch = _mkdir_aged(roots["tmp"], "sess_unknown")
+
+    monkeypatch.setattr(
+        queries,
+        "unscoped_live_session_ids",
+        AsyncMock(side_effect=OSError("db down")),
+    )
+    monkeypatch.setattr(wf_queries, "unscoped_terminal_run_ids", AsyncMock(return_value=set()))
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0
+    assert scratch.exists()
+
+
+async def test_tmp_dir_unknown_owner_kind_is_kept(
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only sessions bind this tree. An id of any other shape is residue we
+    have no rule for, and a rule written for a different owner kind must not
+    be applied to it by default."""
+    foreign = _mkdir_aged(roots["tmp"], "wfr_run")
+    account = _mkdir_aged(roots["tmp"], "acc_browser")
+
+    live = AsyncMock(return_value=set())
+    monkeypatch.setattr(queries, "unscoped_live_session_ids", live)
+    monkeypatch.setattr(wf_queries, "unscoped_terminal_run_ids", AsyncMock(return_value=set()))
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0
+    assert foreign.exists()
+    assert account.exists()
+    live.assert_not_awaited()
+
+
+async def test_tmp_dir_kill_switch(roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    scratch = _mkdir_aged(roots["tmp"], "sess_dead")
+    roots["settings"].host_dir_reaper_enabled = False
+
+    monkeypatch.setattr(queries, "unscoped_live_session_ids", AsyncMock(return_value=set()))
+    monkeypatch.setattr(wf_queries, "unscoped_terminal_run_ids", AsyncMock(return_value=set()))
+
+    assert await sweep_host_dirs(_fake_pool()) == 0
+    assert scratch.exists()
+
+
+async def test_tmp_dir_age_floor_protects_in_flight_provision(
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A just-created dir may be a provision mid-flight; the age floor keeps it
+    even when the session is not yet visible as live."""
+    roots["settings"].host_dir_reaper_min_age_seconds = 3600
+    fresh = _mkdir_aged(roots["tmp"], "sess_fresh", age_s=0.0)
+
+    monkeypatch.setattr(queries, "unscoped_live_session_ids", AsyncMock(return_value=set()))
+    monkeypatch.setattr(wf_queries, "unscoped_terminal_run_ids", AsyncMock(return_value=set()))
+
+    assert await sweep_host_dirs(_fake_pool()) == 0
+    assert fresh.exists()

--- a/tests/unit/test_tar_filter.py
+++ b/tests/unit/test_tar_filter.py
@@ -1,0 +1,225 @@
+"""Tests for the export tar filter (#2280).
+
+The filter sits on the critical path of session durability: everything it
+forwards becomes the session's filesystem, and everything it drops is gone.
+So the tests are written around two properties rather than examples —
+*nothing outside the dropped prefixes is ever altered*, and *the result is
+always a tar Python can read back* — plus the specific shapes (long names,
+pax headers, hardlinks, base-256 sizes) where a naive 512-byte scanner
+silently corrupts a stream.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from aios.sandbox._tar_filter import TarPrefixFilter, _is_ephemeral
+
+
+def _build_tar(entries: list[tuple[str, bytes]], **kwargs: object) -> bytes:
+    """A tar containing ``entries`` as regular files."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", **kwargs) as tf:  # type: ignore[call-overload]
+        for name, payload in entries:
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+def _run(raw: bytes, chunk_size: int = 1024 * 1024) -> bytes:
+    """Feed ``raw`` through the filter in ``chunk_size`` pieces."""
+    filt = TarPrefixFilter()
+    out = bytearray()
+    for start in range(0, len(raw), chunk_size):
+        out += filt.feed(raw[start : start + chunk_size])
+    out += filt.flush()
+    return bytes(out)
+
+
+def _names(raw: bytes) -> list[str]:
+    with tarfile.open(fileobj=io.BytesIO(raw), mode="r") as tf:
+        return tf.getnames()
+
+
+class TestPrefixMatching:
+    @pytest.mark.parametrize(
+        "name",
+        ["tmp/x", "tmp/deep/nested/file", "var/tmp/y", "run/lock", "./tmp/x", "/tmp/x"],
+    )
+    def test_inside_a_dropped_tree(self, name: str) -> None:
+        assert _is_ephemeral(name, ("tmp/", "var/tmp/", "run/")) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "tmp",  # the mount point itself must survive
+            "tmp/",
+            "./tmp",
+            "var",
+            "var/tmp",  # ditto
+            "workspace/tmp/x",  # only ROOT-anchored prefixes match
+            "tmpfoo/x",  # not a path component boundary
+            "root/.cache/ms-playwright/x",  # deliberately durable
+            "app/.venv/lib/x",
+        ],
+    )
+    def test_kept(self, name: str) -> None:
+        assert _is_ephemeral(name, ("tmp/", "var/tmp/", "run/")) is False
+
+
+class TestFiltering:
+    def test_drops_only_the_ephemeral_entries(self) -> None:
+        raw = _build_tar(
+            [
+                ("workspace/keep.txt", b"keep me"),
+                ("tmp/junk.bin", b"x" * 4096),
+                ("var/tmp/more.bin", b"y" * 2048),
+                ("run/sock.lock", b"z"),
+                ("root/.cache/ms-playwright/webkit", b"expensive"),
+            ]
+        )
+        out = _run(raw)
+        assert _names(out) == ["workspace/keep.txt", "root/.cache/ms-playwright/webkit"]
+
+    def test_kept_payloads_are_byte_identical(self) -> None:
+        payload = bytes(range(256)) * 40
+        raw = _build_tar([("workspace/data.bin", payload), ("tmp/junk", b"q" * 9000)])
+        with tarfile.open(fileobj=io.BytesIO(_run(raw)), mode="r") as tf:
+            member = tf.extractfile("workspace/data.bin")
+            assert member is not None
+            assert member.read() == payload
+
+    def test_stream_with_no_matches_is_unchanged(self) -> None:
+        raw = _build_tar([("workspace/a", b"a" * 5000), ("etc/hosts", b"127.0.0.1")])
+        assert _run(raw) == raw
+
+    @pytest.mark.parametrize("chunk_size", [1, 7, 512, 513, 1024, 65536])
+    def test_chunk_boundaries_do_not_matter(self, chunk_size: int) -> None:
+        """The relay reads 1 MiB at a time with no regard for tar's 512-byte
+        records, so a header or payload can be split anywhere."""
+        raw = _build_tar(
+            [("workspace/keep", b"k" * 3000), ("tmp/drop", b"d" * 3000), ("etc/keep2", b"e")]
+        )
+        out = _run(raw, chunk_size=chunk_size)
+        assert _names(out) == ["workspace/keep", "etc/keep2"]
+
+    def test_reports_what_it_dropped(self) -> None:
+        filt = TarPrefixFilter()
+        raw = _build_tar([("tmp/a", b"x" * 10_000), ("tmp/b", b"y" * 10_000)])
+        filt.feed(raw)
+        filt.flush()
+        assert filt.dropped_entries == 2
+        assert filt.dropped_bytes >= 20_000
+
+    def test_empty_stream(self) -> None:
+        assert _run(b"") == b""
+
+
+class TestAwkwardHeaders:
+    def test_gnu_long_names(self) -> None:
+        """>100-char names are emitted as a separate ``L`` record preceding the
+        entry, so the drop decision has to be deferred to the real header."""
+        long_kept = "workspace/" + "a" * 150 + "/keep.txt"
+        long_dropped = "tmp/" + "b" * 150 + "/junk.bin"
+        raw = _build_tar(
+            [(long_kept, b"keep"), (long_dropped, b"z" * 4096)],
+            format=tarfile.GNU_FORMAT,
+        )
+        out = _run(raw)
+        assert _names(out) == [long_kept]
+
+    def test_pax_headers(self) -> None:
+        long_kept = "workspace/" + "a" * 150 + "/keep.txt"
+        long_dropped = "tmp/" + "b" * 150 + "/junk.bin"
+        raw = _build_tar(
+            [(long_kept, b"keep"), (long_dropped, b"z" * 4096)],
+            format=tarfile.PAX_FORMAT,
+        )
+        out = _run(raw)
+        assert _names(out) == [long_kept]
+
+    def test_hardlink_into_a_dropped_tree_is_dropped(self) -> None:
+        """Its target won't be in the output, so forwarding the link would
+        produce an archive ``docker import`` refuses."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tf:
+            info = tarfile.TarInfo("tmp/original")
+            info.size = 10
+            tf.addfile(info, io.BytesIO(b"0123456789"))
+            link = tarfile.TarInfo("workspace/alias")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "tmp/original"
+            tf.addfile(link)
+        out = _run(buf.getvalue())
+        assert _names(out) == []
+
+    def test_hardlink_to_a_kept_file_survives(self) -> None:
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tf:
+            info = tarfile.TarInfo("workspace/original")
+            info.size = 10
+            tf.addfile(info, io.BytesIO(b"0123456789"))
+            link = tarfile.TarInfo("workspace/alias")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "workspace/original"
+            tf.addfile(link)
+        out = _run(buf.getvalue())
+        assert _names(out) == ["workspace/original", "workspace/alias"]
+
+    def test_directories_and_symlinks_pass_through(self) -> None:
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tf:
+            d = tarfile.TarInfo("workspace")
+            d.type = tarfile.DIRTYPE
+            tf.addfile(d)
+            mount_point = tarfile.TarInfo("tmp")
+            mount_point.type = tarfile.DIRTYPE
+            tf.addfile(mount_point)
+            s = tarfile.TarInfo("workspace/link")
+            s.type = tarfile.SYMTYPE
+            s.linkname = "../etc/hosts"
+            tf.addfile(s)
+        out = _run(buf.getvalue())
+        # ``tmp`` itself survives: the bind mount needs a mount point.
+        assert _names(out) == ["workspace", "tmp", "workspace/link"]
+
+
+class TestFailureModes:
+    def test_garbage_is_forwarded_verbatim(self) -> None:
+        """A stream we cannot parse must come out unchanged. Fat beats corrupt."""
+        garbage = b"this is definitely not a tar archive" * 100
+        assert _run(garbage) == garbage
+
+    def test_truncated_archive_is_not_rewritten(self) -> None:
+        raw = _build_tar([("workspace/a", b"a" * 4096)])
+        truncated = raw[: len(raw) - 700]
+        assert _run(truncated) == truncated
+
+    def test_trailing_data_after_end_marker_survives(self) -> None:
+        raw = _build_tar([("workspace/a", b"a")])
+        assert _run(raw + b"trailing") == raw + b"trailing"
+
+
+class TestLargeEntries:
+    def test_base256_size_header(self) -> None:
+        """Entries >8 GiB encode their size in GNU base-256 rather than octal;
+        misreading one desynchronises the parser for the rest of the stream."""
+        from aios.sandbox._tar_filter import _parse_size
+
+        header = bytearray(512)
+        size = 10 * 1024**3
+        raw = size.to_bytes(11, "big")
+        header[124] = 0x80
+        header[125:136] = raw
+        assert _parse_size(bytes(header)) == size
+
+    def test_payload_spanning_many_chunks(self) -> None:
+        big = b"Q" * (3 * 1024 * 1024)
+        raw = _build_tar([("tmp/big", big), ("workspace/small", b"s")])
+        out = _run(raw, chunk_size=1024 * 1024)
+        assert _names(out) == ["workspace/small"]
+        assert len(out) < len(raw) - 2 * 1024 * 1024


### PR DESCRIPTION
Closes #2280.

## The defect

A durable session's snapshot is `docker export`/`docker commit` of its container rootfs. `/tmp` was a plain overlay directory, which made it **durable state**: every byte of scratch a long-lived session accumulated there — per-task working dirs, repo clones, virtualenvs, pytest trees, browser caches — was faithfully preserved into the snapshot image, and paid for **twice** on every idle reap (once as the compressed content blob, once as the unpacked snapshot).

One session's image reached 18 GiB of which **16.4 GiB was `/tmp`**. Because the flatten trigger is a per-session unique-bytes budget, such a session is permanently over budget and re-exports its entire accumulated scratch every ~30 idle minutes, forever. That is also what pushes exports past their deadline into the salvage breaker (#2027): the fatter the scratch, the longer the export, the likelier the timeout — and a session whose snapshot cannot complete is stranded.

## The fix

**`/tmp` becomes a per-session bind mount** at `<workspace_root>/_tmp/<session_id>`.

Docker excludes bind-mount contents from **both** snapshot verbs, so ephemeral scratch becomes *structurally* unable to enter an image — the same mechanism `/workspace`, `/mnt/memory/*` and the github working trees already rely on. This is the whole point of preferring the mount over a filter: a filter covers only the export path (`docker commit` is daemon-side and has no exclusion flag) and only for as long as nobody forgets to apply it. Scratch still survives container recycles — strictly more continuity than a cold `/tmp` gave — and is reclaimed by `host_dir_reaper` once the session is no longer DB-live.

**Sessions only.** A run (`wfr_`) and a browser plane (`acc_`) are torn down with a bare destroy that drops the whole writable layer, so their `/tmp` is already reclaimed at teardown; binding it would make that scratch *outlive* the container it belongs to. The check is a plain prefix test rather than `ids.sandbox_owner_kind`, which is exhaustive-and-raising — an unrecognised owner id must not become a failed provision.

**A streaming tar filter on the flatten export** (`sandbox/_tar_filter.py`) drops `tmp/`, `var/tmp/` and `run/`. The mount cannot remove what is already baked into existing images, and re-exporting one copies its scratch forward forever; the filter lets each affected session shed its historical scratch on its next flatten and then stay lean because of the mount. It interposes in the existing `run_docker_pipeline` relay, which already copies every byte through this process, so it costs a function call per chunk and no extra I/O.

**The headroom gate is repaired** — three separate holes:
- It only guarded the flatten branch. The commit branch — the one taken when a sandbox is *smaller* — had no floor under it at all, and could still consume the last free byte.
- It statted `/`, which inside the worker container is the worker's own overlay and need not be the Docker graph root's filesystem. When they differ the gate measures a disk nothing is being written to and passes while the real target is full. Now configurable via `sandbox_disk_stat_path`.
- It sized a flatten on the **fat** image. For a 25 GB whale that demands ~58 GB free, so the gate would refuse the very flatten that makes the image thin — a fail-closed state whose only exit is the operation it just refused. It now subtracts what the filter will drop, and counts only prefixes on the container's own rootfs (a bind-mounted `/tmp` contributes nothing, because the export does not contain it).

## Correctness of the filter

New hand-rolled binary parsing on the critical path of session durability, so it is built to fail safe and tested as a property rather than by example:

- **Unparseable input is forwarded verbatim.** A fat snapshot is a far better failure than a corrupt one; the filter never truncates a stream it does not understand.
- Handles records split at *any* offset (the relay reads 1 MiB chunks, unrelated to tar's 512-byte records), GNU `L`/`K` and pax `x`/`X` extended headers (buffered and emitted or dropped *with* their target entry), GNU base-256 sizes for >8 GiB members, and the ustar `prefix` field.
- **Hardlinks into a dropped tree are dropped**, not rewritten — the target won't be in the output, so the link would dangle and `docker import` would reject the archive.
- **Mount points survive**: `tmp/` is kept while everything beneath it is dropped, so the bind has something to mount onto.

Beyond the committed tests, the filter was validated by a randomized differential fuzz — 400 archives across USTAR/GNU/PAX formats × 9 chunk sizes, each checked against a reference model for exact kept-entry set, byte-identical payloads, and readability of the output: **0 failures**.

## Tests

- `tests/unit/test_tar_filter.py` — 36 cases: prefix matching, every chunk boundary (1, 7, 512, 513, 1024, 65536), no-match streams byte-identical, GNU longnames, pax, hardlinks both directions, directories/symlinks, base-256 sizes, multi-chunk payloads, garbage/truncation/trailing-data passthrough.
- `tests/unit/sandbox/test_tmp_mount_and_disk_gate.py` — mount present and writable for sessions, absent for `wfr_`/`acc_`, no raise on an unrecognised owner, mount set is exactly the intended three; gate on both branches, the in-band-exit case, the probe's rootfs-only accounting, and its failure degrading to 0 rather than propagating.
- `tests/unit/test_host_dir_reaper.py` — `_tmp` reaped for a dead session, kept for a live one, fail-closed on DB error, unknown owner kinds kept, kill-switch, age floor.

`mypy` / `ruff check` / `ruff format` clean; full unit suite 5607 passed.

## Notes for review

- Adding a mount changes the `mount_snapshot` drift key, so every live sandbox recycles on its next touch after deploy. That is the intended migration path — there is no separate migration step — but it is a fleet-wide recycle and worth a deliberate eye.
- `root/.cache` is deliberately **not** in the dropped set: it holds browser binaries and package caches that are expensive to re-fetch, so it stays durable state. Named as an accepted residual rather than silently included.
- Related: #2027 (salvage timeout on large writable layers), #923 (bounding the live writable layer), #1587 (`/tmp` → `/workspace` auto-stage), #2139 (snapshot pool reclaim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
