### PR TITLE
fix(tools): workflow script contract reader returns plain text, not a JSON-escaped line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   `items`, non-dict property values), and a registry-wide regression fence runs
   the real `token_counter` over every registered tool's rendered schema.
 
+- `get_workflow_script_contract` now returns the authoring contract as a plain-text `ToolResult` instead of a `{"contract": …}` dict, so the ~4KB multi-line manual reaches the model as real prose rather than a JSON-escaped single line (#2294, per the #2291 convention).
 - Restore the context window's history floor: `window_min` again bounds
   RETAINED HISTORY only, so the per-request prelude (system prompt + tool
   schemas + reserves) is subtracted from `window_max` alone. Subtracting it

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -55,7 +55,7 @@ from aios.models.workflows import (
 from aios.services import sessions as sessions_service
 from aios.services import workflows as wf_service
 from aios.tools.input import tool_input
-from aios.tools.registry import registry
+from aios.tools.registry import ToolResult, registry
 from aios.tools.schema_diet import slim_tool_schema
 
 # Heavy snapshot fields the model already sent (or doesn't need echoed back); trimmed
@@ -298,15 +298,24 @@ async def list_run_events_handler(session_id: str, arguments: dict[str, Any]) ->
 
 async def get_workflow_script_contract_handler(
     session_id: str, arguments: dict[str, Any]
-) -> dict[str, Any]:
+) -> ToolResult:
     """The on-demand half of the #2294 progressive disclosure.
 
     Pure constant read — no pool, no account, no session state. This is the
     surface the trimmed ``script`` field description points at, so the authoring
     manual stays genuinely reachable while costing nothing per request.
+
+    Plain-string ``ToolResult`` content, never ``{"contract": text}`` (the #2291
+    convention): ``_shape_tool_result`` passes str content through verbatim ONLY
+    for a ``ToolResult``, and every other return type — a bare ``str`` included —
+    falls to its ``json.dumps`` arm, which escapes all 53 newlines and collapses
+    the contract into a single unreadable line. That would be especially perverse
+    here: this document exists to be READ as formatted prose, with a code block.
+    It also keeps the contract spillable as a real multi-line file if it ever
+    outgrows ``tool_result_max_chars`` (#2292 lowers that to 16k).
     """
     tool_input(_NoArgs, arguments)
-    return {"contract": WORKFLOW_SCRIPT_CONTRACT}
+    return ToolResult(content=WORKFLOW_SCRIPT_CONTRACT)
 
 
 async def resume_gate_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -34,7 +34,7 @@ from aios.models.workflows import (
 )
 from aios.tools import workflow_management as wm
 from aios.tools.invoke import ToolBail, invoke_builtin
-from aios.tools.registry import registry
+from aios.tools.registry import ToolResult, registry
 
 _DT = datetime(2026, 1, 1, tzinfo=UTC)
 _SCRIPT_CONTRACT_TOKENS = ("async def main", "agent", "tool", "gate", "parallel", "pipeline", "log")
@@ -125,9 +125,12 @@ class TestWorkflowScriptContractDiscovery:
         assert "Injected capability API" not in json.dumps(tool.parameters_schema)
 
     async def test_contract_tool_serves_the_contract(self) -> None:
+        # Plain-string ToolResult, per the #2291 convention — a dict return would
+        # reach the model as one JSON-escaped line (see test_workflow_tool_schema_budget).
         result = await invoke_builtin("ses_1", "get_workflow_script_contract", {})
-        assert isinstance(result, dict)
-        _assert_script_contract_present(result["contract"])
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        _assert_script_contract_present(result.content)
 
 
 class TestSchemaRejectsInjectedTrustedIds:

--- a/tests/unit/test_workflow_tool_schema_budget.py
+++ b/tests/unit/test_workflow_tool_schema_budget.py
@@ -30,10 +30,11 @@ import pytest
 import aios.tools  # noqa: F401 - trigger built-in registration side effects
 from aios.harness.step_context import _inject_workflow_script_contract
 from aios.harness.tokens import approx_tokens
+from aios.harness.tool_dispatch import _shape_tool_result, _ToolCall
 from aios.models.workflows import WORKFLOW_SCRIPT_CONTRACT, WorkflowCreate
 from aios.tools.input import tool_input
 from aios.tools.invoke import ToolBail, prepare_builtin
-from aios.tools.registry import openai_tool_entry, registry
+from aios.tools.registry import ToolResult, openai_tool_entry, registry
 from aios.tools.workflow_management import (
     SCRIPT_CONTRACT_TOOL_NAME,
     WORKFLOW_AUTHORING_TOOL_NAMES,
@@ -133,7 +134,48 @@ def test_script_field_points_at_a_real_tool() -> None:
 
 async def test_contract_tool_returns_the_whole_contract() -> None:
     result = await get_workflow_script_contract_handler("sess_x", {})
-    assert result == {"contract": WORKFLOW_SCRIPT_CONTRACT}
+    assert isinstance(result, ToolResult)
+    assert result.content == WORKFLOW_SCRIPT_CONTRACT
+
+
+async def test_contract_reaches_the_model_as_real_multi_line_text() -> None:
+    """The #2291 convention: a plain-string ``ToolResult``, never a dict.
+
+    ``_shape_tool_result`` JSON-encodes every non-``ToolResult`` return, escaping
+    each newline into a literal ``\\n`` and collapsing this ~4KB document — which
+    exists to be read as formatted prose, code block included — onto one line. A
+    bare ``str`` return is wrong the same way (it hits the same arm, just
+    double-quoted), so the type is load-bearing and nothing checks it at the
+    registry boundary.
+    """
+    result = await get_workflow_script_contract_handler("sess_x", {})
+    assert isinstance(result, ToolResult)
+    assert isinstance(result.content, str)
+
+    # Drive the real shaping layer — the bug lives in the seam between the
+    # handler's return type and this function, so neither alone would catch it.
+    tc = _ToolCall(call_id="tc_1", name=SCRIPT_CONTRACT_TOOL_NAME, raw_args={}, bound_log=None)
+    content = _shape_tool_result(tc, result)["content"]
+
+    assert content == WORKFLOW_SCRIPT_CONTRACT
+    # Real newlines, not the escaped two-character sequence json.dumps emits.
+    assert "\n" in content
+    assert content.count("\n") > 40
+    assert "\\n" not in content
+    assert not content.startswith('"')
+    assert "async def main(input)" in content
+
+
+async def test_a_dict_return_would_have_collapsed_the_contract() -> None:
+    """Negative control: proves the assertion above discriminates.
+
+    Without this, a future refactor back to ``{"contract": text}`` could pass the
+    test above if the shaping layer changed underneath it.
+    """
+    tc = _ToolCall(call_id="tc_1", name=SCRIPT_CONTRACT_TOOL_NAME, raw_args={}, bound_log=None)
+    collapsed = _shape_tool_result(tc, {"contract": WORKFLOW_SCRIPT_CONTRACT})["content"]
+    assert "\\n" in collapsed
+    assert "\n" not in collapsed
 
 
 def _offered(*names: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Follow-up to #2294 (merged as #2303, `6fb64d8`). The `get_workflow_script_contract` reader that #2294 introduced returned `{"contract": WORKFLOW_SCRIPT_CONTRACT}` — a plain dict. `_shape_tool_result` JSON-encodes every non-`ToolResult` return, so the ~4KB authoring manual reached the model as **a single line with all 53 newlines escaped to literal `\n`**.

That is the same pathology #2291 fixed for `search_events`/`memory_search` (merged as #2299, `4e9519d`), and it is worse here than in the general case: this tool's entire reason to exist is that #2294 moved the authoring contract *out* of the always-on tool schema so the model could **read it as formatted prose on demand** — headings, a bullet-structured capability API, and a fenced Python code block. Delivering it as one escaped line degrades exactly the surface the parent PR built.

Caught in adversarial review of #2303, but the merge landed first, so this is on `master` now.

## The fix

```python
return ToolResult(content=WORKFLOW_SCRIPT_CONTRACT)
```

matching what `search_events`/`memory_search` now do. Three layers then behave correctly:

- `_shape_tool_result` passes `str` content through **verbatim** — but *only* for a `ToolResult`;
- `_envelope_from_result` hands the in-sandbox CLI the raw text rather than a JSON blob; and
- `cap_tool_result_content` would spill it as a real multi-line, greppable file instead of one enormous line.

That last one is the forward risk this closes: **#2292 lowers `tool_result_max_chars` from 200k to 16k.** The contract is ~4KB today so it stays inline either way, but any growth against that threshold would have spilled it as an unreadable single line — the precise failure mode the 333KB jarbot-org incident produced.

Note a bare `str` return would be wrong the *same* way (it hits the same `json.dumps` arm, just double-quoted). `ToolResult` is the only correct shape, and nothing type-checks this at the registry boundary — which is why the tests below drive the real seam rather than the handler alone.

## Substrate state changes

None — code-only change.

## Test plan

- **`test_contract_reaches_the_model_as_real_multi_line_text`** — drives the actual handler → `_shape_tool_result` chain (the seam the bug lived in, so neither layer alone would have caught it) and asserts the shaped event content is the contract verbatim, carries real newlines (>40 of them), contains no escaped `\n`, isn't a quoted JSON string literal, and still contains `async def main(input)`.
- **`test_a_dict_return_would_have_collapsed_the_contract`** — negative control, so the assertion above can't silently stop discriminating if the shaping layer changes underneath it: a dict return still yields escaped `\n` and zero real newlines.
- `test_contract_tool_returns_the_whole_contract` and `test_contract_tool_serves_the_contract` (through `invoke_builtin`) updated to the `ToolResult` shape.
- `uv run mypy src tests` — clean (1045 files). The handler's return type is now `ToolResult`, so the registry's `ToolHandler` union keeps this honest.
- `uv run ruff check src tests && uv run ruff format --check src tests` — clean.
- `uv run pytest tests/unit -q -n 4` — **5,592 passed**.

## Risk / rollback

Minimal: one handler's return type, no schema, no migration, no substrate. The rendered tool schemas are byte-identical to what #2303 merged (this changes the *result* shape, not the *parameters*), so #2294's budget test is unaffected. Rollback is a plain revert.

Refs #2294, #2291, #2292.
