### PR TITLE
fix(sandbox): read managed-image inspect as JSON, not a format template

### DIFF
--- a/.msg2
+++ b/.msg2
@@ -1,0 +1,44 @@
+fix(sandbox): read managed-image inspect as JSON, not a format template
+
+Docker's `inspect --format` runs under `missingkey=error`. Naming a key an
+image does not carry aborts the template FOR THAT IMAGE and drops it from
+stdout; `list_managed_images` then cannot account for the listed id, and its
+COMPLETE-OR-RAISE contract correctly refuses. So a single such image fails
+the whole enumeration, which fails the GC tick — hourly, indefinitely.
+
+In production one image did exactly that. Every `docker import` result (i.e.
+every flattened snapshot) carries no `Parent` key at all under the containerd
+image store, and `{{.Parent}}` errors on it:
+
+    template parsing error: executing "" at <.Parent>:
+    map has no entry for key "Parent"
+
+One such image among 457 managed images stopped all reclamation while ~72 GB
+of superseded residue accumulated on a host that went on to fill. Because the
+single-id re-probe uses a different format that never touches `.Parent`, it
+succeeded — so the failure surfaced as the maximally confusing "omitted by
+the batch inspect but still exists".
+
+The codebase had already hit this class once, on `.Config.Labels` for
+label-less images, and worked around that instance by fetching the whole
+`Config` object. `.Parent` was the same bug wearing a different key.
+
+Read the JSON instead of templating it: an absent key becomes `None` rather
+than an error, which is also the honest answer, since a flattened image
+genuinely has no parent. That removes the class rather than one more
+instance of it.
+
+Verified against the real daemon: a batch containing a vanished id exits
+nonzero but still writes a well-formed array of the images it did find, so
+the existing proved-absent reconciliation is unaffected.
+
+COMPLETE-OR-RAISE is preserved, not traded away — unparseable or non-array
+output is indeterminate and still fails closed, because reading it as empty
+would report every id in the batch as absent and the GC reconciles DB
+pointers by absence (#2138).
+
+Tests pin the class, not the key: the absent-`Parent` regression, one odd
+image not poisoning its batch, degenerate records (missing/null/wrong-typed
+fields) still yielding usable entries, both fail-closed paths, and a guard
+against reintroducing `--format` on the batch call. Verified as a negative
+control: 7 of the 9 fail without the fix.

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -926,17 +926,32 @@ class DockerBackend:
                 )
             return []
 
-        # Whole-Config form for labels — see ``_inspect_image_fields`` on why a
-        # direct ``{{json .Config.Labels}}`` errors on label-less images under
-        # Docker inspect's ``missingkey=error``.
-        fmt = "{{.Id}}\t{{.Parent}}\t{{.Size}}\t{{json .RepoTags}}\t{{json .Config}}"
+        # Parsed as JSON, NOT via ``--format``. Docker's inspect templates run
+        # under ``missingkey=error``, so naming a key an image does not carry
+        # aborts the template FOR THAT IMAGE and drops it from stdout. The
+        # image then fails the completeness reconciliation below, which fails
+        # the whole enumeration, which kills the GC tick — hourly, forever,
+        # for as long as one such image exists.
+        #
+        # That is not hypothetical: an image built by ``docker import`` (every
+        # flattened snapshot) has NO ``Parent`` key at all under the containerd
+        # image store, and a single one of them was enough to stop all
+        # reclamation on a production host while ~72 GB of superseded residue
+        # accumulated. The previous code had already hit this class once, on
+        # ``.Config.Labels`` for label-less images, and worked around it by
+        # fetching the whole ``Config`` object; ``.Parent`` was the same bug
+        # wearing a different key.
+        #
+        # Reading the JSON removes the class rather than the instance: an
+        # absent key becomes ``None`` instead of an error, which is also the
+        # honest answer (a flattened image genuinely has no parent).
         out: list[ManagedImage] = []
         resolved: set[str] = set()
         for offset in range(0, len(image_ids), _MANAGED_INSPECT_BATCH_SIZE):
             batch = image_ids[offset : offset + _MANAGED_INSPECT_BATCH_SIZE]
             try:
                 rc, stdout_bytes, stderr_bytes = await run_docker_cli(
-                    ["docker", "image", "inspect", "--format", fmt, *batch]
+                    ["docker", "image", "inspect", *batch]
                 )
             except SandboxBackendError as err:
                 # Unreachable/timed-out daemon: nothing about this batch is
@@ -962,15 +977,55 @@ class DockerBackend:
                     exit_code=rc,
                     stderr=stderr_bytes.decode("utf-8", errors="replace").strip(),
                 )
-            for line in stdout_bytes.decode("utf-8").splitlines():
-                if not line.strip():
+            # A batch containing a vanished id exits nonzero but still writes a
+            # well-formed array of the images it DID find, so the payload is
+            # parsed either way; the per-id reconciliation below settles the
+            # difference. Unparseable output is indeterminate, not empty —
+            # treating it as empty would report every id in the batch as
+            # absent, and the GC reconciles DB pointers by absence.
+            raw = stdout_bytes.decode("utf-8", errors="replace").strip()
+            try:
+                records = json.loads(raw) if raw else []
+            except json.JSONDecodeError as err:
+                log.warning(
+                    "sandbox.image_enumeration_incomplete",
+                    offset=offset,
+                    size=len(batch),
+                    reason="unparseable_inspect_payload",
+                )
+                raise SandboxBackendError(
+                    f"incomplete managed image enumeration: inspect batch at offset {offset} "
+                    "returned unparseable JSON"
+                ) from err
+            if not isinstance(records, list):
+                raise SandboxBackendError(
+                    f"incomplete managed image enumeration: inspect batch at offset {offset} "
+                    f"returned {type(records).__name__}, expected a list"
+                )
+            for record in records:
+                if not isinstance(record, dict):
                     continue
-                parts = line.split("\t", 4)
-                image_id = parts[0].strip()
-                parent = parts[1].strip() if len(parts) > 1 else ""
-                size = int(parts[2]) if len(parts) > 2 and parts[2].strip().isdigit() else 0
-                repo_tags = _parse_json_str_list(parts[3]) if len(parts) > 3 else ()
-                img_labels = _labels_from_config_json(parts[4]) if len(parts) > 4 else {}
+                image_id = str(record.get("Id") or "").strip()
+                if not image_id:
+                    continue
+                # ``Parent`` is absent (not empty) on imported/flattened
+                # images; ``Config`` can be null on some images.
+                parent = str(record.get("Parent") or "").strip()
+                raw_size = record.get("Size")
+                size = raw_size if isinstance(raw_size, int) else 0
+                raw_tags = record.get("RepoTags")
+                repo_tags = (
+                    tuple(str(tag) for tag in raw_tags if isinstance(tag, str))
+                    if isinstance(raw_tags, list)
+                    else ()
+                )
+                config = record.get("Config")
+                raw_labels = config.get("Labels") if isinstance(config, dict) else None
+                img_labels = (
+                    {str(k): str(v) for k, v in raw_labels.items()}
+                    if isinstance(raw_labels, dict)
+                    else {}
+                )
                 resolved.add(image_id)
                 out.append(
                     ManagedImage(
@@ -1266,20 +1321,6 @@ def _labels_from_config_json(raw: str) -> dict[str, str]:
     if not isinstance(labels, dict):
         return {}
     return {str(k): str(v) for k, v in labels.items()}
-
-
-def _parse_json_str_list(raw: str) -> tuple[str, ...]:
-    """Parse a ``{{json .RepoTags}}`` field into a tuple of tags (``()`` if none)."""
-    raw = raw.strip()
-    if not raw or raw in ("null", "<no value>"):
-        return ()
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return ()
-    if not isinstance(parsed, list):
-        return ()
-    return tuple(str(item) for item in parsed)
 
 
 def _is_no_such_container(stderr: str) -> bool:

--- a/tests/unit/sandbox/test_docker_managed_chunking.py
+++ b/tests/unit/sandbox/test_docker_managed_chunking.py
@@ -21,15 +21,21 @@ async def test_list_managed_images_fails_closed_when_any_inspect_batch_fails(
     async def fake_run(argv: list[str], **kwargs: object) -> tuple[int, bytes, bytes]:
         if argv[1] == "images":
             return 0, ("\n".join(ids) + "\n").encode(), b""
-        batch = argv[5:]
+        batch = argv[3:]
         inspect_batches.append(batch)
         if len(inspect_batches) == 2:
             raise SandboxBackendError("timed out")
-        lines = [
-            f'{iid}\t\t1\t["tag-{iid}"]\t{json.dumps({"Labels": {"aios.session_id": iid}})}'
+        payload = [
+            {
+                "Id": iid,
+                "Parent": "",
+                "Size": 1,
+                "RepoTags": [f"tag-{iid}"],
+                "Config": {"Labels": {"aios.session_id": iid}},
+            }
             for iid in batch
         ]
-        return 0, ("\n".join(lines) + "\n").encode(), b""
+        return 0, json.dumps(payload).encode(), b""
 
     monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
     with pytest.raises(SandboxBackendError, match="incomplete managed image enumeration"):
@@ -55,7 +61,7 @@ async def test_gc_does_not_reconcile_absence_from_failed_image_inspect_batch(
         inspect_calls += 1
         if inspect_calls == 2:
             raise SandboxBackendError("timed out")
-        batch = argv[5:]
+        batch = argv[3:]
         lines = [f'{iid}\t\t1\t["tag-{iid}"]\t{{"Labels": {{}}}}' for iid in batch]
         return 0, ("\n".join(lines) + "\n").encode(), b""
 
@@ -81,13 +87,29 @@ async def test_gc_does_not_reconcile_absence_from_failed_image_inspect_batch(
     reconcile.assert_not_awaited()
 
 
-def _managed_line(iid: str) -> str:
-    return f'{iid}\t\t1\t["tag-{iid}"]\t{json.dumps({"Labels": {}})}'
+def _managed_record(iid: str) -> dict[str, object]:
+    """One entry as ``docker image inspect`` really emits it.
+
+    ``Parent`` is present-but-empty here (the ordinary layered case). The
+    absent-key case — every ``docker import``/flattened image — has its own
+    test; it is what used to abort the template and kill the whole tick.
+    """
+    return {
+        "Id": iid,
+        "Parent": "",
+        "Size": 1,
+        "RepoTags": [f"tag-{iid}"],
+        "Config": {"Labels": {}},
+    }
+
+
+def _managed_payload(iids: list[str]) -> bytes:
+    return json.dumps([_managed_record(iid) for iid in iids]).encode()
 
 
 def _is_single_probe(argv: list[str]) -> bool:
     """The verified-negative probe: ``_inspect_image_fields``'s RootFS format."""
-    return argv[1:3] == ["image", "inspect"] and "RootFS" in argv[4]
+    return argv[1:3] == ["image", "inspect"] and "--format" in argv
 
 
 @pytest.mark.asyncio
@@ -109,8 +131,7 @@ async def test_list_managed_images_fails_closed_when_a_batch_silently_omits_a_li
         if _is_single_probe(argv):
             # The omitted image is alive and well.
             return 0, f"{argv[5]}\t1\t1\t{json.dumps({'Labels': {}})}\n".encode(), b""
-        lines = [_managed_line(iid) for iid in argv[5:] if iid != dropped]
-        return 0, ("\n".join(lines) + "\n").encode(), b""
+        return 0, _managed_payload([i for i in argv[3:] if i != dropped]), b""
 
     monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
     with pytest.raises(SandboxBackendError, match="incomplete managed image enumeration"):
@@ -135,8 +156,8 @@ async def test_list_managed_images_omits_only_an_image_proved_absent(
             return 0, ("\n".join(ids) + "\n").encode(), b""
         if _is_single_probe(argv):
             return 1, b"", b"Error: No such image: " + argv[5].encode()
-        lines = [_managed_line(iid) for iid in argv[5:] if iid != vanished]
-        return 1, ("\n".join(lines) + "\n").encode(), b"Error: No such image: " + vanished.encode()
+        payload = _managed_payload([i for i in argv[3:] if i != vanished])
+        return 1, payload, b"Error: No such image: " + vanished.encode()
 
     monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
     images = await DockerBackend().list_managed_images(instance_id="test")
@@ -159,8 +180,7 @@ async def test_gc_does_not_reconcile_absence_from_a_silently_truncated_listing(
             return 0, ("\n".join(ids) + "\n").encode(), b""
         if _is_single_probe(argv):
             return 0, f"{argv[5]}\t1\t1\t{json.dumps({'Labels': {}})}\n".encode(), b""
-        lines = [_managed_line(iid) for iid in argv[5:] if iid != dropped]
-        return 0, ("\n".join(lines) + "\n").encode(), b""
+        return 0, _managed_payload([i for i in argv[3:] if i != dropped]), b""
 
     monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
     registry = SandboxRegistry(DockerBackend())

--- a/tests/unit/sandbox/test_gc_absence_completeness.py
+++ b/tests/unit/sandbox/test_gc_absence_completeness.py
@@ -39,8 +39,24 @@ from aios.sandbox.registry import GcPressureResult, SandboxRegistry
 _NOW = datetime(2026, 6, 10, tzinfo=UTC)
 
 
-def _managed_line(iid: str) -> str:
-    return f'{iid}\t\t1\t["tag-{iid}"]\t{json.dumps({"Labels": {}})}'
+def _managed_record(iid: str) -> dict[str, object]:
+    """One entry as ``docker image inspect`` really emits it.
+
+    ``Parent`` is present-but-empty here (the ordinary layered case). The
+    absent-key case — every ``docker import``/flattened image — has its own
+    test; it is what used to abort the template and kill the whole tick.
+    """
+    return {
+        "Id": iid,
+        "Parent": "",
+        "Size": 1,
+        "RepoTags": [f"tag-{iid}"],
+        "Config": {"Labels": {}},
+    }
+
+
+def _managed_payload(iids: list[str]) -> bytes:
+    return json.dumps([_managed_record(iid) for iid in iids]).encode()
 
 
 # ─── Finding 1: the listing layer itself must prove completeness ────────────
@@ -67,8 +83,7 @@ async def test_transiently_empty_listing_is_not_reported_as_an_empty_host(
             if listings == 1:
                 return 0, b"", b""
             return 0, ("\n".join(ids) + "\n").encode(), b""
-        lines = [_managed_line(iid) for iid in argv[5:]]
-        return 0, ("\n".join(lines) + "\n").encode(), b""
+        return 0, _managed_payload(list(argv[3:])), b""
 
     monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
 
@@ -115,8 +130,7 @@ async def test_nonempty_listing_does_not_pay_for_a_second_read(
         if argv[1] == "images":
             listings += 1
             return 0, ("\n".join(ids) + "\n").encode(), b""
-        lines = [_managed_line(iid) for iid in argv[5:]]
-        return 0, ("\n".join(lines) + "\n").encode(), b""
+        return 0, _managed_payload(list(argv[3:])), b""
 
     monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
 
@@ -165,8 +179,7 @@ async def test_gc_does_not_clear_every_pointer_from_a_transiently_empty_listing(
             if listings == 1:
                 return 0, b"", b""
             return 0, b"sha256:0000\n", b""
-        lines = [_managed_line(iid) for iid in argv[5:]]
-        return 0, ("\n".join(lines) + "\n").encode(), b""
+        return 0, _managed_payload(list(argv[3:])), b""
 
     monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
     registry = SandboxRegistry(DockerBackend())

--- a/tests/unit/sandbox/test_gc_enumeration_missing_keys.py
+++ b/tests/unit/sandbox/test_gc_enumeration_missing_keys.py
@@ -1,0 +1,187 @@
+"""Managed-image enumeration must survive images that omit inspect keys.
+
+Docker's ``inspect --format`` runs under ``missingkey=error``: naming a key an
+image does not carry aborts the template FOR THAT IMAGE, which silently drops
+it from stdout. ``list_managed_images`` then cannot account for the id, and
+its COMPLETE-OR-RAISE contract correctly refuses — so one such image fails the
+whole enumeration, which fails the GC tick, hourly, for as long as it exists.
+
+That is how it presented in production: a single image built by ``docker
+import`` (every flattened snapshot; they carry no ``Parent`` key at all under
+the containerd image store) among 457 managed images stopped ALL reclamation
+while superseded residue accumulated. The single-id re-probe used a different
+format that never touched ``.Parent``, so it succeeded — which is why the
+failure surfaced as the maximally confusing "omitted by the batch inspect but
+still exists".
+
+The fix reads the inspect JSON instead of templating it, so an absent key is
+``None`` rather than an error. These tests pin the class, not just the one
+key: any field may be missing, null, or the wrong type, and enumeration must
+still return a usable record for every id.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from aios.sandbox.backends import docker as docker_backend
+from aios.sandbox.backends.base import SandboxBackendError
+from aios.sandbox.backends.docker import DockerBackend
+
+_LIST_ARGV_HEAD = "images"
+
+
+def _fake_cli(
+    listing: list[str], records: list[dict[str, object]], *, rc: int = 0
+) -> Callable[..., Awaitable[tuple[int, bytes, bytes]]]:
+    """Fake ``run_docker_cli`` serving one listing and one inspect batch."""
+
+    async def run(argv: list[str], **_kw: object) -> tuple[int, bytes, bytes]:
+        if argv[1] == _LIST_ARGV_HEAD:
+            return 0, ("\n".join(listing) + "\n").encode(), b""
+        if "--format" in argv:  # the single-id verified-negative probe
+            return 1, b"", b"Error: No such image: " + argv[-1].encode()
+        return rc, json.dumps(records).encode(), b""
+
+    return run
+
+
+@pytest.mark.asyncio
+async def test_image_without_a_parent_key_does_not_fail_enumeration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE production regression. A ``docker import`` image has no ``Parent``.
+
+    Before the fix this raised ``incomplete managed image enumeration`` and
+    took every GC tick down with it.
+    """
+    flattened = {
+        "Id": "sha256:flat",
+        # NOTE: no "Parent" key at all — not empty, absent.
+        "Size": 6_377_787_303,
+        "RepoTags": ["aios-sbx-default-sess_x:latest"],
+        "Config": {"Labels": {"aios.managed": "true", "aios.flattened": "true"}},
+    }
+    monkeypatch.setattr(docker_backend, "run_docker_cli", _fake_cli(["sha256:flat"], [flattened]))
+
+    images = await DockerBackend().list_managed_images(instance_id="default")
+
+    assert len(images) == 1
+    assert images[0].image_id == "sha256:flat"
+    assert images[0].parent_id is None, "a flattened image genuinely has no parent"
+    assert images[0].size_bytes == 6_377_787_303
+    assert images[0].labels["aios.flattened"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_one_odd_image_does_not_poison_the_rest_of_the_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The blast radius that made this so costly: 1 bad image in 457 stopped
+    reclamation for all of them."""
+    records: list[dict[str, object]] = [
+        {
+            "Id": f"sha256:{i:04d}",
+            "Parent": "",
+            "Size": 10,
+            "RepoTags": [f"tag-{i}"],
+            "Config": {"Labels": {}},
+        }
+        for i in range(20)
+    ]
+    records.append({"Id": "sha256:flat", "Size": 99, "RepoTags": [], "Config": None})
+    listing = [str(r["Id"]) for r in records]
+    monkeypatch.setattr(docker_backend, "run_docker_cli", _fake_cli(listing, records))
+
+    images = await DockerBackend().list_managed_images(instance_id="default")
+
+    assert len(images) == 21
+    assert {img.image_id for img in images} == set(listing)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "record",
+    [
+        {"Id": "sha256:a"},  # everything but the id missing
+        {"Id": "sha256:a", "Parent": None, "Size": None, "RepoTags": None, "Config": None},
+        {"Id": "sha256:a", "Size": "not-an-int", "RepoTags": "not-a-list", "Config": 7},
+        {"Id": "sha256:a", "RepoTags": ["ok", 5, None], "Config": {"Labels": None}},
+    ],
+    ids=["only-id", "all-null", "wrong-types", "mixed-tag-types"],
+)
+async def test_degenerate_records_still_yield_a_usable_entry(
+    monkeypatch: pytest.MonkeyPatch, record: dict[str, object]
+) -> None:
+    """Enumeration must not raise on any shape docker might emit: refusing is
+    how the tick dies, and the tick dying is the whole failure mode."""
+    monkeypatch.setattr(docker_backend, "run_docker_cli", _fake_cli(["sha256:a"], [record]))
+
+    images = await DockerBackend().list_managed_images(instance_id="default")
+
+    assert len(images) == 1
+    assert images[0].image_id == "sha256:a"
+    assert isinstance(images[0].size_bytes, int)
+    assert isinstance(images[0].labels, dict)
+    assert isinstance(images[0].repo_tags, tuple)
+
+
+@pytest.mark.asyncio
+async def test_unparseable_payload_still_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The COMPLETE-OR-RAISE contract is preserved, not traded away.
+
+    Output we cannot parse is INDETERMINATE, not empty — reading it as empty
+    would report every id in the batch as absent, and the GC reconciles DB
+    pointers by absence (aios#2138).
+    """
+
+    async def run(argv: list[str], **_kw: object) -> tuple[int, bytes, bytes]:
+        if argv[1] == _LIST_ARGV_HEAD:
+            return 0, b"sha256:a\n", b""
+        return 0, b"this is not json", b""
+
+    monkeypatch.setattr(docker_backend, "run_docker_cli", run)
+
+    with pytest.raises(SandboxBackendError, match="incomplete managed image enumeration"):
+        await DockerBackend().list_managed_images(instance_id="default")
+
+
+@pytest.mark.asyncio
+async def test_non_list_payload_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run(argv: list[str], **_kw: object) -> tuple[int, bytes, bytes]:
+        if argv[1] == _LIST_ARGV_HEAD:
+            return 0, b"sha256:a\n", b""
+        return 0, b'{"Id": "sha256:a"}', b""  # object, not array
+
+    monkeypatch.setattr(docker_backend, "run_docker_cli", run)
+
+    with pytest.raises(SandboxBackendError, match="incomplete managed image enumeration"):
+        await DockerBackend().list_managed_images(instance_id="default")
+
+
+@pytest.mark.asyncio
+async def test_batch_no_longer_passes_a_format_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guards the fix itself: reintroducing ``--format`` on the BATCH call
+    reintroduces the missingkey class. The single-id probe may still use one."""
+    seen: list[list[str]] = []
+
+    async def run(argv: list[str], **_kw: object) -> tuple[int, bytes, bytes]:
+        seen.append(argv)
+        if argv[1] == _LIST_ARGV_HEAD:
+            return 0, b"sha256:a\n", b""
+        return 0, json.dumps([{"Id": "sha256:a", "Config": {"Labels": {}}}]).encode(), b""
+
+    monkeypatch.setattr(docker_backend, "run_docker_cli", run)
+    await DockerBackend().list_managed_images(instance_id="default")
+
+    batch_calls = [a for a in seen if a[1:3] == ["image", "inspect"]]
+    assert batch_calls, "the batch inspect must have run"
+    for argv in batch_calls:
+        assert "--format" not in argv


### PR DESCRIPTION
## The defect

Docker's `inspect --format` runs under `missingkey=error`. Naming a key an image does not carry **aborts the template for that image** and drops it from stdout. `list_managed_images` then cannot account for the listed id, and its COMPLETE-OR-RAISE contract (#2138) correctly refuses — so **one such image fails the whole enumeration, which fails the GC tick, hourly, indefinitely.**

The batch format was:

```
{{.Id}}\t{{.Parent}}\t{{.Size}}\t{{json .RepoTags}}\t{{json .Config}}
```

Every image produced by `docker import` — i.e. **every flattened snapshot** — has no `Parent` key at all under the containerd image store:

```
$ docker image inspect --format '{{.Id}}	{{.Parent}}	...' <flattened image>
template parsing error: template: :1:10: executing "" at <.Parent>:
map has no entry for key "Parent"
```

In production a single such image among **457** managed images stopped all reclamation while superseded residue accumulated on a host that went on to fill. Because the single-id re-probe (`_inspect_image_fields`) uses a different format that never touches `.Parent`, it succeeded — so the failure surfaced as the maximally confusing *"omitted by the batch inspect but still exists"*, with the log line naming an image that inspects perfectly by hand.

This is the same class the codebase already hit once, on `.Config.Labels` for label-less images. That instance was worked around by fetching the whole `Config` object — the existing comment even documents the hazard. `.Parent` was the same bug wearing a different key.

## The fix

Read the inspect JSON instead of templating it. An absent key becomes `None` rather than an error — which is also the honest answer, since a flattened image genuinely has no parent. That removes the class rather than one more instance of it, and no future key addition can reintroduce it.

Verified against a real daemon that the load-bearing assumption holds: a batch containing a vanished id exits nonzero but **still writes a well-formed JSON array of the images it did find**, so the existing proved-absent reconciliation is unaffected.

**COMPLETE-OR-RAISE is preserved, not traded away.** Unparseable or non-array output is *indeterminate* and still fails closed — reading it as empty would report every id in the batch as absent, and the GC reconciles DB pointers by absence. That inversion is exactly what #2138 exists to prevent.

Also removes `_parse_json_str_list`, now unreferenced.

## Tests

`tests/unit/sandbox/test_gc_enumeration_missing_keys.py` pins the **class**, not the one key:

- the absent-`Parent` production regression;
- one odd image not poisoning the other 20 in its batch (the blast radius that made this so costly);
- degenerate records — missing, null, and wrong-typed `Size`/`RepoTags`/`Config`/`Labels` — still yielding a usable entry, because *refusing* is how the tick dies;
- both fail-closed paths (unparseable, non-array);
- a guard asserting the batch call carries no `--format`, so the fix cannot be undone by reflex.

**Negative control:** with the source fix reverted, 7 of the 9 fail (the two fail-closed tests correctly pass either way). The existing enumeration tests in `test_gc_absence_completeness.py` and `test_docker_managed_chunking.py` are updated to emit the real JSON shape.

`mypy` / `ruff check` / `ruff format` clean; full unit suite 5599 passed.

## Relationship to #2305

Independent and mergeable in either order (they touch different regions of `backends/docker.py`), but this one is the more urgent of the two: **#2305 shrinks snapshots, and this restores the ability to reclaim what already exists.** Related: #2139 (pool reclaim enforced by a single log line), #2074 / #2057 (prior GC-tick-death incidents in this same subsystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
