### PR TITLE
fix: emit items:{} on dieted opaque arrays so litellm token_counter and OpenAI accept them (#2294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Fix the #2294 schema-diet production incident: the dieted opaque arrays
+  rendered as bare `{"type": "array"}` with no `items`, and litellm's
+  `token_counter` → `_format_type` dereferences `props['items']`
+  unconditionally, so `prelude_overhead_local` raised `KeyError: 'items'` on
+  every step of every workflow-capable agent (the fleet was rolled back).
+  Opaque arrays now render as `{"type": "array", "items": {}}` — also required
+  for OpenAI provider validity. `sanitize_mcp_schema` closes the same defect
+  class for untrusted third-party MCP schemas (missing/tuple-form/boolean
+  `items`, non-dict property values), and a registry-wide regression fence runs
+  the real `token_counter` over every registered tool's rendered schema.
+
 - Restore the context window's history floor: `window_min` again bounds
   RETAINED HISTORY only, so the per-request prelude (system prompt + tool
   schemas + reserves) is subtracted from `window_max` alone. Subtracting it

--- a/src/aios/mcp/schema.py
+++ b/src/aios/mcp/schema.py
@@ -30,24 +30,47 @@ MCP_ANNOTATIONS_KEY = "_mcp_annotations"
 
 
 def sanitize_mcp_schema(node: Any) -> Any:
-    """Drop the ``type`` keyword next to ``anyOf``/``oneOf`` (the union carries the real shape).
+    """Rewrite an untrusted schema into the subset litellm + providers tolerate.
 
-    Only the JSON Schema ``type`` **keyword** — whose value is a type name
-    (``"string"``) or a list of them (``["string", "null"]``) — is redundant beside
-    a union. A property literally **named** ``type`` (its value is a sub-schema
-    ``dict``) inside a ``properties`` map is a parameter, not a keyword, and must be
-    preserved even when a sibling property is named ``anyOf``/``oneOf``; aios
-    sanitizes untrusted third-party tool schemas, so dropping it would silently
-    corrupt a valid tool and make the model call it wrong.
+    Three repairs, applied recursively:
+
+    * Drop the ``type`` keyword next to ``anyOf``/``oneOf`` (the union carries
+      the real shape). Only the JSON Schema ``type`` **keyword** — whose value is
+      a type name (``"string"``) or a list of them (``["string", "null"]``) — is
+      redundant beside a union. A property literally **named** ``type`` (its
+      value is a sub-schema ``dict``) inside a ``properties`` map is a parameter,
+      not a keyword, and must be preserved even when a sibling property is named
+      ``anyOf``/``oneOf``; aios sanitizes untrusted third-party tool schemas, so
+      dropping it would silently corrupt a valid tool and make the model call it
+      wrong.
+
+    * On ``type == "array"``, ensure ``items`` is a dict: litellm's
+      ``token_counter`` → ``_format_type`` dereferences ``props['items']``
+      unconditionally (``KeyError: 'items'`` when missing — the #2294 incident
+      class) and recurses with ``.get`` (``AttributeError`` on draft-4 tuple-form
+      ``items: [...]`` or boolean ``items``). OpenAI also rejects arrays without
+      ``items``. ``{}`` is the "anything" schema, so the repair only loosens.
+
+    * Coerce non-dict ``properties`` values (boolean schemas like ``"foo": true``)
+      to ``{}`` — litellm's ``_format_object_parameters`` calls ``.get`` on every
+      property value.
     """
     if isinstance(node, dict):
         has_union = "anyOf" in node or "oneOf" in node
         drop_type = has_union and isinstance(node.get("type"), (str, list))
-        return {
+        cleaned = {
             key: sanitize_mcp_schema(value)
             for key, value in node.items()
             if not (drop_type and key == "type")
         }
+        if cleaned.get("type") == "array" and not isinstance(cleaned.get("items"), dict):
+            cleaned["items"] = {}
+        properties = cleaned.get("properties")
+        if isinstance(properties, dict):
+            cleaned["properties"] = {
+                name: prop if isinstance(prop, dict) else {} for name, prop in properties.items()
+            }
+        return cleaned
     if isinstance(node, list):
         return [sanitize_mcp_schema(item) for item in node]
     return node

--- a/src/aios/tools/schema_diet.py
+++ b/src/aios/tools/schema_diet.py
@@ -161,10 +161,18 @@ def _opaque_array(prop: Any, description: str) -> dict[str, Any]:
     actually an array: collapsing a non-array to ``{"type": "array"}`` would be
     the one way this module could TIGHTEN the dispatch-time check, so a
     name-only match is not enough to fire.
+
+    ``items: {}`` (the "anything" schema) is load-bearing, not boilerplate —
+    do NOT re-drop it. litellm's ``token_counter`` → ``_format_type``
+    dereferences ``props['items']`` unconditionally on ``type == "array"``
+    (litellm 1.96.2, ``litellm_core_utils/token_counter.py:808``), so a bare
+    ``{"type": "array"}`` raises ``KeyError: 'items'`` on every step of every
+    agent holding the tool — the #2294 production incident. OpenAI providers
+    also reject array schemas without ``items`` ("items is required").
     """
     if isinstance(prop, dict) and not _is_array(prop):
         return prop
-    array: dict[str, Any] = {"type": "array"}
+    array: dict[str, Any] = {"type": "array", "items": {}}
     if _allows_null(prop):
         return {"anyOf": [array, {"type": "null"}], "description": description}
     return {**array, "description": description}

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -347,9 +347,11 @@ SCRIPT_FIELD_DESCRIPTION = (
     "Call `get_workflow_script_contract` for the authoring contract; `get_workflow` "
     "on an existing workflow for an example."
 )
+# Kept terse: the #2294 per-tool byte budget counts every character of these
+# three descriptions once per authoring tool. The example shows the
+# agent-config envelope shape, so it isn't named here.
 TOOLS_FIELD_DESCRIPTION = (
-    'Declared tool surface (agent-config envelope, e.g. [{"type": "bash"}]; a subset '
-    "of your own). Usually omitted."
+    'Declared tool surface (e.g. [{"type": "bash"}]; a subset of your own). Usually omitted.'
 )
 MCP_SERVERS_FIELD_DESCRIPTION = (
     "Declared MCP servers (agent-config envelope; a subset of your own). Usually omitted."

--- a/tests/unit/test_mcp_schema_sanitize.py
+++ b/tests/unit/test_mcp_schema_sanitize.py
@@ -118,6 +118,42 @@ class TestSanitizer:
         cleaned = sanitize_mcp_schema(node)
         assert "type" in cleaned["properties"]
 
+    # Arrays must always carry a dict ``items`` and properties must be dicts:
+    # litellm's ``_format_type`` does ``props['items']`` unconditionally on
+    # ``type == "array"`` (the #2294 KeyError incident class) and its
+    # ``_format_object_parameters`` calls ``.get`` on every property value;
+    # OpenAI additionally rejects array schemas without ``items``.
+
+    def test_adds_items_to_bare_array(self) -> None:
+        assert sanitize_mcp_schema({"type": "array"}) == {"type": "array", "items": {}}
+
+    def test_adds_items_to_nested_bare_array(self) -> None:
+        node = {"type": "object", "properties": {"xs": {"type": "array"}}}
+        cleaned = sanitize_mcp_schema(node)
+        assert cleaned["properties"]["xs"] == {"type": "array", "items": {}}
+
+    def test_replaces_tuple_form_items(self) -> None:
+        # Draft-4 tuple validation: ``items: [...]`` — litellm recurses with
+        # ``.get`` and crashes on the list.
+        node = {"type": "array", "items": [{"type": "string"}, {"type": "integer"}]}
+        assert sanitize_mcp_schema(node)["items"] == {}
+
+    def test_replaces_boolean_items(self) -> None:
+        node = {"type": "array", "items": True}
+        assert sanitize_mcp_schema(node)["items"] == {}
+
+    def test_keeps_dict_items_intact(self) -> None:
+        node = {"type": "array", "items": {"type": "string"}}
+        assert sanitize_mcp_schema(node) == node
+
+    def test_coerces_non_dict_property_value(self) -> None:
+        # ``"foo": true`` is a valid boolean JSON Schema ("anything"), but
+        # litellm's ``_format_object_parameters`` calls ``.get`` on it.
+        node = {"type": "object", "properties": {"foo": True, "bar": {"type": "string"}}}
+        cleaned = sanitize_mcp_schema(node)
+        assert cleaned["properties"]["foo"] == {}
+        assert cleaned["properties"]["bar"] == {"type": "string"}
+
     def test_returns_non_dict_unchanged(self) -> None:
         assert sanitize_mcp_schema("string") == "string"
         assert sanitize_mcp_schema(42) == 42
@@ -148,6 +184,39 @@ class TestMakeFunctionToolIntegration:
         assert envelope["function"]["description"] == "Update an agent"
         assert envelope["function"]["strict"] is False
         assert "type" not in envelope["function"]["parameters"]["properties"]["tools"]
+
+        count = token_counter(messages=[{"role": "user", "content": "hi"}], tools=[envelope])
+        assert count > 0
+
+    def test_bare_array_schema_survives_token_counter(self) -> None:
+        # Red on the pre-fix sanitizer: litellm's ``_format_type`` raises
+        # ``KeyError: 'items'`` on a bare array (the #2294 incident class).
+        schema = {"type": "object", "properties": {"xs": {"type": "array"}}}
+        tool = Tool(name="t", description="d", inputSchema=schema)
+        envelope = make_function_tool("mcp__s__t", tool)
+
+        assert envelope["function"]["parameters"]["properties"]["xs"]["items"] == {}
+        count = token_counter(messages=[{"role": "user", "content": "hi"}], tools=[envelope])
+        assert count > 0
+
+    def test_tuple_and_bool_items_survive_token_counter(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "pairs": {"type": "array", "items": [{"type": "string"}]},
+                "anything": {"type": "array", "items": True},
+            },
+        }
+        tool = Tool(name="t", description="d", inputSchema=schema)
+        envelope = make_function_tool("mcp__s__t", tool)
+
+        count = token_counter(messages=[{"role": "user", "content": "hi"}], tools=[envelope])
+        assert count > 0
+
+    def test_non_dict_property_value_survives_token_counter(self) -> None:
+        schema = {"type": "object", "properties": {"foo": True}}
+        tool = Tool(name="t", description="d", inputSchema=schema)
+        envelope = make_function_tool("mcp__s__t", tool)
 
         count = token_counter(messages=[{"role": "user", "content": "hi"}], tools=[envelope])
         assert count > 0

--- a/tests/unit/test_schema_diet.py
+++ b/tests/unit/test_schema_diet.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from aios.tools.schema_diet import slim_tool_schema
+from aios.tools.schema_diet import _strip_boilerplate, slim_tool_schema
 
 
 class _Nested(BaseModel):
@@ -43,8 +43,18 @@ def _slim(**kwargs: Any) -> dict[str, Any]:
 
 
 def test_opaque_field_collapses_to_a_bare_array() -> None:
+    """Opaque means ``items: {}`` — NEVER a bare ``{"type": "array"}``.
+
+    litellm's ``_format_type`` dereferences ``props['items']`` unconditionally
+    on ``type == "array"`` (``KeyError: 'items'`` on every step — the #2294
+    production incident), and OpenAI rejects array schemas without ``items``.
+    """
     slim = _slim()
-    assert slim["properties"]["servers"] == {"type": "array", "description": "Opaque."}
+    assert slim["properties"]["servers"] == {
+        "type": "array",
+        "items": {},
+        "description": "Opaque.",
+    }
 
 
 def test_collapsing_the_opaque_field_prunes_its_defs() -> None:
@@ -59,7 +69,23 @@ def test_nullable_opaque_field_keeps_its_null_arm() -> None:
     slim = slim_tool_schema(
         _Nullable.model_json_schema(), opaque_arrays={"servers": "Opaque."}, redescribe={}
     )
-    assert slim["properties"]["servers"]["anyOf"] == [{"type": "array"}, {"type": "null"}]
+    assert slim["properties"]["servers"]["anyOf"] == [
+        {"type": "array", "items": {}},
+        {"type": "null"},
+    ]
+
+
+def test_opaque_items_survive_boilerplate_stripping() -> None:
+    """``_strip_boilerplate`` must never re-drop the load-bearing ``items: {}``.
+
+    It strips ``title`` / ``default: null`` / ``additionalProperties: true``
+    only; this fence pins that an empty ``items`` schema is not mistaken for
+    boilerplate — by the stripper directly, and by the full pipeline.
+    """
+    node = {"type": "array", "items": {}, "description": "Opaque."}
+    _strip_boilerplate(node)
+    assert node["items"] == {}
+    assert _slim()["properties"]["servers"]["items"] == {}
 
 
 def test_redescribe_replaces_only_the_description() -> None:
@@ -145,6 +171,6 @@ def test_nested_properties_are_reached_through_a_ref() -> None:
         redescribe={"script": "Short."},
     )
     nested = slim["$defs"]["_Body"]["properties"]
-    assert nested["servers"] == {"type": "array", "description": "Opaque."}
+    assert nested["servers"] == {"type": "array", "items": {}, "description": "Opaque."}
     assert nested["script"]["description"] == "Short."
     assert "_Nested" not in slim["$defs"]

--- a/tests/unit/test_workflow_tool_schema_budget.py
+++ b/tests/unit/test_workflow_tool_schema_budget.py
@@ -29,6 +29,7 @@ import pytest
 
 import aios.tools  # noqa: F401 - trigger built-in registration side effects
 from aios.harness.step_context import _inject_workflow_script_contract
+from aios.harness.tokens import approx_tokens
 from aios.models.workflows import WORKFLOW_SCRIPT_CONTRACT, WorkflowCreate
 from aios.tools.input import tool_input
 from aios.tools.invoke import ToolBail, prepare_builtin
@@ -94,6 +95,28 @@ def test_trusted_id_injection_still_refused(name: str) -> None:
     assert schema["additionalProperties"] is False
     with pytest.raises(ToolBail):
         prepare_builtin(name, {"creator_session_id": "sess_evil"})
+
+
+# ── every rendered schema must be countable by the real token counter ──────
+#
+# The byte budgets above measure ``json.dumps`` length; the loop unit tests
+# patch ``prelude_overhead_local`` to 0. Neither ever runs the REAL
+# ``litellm.token_counter`` over a rendered registry schema — which is exactly
+# how #2294's bare ``{"type": "array"}`` (no ``items``) shipped: litellm's
+# ``_format_type`` does ``props['items']`` unconditionally, so every step of
+# every workflow-capable agent raised ``KeyError: 'items'`` in production and
+# the fleet was rolled back. These tests close that gap: every registered
+# tool's rendered entry must survive the counter, individually and all at once.
+
+
+@pytest.mark.parametrize("name", registry.names())
+def test_every_registered_schema_is_countable(name: str) -> None:
+    assert approx_tokens([], tools=[openai_tool_entry(registry.get(name))]) > 0
+
+
+def test_whole_registry_is_countable_at_once() -> None:
+    tools = [openai_tool_entry(registry.get(name)) for name in registry.names()]
+    assert approx_tokens([], tools=tools) > 0
 
 
 # ── the on-demand half ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the production incident caused by [#2303](https://github.com/eumemic/aios/pull/2303) (issue [#2294](https://github.com/eumemic/aios/issues/2294), workflow schema diet): the dieted opaque arrays rendered as bare `{"type": "array"}` with no `items`, and every step of every workflow-capable agent crashed with `KeyError: 'items'` — the fleet was rolled back and master has been unpromotable since. Opaque arrays now render as `{"type": "array", "items": {}}`, the MCP sanitizer closes the same defect class for untrusted third-party schemas, and a registry-wide regression fence runs the **real** `litellm.token_counter` over every registered tool's rendered schema.

### The incident

`prelude_overhead_local` (`src/aios/harness/step_context.py:221`) runs on every agent step and feeds the rendered tool schemas to `litellm.token_counter`. litellm 1.96.2's `_format_type` (`litellm_core_utils/token_counter.py:808`) dereferences `props['items']` unconditionally on `type == "array"`, so any agent holding `create_workflow` / `update_workflow` / `call_workflow` (the trio registers together — every workflow-capable agent) raised `KeyError: 'items'` on every step.

### Why `items: {}` is the correct opaque form (two independent facts)

1. **litellm hard-derefs it** — `_format_type` does `props['items']` with no guard; litellm's own comment: *"items is required, OpenAI throws an error if it's missing."*
2. **OpenAI providers reject arrays without `items`** — so the bare form was invalid on the wire regardless of the counter. `{}` is the "anything" schema: it only loosens the dispatch-time check, never tightens it.

Both `_opaque_array` arms (plain and nullable-`anyOf`) now carry `items: {}`, with a comment citing both facts so a future dieter can't re-drop it. No defensive try/except was added to `harness/tokens.py` — the fail-hard stance stands; the producers are fixed and fenced.

### Same-class hole closed in the MCP sanitizer

`sanitize_mcp_schema` (`src/aios/mcp/schema.py`) did not repair third-party schemas either, so an MCP server advertising a bare array would crash the harness identically. It now:

- adds `items: {}` when an array's `items` is missing or not a dict (draft-4 tuple-form `items: [...]` and boolean `items` both crash litellm's recursion with `AttributeError`);
- coerces non-dict `properties` values (`"foo": true`) to `{}` — the other litellm `AttributeError` site (`_format_object_parameters`).

### The CI gap the fence closes

The budget test measured **bytes** (`json.dumps` length), never tokens; the loop unit tests patch `prelude_overhead_local` to 0. No unit test ever ran the real counter over a real rendered registry schema. New tests in `test_workflow_tool_schema_budget.py` assert `approx_tokens([], tools=[openai_tool_entry(registry.get(name))]) > 0` for **every** registered tool (parametrized) plus one whole-registry pass. Red-first evidence on unmodified master:

```
E           KeyError: 'items'
.venv/lib/python3.13/site-packages/litellm/litellm_core_utils/token_counter.py:808: KeyError
FAILED tests/unit/test_workflow_tool_schema_budget.py::test_every_registered_schema_is_countable[create_workflow]
FAILED tests/unit/test_workflow_tool_schema_budget.py::test_whole_registry_is_countable_at_once
```

### One deviation from "only schema_diet + mcp/schema"

The byte budgets were deliberately **not** raised (`MAX_RENDERED_BYTES = 2_500`, `MAX_TRIO_BYTES = 6_500`), but `items: {}` pushed `call_workflow` to 2,515 bytes — 15 over. Per the budget test's own instruction ("trim the prose"), `TOOLS_FIELD_DESCRIPTION` in `workflow_management.py` drops the redundant "agent-config envelope" phrase (the `[{"type": "bash"}]` example already shows the shape). `call_workflow` now renders at 2,492 bytes.

### Ordering

[PR #2306](https://github.com/eumemic/aios/pull/2306) (contract reader plain-text) is independent — it changes a tool *result*, not schemas — and does not conflict; both fixes ride the same promote.

## Substrate state changes

None — code-only change.

## Test plan

Red-first: every new/updated test was run against unmodified master and failed with the expected error (`KeyError: 'items'` for the fence and diet tests; `AttributeError: 'list'/'bool' object has no attribute 'get'` for the MCP tuple/bool/property cases) before the fix was applied.

- `uv run pytest tests/unit/test_schema_diet.py tests/unit/test_workflow_tool_schema_budget.py tests/unit/test_mcp_schema_sanitize.py -q` → 121 passed
- `uv run pytest tests/unit -q` → 5672 passed
- `uv run mypy src tests` → clean; `uv run ruff check src tests` + `format --check` → clean
- End-to-end sanity: `approx_tokens([], tools=[openai_tool_entry(registry.get(n)) for n in ("create_workflow", "update_workflow", "call_workflow", "get_workflow_script_contract")])` → **848 tokens** (raised `KeyError` before the fix)

## Risk / rollback

Low: `items: {}` strictly loosens the model-facing schema (dispatch-time validation posture unchanged; pydantic handlers still enforce the real models). Rollback is a plain revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

