### PR TITLE
feat(browser): L3 deny-internal egress lockdown for the account browser (jarbot#106 F2)

### DIFF
--- a/src/aios/sandbox/network.py
+++ b/src/aios/sandbox/network.py
@@ -113,17 +113,24 @@ async def ensure_sandbox_network() -> None:
 
 
 async def ensure_browser_network() -> None:
-    """Idempotently create the browser network with ICC disabled.
+    """Idempotently create the browser network with ICC disabled and IPv6 off.
 
     Same concurrent-startup race discipline as :func:`ensure_sandbox_network`
-    (attempt, then re-verify the desired condition), plus one hard invariant
-    check: ``docker network create`` flags are INERT for a pre-existing
-    network, and a live network must never be torn down and recreated — so a
-    pre-existing ``aios-browser`` whose ICC option is not ``"false"`` (an
-    older deploy, a hand-made network) hard-fails the worker rather than
-    silently running browser containers on an ICC-open bridge.  ICC-off is
-    load-bearing: it is what keeps one account's computer from reaching
-    another's (jarbot#106 §6.2 phase gate).
+    (attempt, then re-verify the desired condition), plus TWO hard invariant
+    checks — ``docker network create`` flags are INERT for a pre-existing
+    network, and a live network must never be torn down and recreated, so each
+    load-bearing property is re-verified on an already-existing network rather
+    than assumed:
+
+    * **ICC off** keeps one account's computer from reaching another's
+      (jarbot#106 §6.2 phase gate) — a pre-existing ``aios-browser`` whose ICC
+      option is not ``"false"`` hard-fails the worker.
+    * **IPv6 off** is what makes the browser's egress lockdown
+      (:func:`apply_browser_deny_internal`) sound: that lockdown is IPv4-only,
+      so a v6 route would let untrusted web content bypass it to v6 internal /
+      link-local / metadata. A pre-existing network with IPv6 enabled therefore
+      hard-fails too, rather than the IPv4-only ``--ipv6=false`` create flag
+      being silently trusted on a network it can no longer affect.
     """
     if not await _network_exists(BROWSER_NETWORK_NAME):
         rc, _, stderr_bytes = await run_docker_cli(
@@ -154,6 +161,14 @@ async def ensure_browser_network() -> None:
             "network while no browser containers run and let the worker recreate it."
         )
 
+    if await _network_enable_ipv6(BROWSER_NETWORK_NAME):
+        raise RuntimeError(
+            f"browser network {BROWSER_NETWORK_NAME!r} has IPv6 enabled; the "
+            "browser egress lockdown is IPv4-only, so a v6 route would bypass it. "
+            "Create flags are inert for an existing network: remove the network "
+            "while no browser containers run and let the worker recreate it."
+        )
+
 
 async def _network_exists(name: str) -> bool:
     rc, _, _ = await run_docker_cli(["docker", "network", "inspect", name])
@@ -180,6 +195,19 @@ async def _network_option(network: str, option: str) -> str | None:
     # ``<nil>``, whose map holds pointers).
     out = stdout_bytes.decode("utf-8", errors="replace").strip()
     return out or None
+
+
+async def _network_enable_ipv6(network: str) -> bool:
+    """Whether ``network`` has IPv6 enabled (``docker network inspect``).
+
+    ``EnableIPv6`` is a top-level network field (not a driver ``-o`` option), so
+    it reads via its own ``--format`` rather than :func:`_network_option`. An
+    uninspectable network reads as ``False`` — a missing network can carry no v6
+    route, and the ICC/existence checks around this one already fail loudly."""
+    rc, stdout_bytes, _ = await run_docker_cli(
+        ["docker", "network", "inspect", "--format", "{{.EnableIPv6}}", network]
+    )
+    return rc == 0 and stdout_bytes.decode("utf-8", errors="replace").strip() == "true"
 
 
 async def _container_on_network(container: str, network: str) -> bool:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -69,6 +69,7 @@ from aios.sandbox.network import WORKER_NETWORK_ALIAS
 from aios.sandbox.setup import (
     PACKAGE_REGISTRY_HOSTS,
     EgressProvisionResult,
+    apply_browser_deny_internal,
     apply_network_lockdown,
     apply_secret_egress_dnat,
     build_egress_dump_script,
@@ -80,6 +81,7 @@ from aios.sandbox.setup import (
 )
 from aios.sandbox.snapshot_store import LocalDaemonStore, SnapshotStore, TarballStore
 from aios.sandbox.spec import (
+    BrowserRuntimeUnsupportedError,
     ProvisioningPlan,
     build_spec_from_browser,
     build_spec_from_run,
@@ -881,10 +883,12 @@ class SandboxRegistry:
 
         - **Warm hit = liveness probe only** — no spec-version, no mount drift
           (nothing in ``sessions.*`` describes the browser).
-        - **Cold path is snapshot-free and setup-free** — no salvage, no egress
-          CA, no packages, no lockdown sidecar. The container is exec-only on
-          the ICC-off browser bridge; its durable state (the Chromium profile)
-          lives on the plane bind mount, not the rootfs.
+        - **Cold path is snapshot-free and near-setup-free** — no salvage, no
+          egress CA, no packages. Its ONE setup step is the L3 deny-internal
+          egress sidecar (metadata/RFC1918/CGNAT dropped, public web open); the
+          container is otherwise exec-only on the ICC-off browser bridge, and
+          its durable state (the Chromium profile) lives on the plane bind
+          mount, not the rootfs.
 
         Raises :class:`~aios.sandbox.spec.BrowserImageUnconfiguredError` before
         any Docker call when the deployment has no browser image configured.
@@ -912,13 +916,52 @@ class SandboxRegistry:
             return handle
 
     async def _provision_browser(self, account_id: str) -> SandboxHandle:
-        """Cold-start the account's browser container: build the bare spec, create.
+        """Cold-start the account's browser container: create, then lock egress.
 
-        No proxies, no broker secret, no setup steps — create-failure needs no
-        cleanup because nothing was registered.
+        No proxies, no broker secret, no snapshot. The one setup step is the L3
+        deny-internal egress sidecar (:func:`apply_browser_deny_internal`): the
+        browser renders untrusted web content, so metadata/RFC1918/CGNAT egress
+        is dropped while the public web stays open. A lockdown failure fails the
+        provision — the just-created container is torn down and the error
+        propagates — rather than handing back a browser that can reach internal
+        services.
+
+        A configured custom browser runtime is rejected UP FRONT: the egress
+        sidecar installs iptables in the container's netns, which does not
+        initialize under a non-default runtime (runsc's netstack), so a
+        custom-runtime browser would fail closed mid-provision with an opaque
+        iptables error. The guard makes that a clean, model-visible refusal.
         """
+        # Reject a configured custom browser runtime up front. This checks the
+        # SETTING; the supported posture is the default runtime, which must be
+        # runc. (On a host whose Docker daemon default-runtime is itself a
+        # custom runtime, a browser with the setting unset would inherit it and
+        # fail closed at the egress sidecar below instead — never a bypass.)
+        runtime = get_settings().sandbox_browser_runtime
+        if runtime is not None:
+            log.warning(
+                "sandbox.browser_runtime_unsupported",
+                account_id=account_id,
+                runtime=runtime,
+            )
+            raise BrowserRuntimeUnsupportedError(
+                "browser egress isolation requires the default container runtime; "
+                "a custom browser runtime is not supported (its network namespace "
+                "cannot carry the egress rules)"
+            )
         spec = build_spec_from_browser(account_id)
         handle = await self._backend.create(spec)
+        try:
+            await apply_browser_deny_internal(self._backend, handle)
+        except BaseException:
+            # Fail closed: never hand back a browser whose untrusted web content
+            # can reach internal/metadata endpoints because its egress lockdown
+            # didn't land. ``BaseException`` (not ``Exception``) so a provision
+            # cancellation/timeout still tears the container down, matching the
+            # session-provision teardown. Nothing else was registered, so a bare
+            # destroy suffices.
+            await self._destroy_browser_quietly(account_id, handle)
+            raise
         log.info(
             "sandbox.browser_provisioned",
             account_id=account_id,

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -727,6 +727,85 @@ def build_secret_egress_dnat_script(dnat_hosts: Sequence[str], dnat_target: tupl
     )
 
 
+# The internal / link-local / metadata / CGNAT destination ranges a browser
+# container is denied outbound (jarbot#106). A deliberately NARROW, targeted L3
+# subset for the SSRF / credential-theft threat — NOT the full internal-IP
+# predicate in ``aios.tools.url_safety`` (which also blocks multicast, reserved,
+# and TEST-NET; those are non-SSRF and unroutable from this isolated bridge, so
+# they are intentionally omitted rather than carried as near-dead rules).
+# Link-local 169.254.0.0/16 covers the cloud-metadata endpoint (169.254.169.254);
+# the three RFC1918 blocks cover every private network INCLUDING the docker
+# bridge gateway (so "reach the host via the gateway" is already denied — no
+# separate gateway rule); 100.64.0.0/10 is CGNAT, which ``ipaddress`` does NOT
+# fold into ``is_private``, so it must be listed explicitly. 127.0.0.0/8 is
+# deliberately ABSENT: the container's embedded DNS resolver is 127.0.0.11
+# (netns-local loopback) and the browser needs it to resolve the public web.
+# This is a DESTINATION-IP filter: an internal service reachable on a PUBLIC IP
+# is not covered here and must rely on its own auth (e.g. the API bearer key).
+# IPv4-only: ``ensure_browser_network`` enforces the ``aios-browser`` network is
+# ``--ipv6=false`` (hard-failing otherwise), so a browser container gets no v6
+# address or route and v6 egress is impossible — no v6 rules needed.
+_BROWSER_DENY_INTERNAL_CIDRS = (
+    "169.254.0.0/16",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "100.64.0.0/10",
+)
+
+
+def build_browser_deny_internal_script() -> str:
+    """Build the L3 deny-internal egress script for a browser container.
+
+    The browser renders UNTRUSTED web content, so — unlike the session/run
+    lockdown, which is a default-DROP allow-list (:func:`build_iptables_script`)
+    — general (public) egress must stay OPEN. This is the default-ACCEPT sibling
+    of :func:`build_secret_egress_dnat_script`: it leaves the filter OUTPUT
+    policy at ``ACCEPT`` (NO ``-P OUTPUT DROP``) and only appends targeted
+    ``DROP`` rules for the ranges in :data:`_BROWSER_DENY_INTERNAL_CIDRS`. That
+    closes cloud-metadata theft (169.254.169.254) and internal-service SSRF at
+    L3 — on the resolved *destination IP*, so it holds against the DNS rebinding
+    the driver's userspace navigate guard (navigate-time, hostname-based) cannot
+    catch — while leaving the public web reachable.
+
+    Only the filter OUTPUT chain is flushed (for idempotent re-apply); the nat
+    table is untouched. No ``_RESOLV_PREAMBLE``: the rules are static CIDRs, so
+    nothing resolves a hostname.
+    """
+    lines = [
+        "set -e",
+        "",
+        _IPTABLES_BACKEND_SELECT,
+        "",
+        "# Clear filter OUTPUT (empty on the fresh container this always runs on),",
+        "# leave the policy at ACCEPT (general egress stays open), do NOT touch nat.",
+        '"$IPT" -F OUTPUT',
+        "",
+        "# Deny egress to the internal / link-local / metadata / CGNAT ranges; every",
+        "# other destination (the public web) stays allowed by the ACCEPT policy.",
+    ]
+    lines += [f'"$IPT" -A OUTPUT -d {cidr} -j DROP' for cidr in _BROWSER_DENY_INTERNAL_CIDRS]
+    return "\n".join(lines)
+
+
+def build_browser_deny_internal_verify_script() -> str:
+    """Read-back verify that every deny-internal DROP rule actually landed.
+
+    Proof the rules took effect in the shared netns, not merely that the apply
+    script exited 0 — the browser's analog of the ``-P OUTPUT DROP`` read-back
+    in :func:`build_lockdown_verify_script`. ``set -e`` makes each missing-rule
+    grep independently fatal. There is NO policy assertion: the deny-internal
+    path deliberately leaves the filter policy at ``ACCEPT``. ``grep -F`` so the
+    CIDR dots/slash are matched literally, not as a regexp.
+    """
+    lines = ["set -e", _IPTABLES_BACKEND_SELECT]
+    lines += [
+        f"\"$IPT\" -S OUTPUT | grep -qF -- '-d {cidr} -j DROP'"
+        for cidr in _BROWSER_DENY_INTERNAL_CIDRS
+    ]
+    return "\n".join(lines)
+
+
 # Docker's embedded DNS, served inside every user-defined-network netns (the
 # sandbox runs on the ``aios-sandbox`` user-defined bridge). The lockdown
 # sidecar joins that netns but inherits the operator image's (typically empty)
@@ -1043,3 +1122,82 @@ async def apply_secret_egress_dnat(
         dnat_host_count=len(dnat_hosts),
     )
     return _parse_egress_provision_result(result.stdout)
+
+
+async def apply_browser_deny_internal(backend: SandboxBackend, handle: SandboxHandle) -> None:
+    """Apply + verify a browser container's L3 deny-internal egress (jarbot#106).
+
+    Called right after the browser container is created. Runs the same
+    operator-image netns sidecar as :func:`apply_network_lockdown` — the browser
+    container itself holds no ``NET_ADMIN``, so root-in-container can neither
+    flush nor poison the rules — but applies
+    :func:`build_browser_deny_internal_script` (default-ACCEPT + targeted DROP)
+    and verifies every DROP rule landed (there is no DROP *policy* to assert).
+
+    Deliberately NOT factored into a shared helper with the session/run egress
+    orchestrators (matching the :func:`apply_secret_egress_dnat` precedent): the
+    browser path carries its own ``sandbox.browser_egress_*`` log events so an
+    operator alert never mis-attributes a browser-plane egress failure to a
+    session networking-policy violation.
+
+    Takes NO ``runtime``: a browser is provisioned only under the default
+    container runtime — the registry rejects a custom runtime before create,
+    because this netns-sidecar iptables path does not initialize under runsc's
+    netstack — so the sidecar always runs under the default runtime too.
+
+    **Fails closed**: on a sidecar infra error, a nonzero apply, or a failed
+    read-back verify, :class:`SandboxBackendError` propagates and the registry
+    tears the just-created container down rather than handing back a browser
+    whose untrusted web content can reach the cloud-metadata endpoint or
+    internal services.
+    """
+    settings = get_settings()
+    try:
+        result = await backend.run_netns_sidecar(
+            handle.sandbox_id,
+            image=settings.docker_image,
+            script=build_browser_deny_internal_script(),
+            timeout_seconds=30,
+            max_output_bytes=settings.bash_max_output_bytes,
+        )
+    except SandboxBackendError:
+        log.warning("sandbox.browser_egress_sidecar_error", owner_id=handle.owner_id)
+        raise
+
+    if result.exit_code != 0:
+        log.warning(
+            "sandbox.browser_egress_failed",
+            owner_id=handle.owner_id,
+            exit_code=result.exit_code,
+            stderr=result.stderr[:500],
+        )
+        raise SandboxBackendError(
+            f"browser deny-internal egress failed (exit {result.exit_code}) for "
+            f"{handle.owner_id}; refusing to run a browser whose untrusted web content "
+            f"can reach internal/metadata endpoints"
+        )
+
+    try:
+        verify = await backend.run_netns_sidecar(
+            handle.sandbox_id,
+            image=settings.docker_image,
+            script=build_browser_deny_internal_verify_script(),
+            timeout_seconds=15,
+            max_output_bytes=settings.bash_max_output_bytes,
+        )
+    except SandboxBackendError:
+        log.warning("sandbox.browser_egress_verify_error", owner_id=handle.owner_id)
+        raise
+    if verify.exit_code != 0:
+        log.warning(
+            "sandbox.browser_egress_verify_failed",
+            owner_id=handle.owner_id,
+            exit_code=verify.exit_code,
+        )
+        raise SandboxBackendError(
+            f"browser deny-internal egress verification failed for {handle.owner_id}: "
+            "an internal-range DROP rule is missing after apply; refusing to run a "
+            "browser with unverified egress isolation"
+        )
+
+    log.info("sandbox.browser_egress_applied", owner_id=handle.owner_id)

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -1258,6 +1258,22 @@ class BrowserImageUnconfiguredError(SandboxBackendError):
     """
 
 
+class BrowserRuntimeUnsupportedError(BrowserImageUnconfiguredError):
+    """The configured browser container runtime is not supported.
+
+    A subclass of :class:`BrowserImageUnconfiguredError` so it rides the same
+    non-retryable "browser not usable on this deployment" path (``driver_call``
+    passes it through distinctly rather than wrapping it as a retryable
+    ``BrowserUnavailableError`` — a static config choice, retrying never helps).
+    Raised by the registry BEFORE create when ``sandbox_browser_runtime`` is
+    set: the browser's deny-internal egress lockdown installs iptables in the
+    container's netns, which does not initialize under runsc's netstack, so a
+    custom-runtime browser would otherwise fail closed at the egress sidecar
+    with an opaque iptables error. Rejecting up front makes the illegal
+    combination (custom runtime + always-on egress) explicit.
+    """
+
+
 def build_spec_from_browser(account_id: str) -> SandboxSpec:
     """Build the spec for an account's shared browser container (jarbot#106).
 
@@ -1302,15 +1318,17 @@ def build_spec_from_browser(account_id: str) -> SandboxSpec:
             INSTANCE_LABEL_KEY: settings.instance_id,
             SESSION_LABEL_KEY: account_id,
         },
-        # No egress policy machinery: the container is unreachable FROM
-        # sandboxes (inter-bridge isolation + ICC-off) and runs no agent code;
-        # per-site policy is driver-level (jarbot#106 §5.2). The container's
-        # inability to drive the control plane rests on topology, NOT on egress
-        # blocking (egress is open in Phase 1): no published ports, no
-        # tool-broker socket mounted, ``host_gateway_alias=None`` (no
-        # host.docker.internal alias), and the API requires a bearer key. A
-        # future Phase adds per-site egress lockdown for the untrusted web
-        # content the browser renders.
+        # No session/run egress-policy machinery here (``network_policy=None``):
+        # the container is unreachable FROM sandboxes (inter-bridge isolation +
+        # ICC-off) and runs no agent code, and its inability to drive the
+        # control plane rests on topology — no published ports, no tool-broker
+        # socket mounted, ``host_gateway_alias=None`` (no host.docker.internal
+        # alias), and the API requires a bearer key. The OUTBOUND surface of the
+        # untrusted web content it renders is locked down separately, AFTER
+        # create, by the registry's L3 deny-internal egress sidecar
+        # (``apply_browser_deny_internal``): metadata/RFC1918/CGNAT dropped,
+        # public web open. A per-*site* allowlist remains driver-level future
+        # work (jarbot#106 §5.2).
         network_policy=None,
         host_gateway_alias=None,
         image=settings.sandbox_browser_image,
@@ -1319,5 +1337,9 @@ def build_spec_from_browser(account_id: str) -> SandboxSpec:
         memory_bytes=settings.sandbox_browser_memory_bytes,
         pids_limit=settings.sandbox_browser_pids_limit,
         seccomp_profile=settings.sandbox_browser_seccomp_profile,
+        # The registry rejects a non-None sandbox_browser_runtime before this
+        # builder is ever called (its egress lockdown does not work under a
+        # custom runtime), so in production this threads None today; it re-carries
+        # a value once egress-under-a-custom-runtime is supported.
         runtime=settings.sandbox_browser_runtime,
     )

--- a/src/aios/tools/browser.py
+++ b/src/aios/tools/browser.py
@@ -38,7 +38,7 @@ from aios.harness.vision import (
 )
 from aios.sandbox.browser import EXEC_KILL_MARGIN_S, BrowserUnavailableError, driver_call
 from aios.sandbox.browser_protocol import BrowserRequest, BrowserResponse
-from aios.sandbox.spec import BrowserImageUnconfiguredError
+from aios.sandbox.spec import BrowserImageUnconfiguredError, BrowserRuntimeUnsupportedError
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 from aios.tools.invoke import ToolBail
@@ -284,6 +284,10 @@ _UNAVAILABLE_MESSAGE = (
     "Browser tools are not available in this deployment: no browser image is "
     "configured. This capability is not yet enabled."
 )
+_RUNTIME_UNSUPPORTED_MESSAGE = (
+    "Browser tools are not available in this deployment: it configures a browser "
+    "container runtime that is not supported. This capability is not enabled here."
+)
 _UNREACHABLE_MESSAGE = (
     "The computer is unavailable right now (its browser failed to start or is "
     "not responding). Try again shortly."
@@ -372,6 +376,11 @@ async def _invoke_driver(
             request,
             timeout_s=settings.sandbox_browser_action_timeout_seconds + EXEC_KILL_MARGIN_S,
         )
+    except BrowserRuntimeUnsupportedError as err:
+        # A BrowserImageUnconfiguredError SUBCLASS, so it must be caught FIRST —
+        # otherwise the image arm below would render the false "no browser image
+        # is configured" message for what is actually a runtime misconfiguration.
+        raise ToolBail(_RUNTIME_UNSUPPORTED_MESSAGE) from err
     except BrowserImageUnconfiguredError as err:
         raise ToolBail(_UNAVAILABLE_MESSAGE) from err
     except BrowserUnavailableError as err:

--- a/tests/e2e/test_browser_network_isolation.py
+++ b/tests/e2e/test_browser_network_isolation.py
@@ -19,6 +19,12 @@ against real Docker:
   half) — the per-environment proof that a deploy's config actually delivers
   the authored profile, not just that the image can be sandboxed when a test
   passes the flag by hand.
+* on that same real path, the L3 deny-internal egress lockdown
+  (``apply_browser_deny_internal``) drops the browser's OUTBOUND traffic to the
+  link-local/metadata, RFC1918, and CGNAT ranges while leaving the public web
+  open — read back from the shared netns (the environment-independent proof the
+  DROP rules landed) and corroborated by a socket probe that cannot reach the
+  cloud-metadata endpoint from inside the browser.
 
 Each unreachability assertion is double-guarded against a vacuous pass: the
 listener curls ITSELF (so the target is proven up, absorbing the bind race),
@@ -46,6 +52,7 @@ from aios.sandbox.network import (
     ensure_browser_network,
     ensure_sandbox_network,
 )
+from aios.sandbox.setup import apply_browser_deny_internal
 from aios.sandbox.spec import build_spec_from_browser
 from tests.conftest import needs_docker
 from tests.e2e.browser_image_common import IMAGE as BROWSER_IMAGE
@@ -329,5 +336,83 @@ async def test_real_browser_spec_runs_chromium_sandboxed(
         await asyncio.to_thread(wait_ready, handle.sandbox_id)
         await asyncio.to_thread(assert_chromium_sandbox_on, handle.sandbox_id)
         await asyncio.to_thread(assert_mount_ns_denied, handle.sandbox_id)
+    finally:
+        await backend.destroy(handle)
+
+
+# The ranges the deny-internal lockdown drops. A deliberately INDEPENDENT literal
+# (NOT imported from production) so this read-back is a true oracle: a wrong value
+# in the production tuple is caught here even though the unit test imports it.
+_DENY_INTERNAL_CIDRS = (
+    "169.254.0.0/16",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "100.64.0.0/10",
+)
+
+
+async def test_real_browser_egress_denies_internal(
+    _networks_ready: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deny-internal egress lockdown drops metadata/RFC1918/CGNAT outbound
+    from a real-provisioned browser while leaving the public web open.
+
+    The definitive, environment-independent proof is the read-back of the actual
+    OUTPUT chain via the operator sidecar (which owns ``iptables`` in the shared
+    netns; the browser holds no NET_ADMIN): every internal-range DROP rule must
+    be present. A socket probe from inside the browser then corroborates that
+    169.254.169.254 (cloud metadata) is unreachable — on an unrouted runner the
+    probe fails regardless, but on a routed one (e.g. GHA/Azure IMDS) it proves
+    the rule has teeth, not just that the rule text is present."""
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    monkeypatch.setattr(settings, "sandbox_browser_image", BROWSER_IMAGE or IMAGE)
+    # The egress sidecar runs the OPERATOR image (ships iptables-legacy); point
+    # it at whichever sandbox image this environment built/pulled.
+    monkeypatch.setattr(settings, "docker_image", IMAGE)
+    account_id = f"acc_{uuid.uuid4().hex[:8].upper()}"
+
+    backend = DockerBackend()
+    spec = build_spec_from_browser(account_id)
+    world_writable(spec.workspace.host_path)
+    handle = await backend.create(spec)
+    try:
+        # Applies + internally read-back-verifies; raises (fail-closed) if a
+        # rule is missing, so a clean return already implies the rules landed.
+        await apply_browser_deny_internal(backend, handle)
+
+        # Independent read-back of the real OUTPUT chain from the shared netns.
+        dump = await backend.run_netns_sidecar(
+            handle.sandbox_id,
+            image=IMAGE,
+            script=(
+                "if command -v iptables-legacy >/dev/null 2>&1; then IPT=iptables-legacy; "
+                'else IPT=iptables; fi; "$IPT" -S OUTPUT'
+            ),
+            timeout_seconds=15,
+            max_output_bytes=settings.bash_max_output_bytes,
+        )
+        assert dump.exit_code == 0, dump.stderr
+        for cidr in _DENY_INTERNAL_CIDRS:
+            assert f"-d {cidr} -j DROP" in dump.stdout, (
+                f"deny-internal rule for {cidr} missing from OUTPUT:\n{dump.stdout}"
+            )
+        # Loopback must stay open — the browser's embedded DNS is 127.0.0.11.
+        assert "-d 127.0.0.0/8 -j DROP" not in dump.stdout
+
+        # Corroborate from inside the browser (python3 runs the driver, so it is
+        # on PATH): a DROP makes connect() time out → non-zero exit; REACHED
+        # (exit 0) would mean the metadata endpoint is live to the browser.
+        probe = await backend.exec(
+            handle,
+            'python3 -c "import socket; socket.create_connection'
+            "(('169.254.169.254', 80), timeout=3)\"",
+            timeout_seconds=15,
+            max_output_bytes=settings.bash_max_output_bytes,
+        )
+        assert probe.exit_code != 0, "browser reached the cloud-metadata endpoint (169.254.169.254)"
     finally:
         await backend.destroy(handle)

--- a/tests/unit/sandbox/test_sandbox_network.py
+++ b/tests/unit/sandbox/test_sandbox_network.py
@@ -276,3 +276,25 @@ class TestEnsureBrowserNetwork:
         install_docker_responder(monkeypatch, responder)
         with pytest.raises(RuntimeError, match="inter-container communication enabled"):
             await ensure_browser_network()
+
+    async def test_existing_ipv6_enabled_network_hard_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pre-existing ``aios-browser`` with IPv6 enabled must fail the worker:
+        the browser egress lockdown is IPv4-only, so a v6 route would bypass it,
+        and ``--ipv6=false`` is inert on an already-existing network. ICC is off
+        here, so the (earlier) ICC check passes and the v6 check is what fires."""
+
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            if argv[:3] == ["docker", "network", "inspect"] and "--format" in argv:
+                fmt = argv[argv.index("--format") + 1]
+                if ".EnableIPv6" in fmt:
+                    return 0, b"true\n", b""
+                return 0, b"false\n", b""  # ICC option is 'false' — ICC check passes
+            if argv[:3] == ["docker", "network", "inspect"]:
+                return 0, b"[]", b""
+            pytest.fail(f"unexpected argv: {argv}")
+
+        install_docker_responder(monkeypatch, responder)
+        with pytest.raises(RuntimeError, match="IPv6 enabled"):
+            await ensure_browser_network()

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -178,6 +178,20 @@ class TestActionHandlers:
         with pytest.raises(ToolBail, match="not available in this deployment"):
             await handler(_SESSION_ID, {})
 
+    async def test_runtime_unsupported_gives_the_runtime_message(
+        self, seams: dict[str, Any]
+    ) -> None:
+        """A ``BrowserRuntimeUnsupportedError`` is a ``BrowserImageUnconfiguredError``
+        subclass, so it must be caught by its OWN arm (before the image arm) and
+        render the accurate runtime message — not the false 'no browser image is
+        configured'."""
+        from aios.sandbox.spec import BrowserRuntimeUnsupportedError
+
+        seams["driver"].side_effect = BrowserRuntimeUnsupportedError("custom runtime")
+        handler = registry.get("browser_snapshot").handler
+        with pytest.raises(ToolBail, match="runtime that is not supported"):
+            await handler(_SESSION_ID, {})
+
     async def test_grant_recheck_refusal_propagates(self, seams: dict[str, Any]) -> None:
         seams["granted"].side_effect = ToolBail("browser_click is not enabled for this agent")
         handler = registry.get("browser_click").handler
@@ -201,6 +215,25 @@ class TestDriverCall:
             side_effect=BrowserImageUnconfiguredError("no image configured")
         )
         with pytest.raises(BrowserImageUnconfiguredError):
+            await driver_call(
+                registry_mock, _ACCOUNT_ID, BrowserRequest(op="snapshot"), timeout_s=5
+            )
+
+    async def test_runtime_unsupported_passes_through_unlaundered(self) -> None:
+        """``BrowserRuntimeUnsupportedError`` (a ``BrowserImageUnconfiguredError``
+        subclass) must ride the same non-retryable pass-through, NOT be laundered
+        into a retryable ``BrowserUnavailableError`` — retrying never helps a
+        statically-misconfigured runtime. Reordering driver_call's except arms or
+        rebasing the exception on ``SandboxBackendError`` would flip this."""
+        from aios.sandbox.browser import driver_call
+        from aios.sandbox.browser_protocol import BrowserRequest
+        from aios.sandbox.spec import BrowserRuntimeUnsupportedError
+
+        registry_mock = MagicMock()
+        registry_mock.get_or_provision_browser = AsyncMock(
+            side_effect=BrowserRuntimeUnsupportedError("custom runtime")
+        )
+        with pytest.raises(BrowserRuntimeUnsupportedError):
             await driver_call(
                 registry_mock, _ACCOUNT_ID, BrowserRequest(op="snapshot"), timeout_s=5
             )

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -26,8 +26,12 @@ from aios.sandbox.backends.base import (
 )
 from aios.sandbox.backends.docker import DockerBackend
 from aios.sandbox.setup import (
+    _BROWSER_DENY_INTERNAL_CIDRS,
+    apply_browser_deny_internal,
     apply_network_lockdown,
     apply_secret_egress_dnat,
+    build_browser_deny_internal_script,
+    build_browser_deny_internal_verify_script,
     build_iptables_script,
     build_lockdown_verify_script,
     build_secret_egress_dnat_script,
@@ -1461,3 +1465,149 @@ class TestCredentialHostEgressVerdict:
             )
         )
         assert not [argv for table, argv in rules if table == "filter" and "REJECT" in argv]
+
+
+# ── Browser deny-internal egress (jarbot#106) ─────────────────────────────────
+
+
+class TestBuildBrowserDenyInternalScript:
+    """The default-ACCEPT + targeted-DROP script for the untrusted-web browser:
+    public egress stays open, internal/link-local/metadata/CGNAT is dropped."""
+
+    def test_drops_each_internal_range(self) -> None:
+        script = build_browser_deny_internal_script()
+        for cidr in _BROWSER_DENY_INTERNAL_CIDRS:
+            assert f'"$IPT" -A OUTPUT -d {cidr} -j DROP' in script
+
+    def test_drops_exactly_the_internal_set_public_egress_stays_open(self) -> None:
+        # The design's whole distinguishing property vs the session lockdown:
+        # public egress stays OPEN. Pin the DROP set EXACTLY so a regression that
+        # bricks the browser — an added `0.0.0.0/0`, or a catch-all
+        # `-A OUTPUT -j DROP` — is caught, not just a removed/edited range.
+        script = build_browser_deny_internal_script()
+        assert script.count("-j DROP") == len(_BROWSER_DENY_INTERNAL_CIDRS)
+        assert "-d 0.0.0.0/0" not in script  # no all-IPs catch-all DROP
+
+    def test_no_drop_policy_general_egress_stays_open(self) -> None:
+        # The whole point vs the session lockdown: NO default-DROP, so the
+        # browser can still reach the public web.
+        assert "-P OUTPUT DROP" not in build_browser_deny_internal_script()
+
+    def test_does_not_drop_loopback(self) -> None:
+        # 127.0.0.11 (embedded DNS) is netns-local loopback the browser needs to
+        # resolve real sites — 127/8 must NOT be in the DROP set.
+        assert "127.0.0" not in build_browser_deny_internal_script()
+
+    def test_flushes_filter_output_only_not_nat(self) -> None:
+        script = build_browser_deny_internal_script()
+        assert '"$IPT" -F OUTPUT' in script
+        assert "-t nat" not in script
+
+    def test_uses_selected_backend_no_bare_iptables(self) -> None:
+        script = build_browser_deny_internal_script()
+        assert "IPT=iptables-legacy" in script
+        for line in script.splitlines():
+            assert not line.lstrip().startswith("iptables ")
+
+    def test_emits_set_e_first(self) -> None:
+        assert build_browser_deny_internal_script().splitlines()[0] == "set -e"
+
+    def test_no_dns_preamble(self) -> None:
+        # Static CIDRs resolve nothing, so the embedded-DNS preamble is absent.
+        assert "127.0.0.11" not in build_browser_deny_internal_script()
+        assert "resolve_ipv4" not in build_browser_deny_internal_script()
+
+
+class TestBuildBrowserDenyInternalVerifyScript:
+    """The read-back verify asserts every DROP rule landed — no policy check."""
+
+    def test_asserts_each_drop_rule_present(self) -> None:
+        script = build_browser_deny_internal_verify_script()
+        for cidr in _BROWSER_DENY_INTERNAL_CIDRS:
+            assert f"grep -qF -- '-d {cidr} -j DROP'" in script
+
+    def test_no_policy_assertion(self) -> None:
+        # The deny-internal path leaves the policy at ACCEPT — verifying a DROP
+        # policy would always fail.
+        assert "-P OUTPUT DROP" not in build_browser_deny_internal_verify_script()
+
+    def test_uses_selected_backend(self) -> None:
+        script = build_browser_deny_internal_verify_script()
+        assert "IPT=iptables-legacy" in script
+        assert '"$IPT" -S OUTPUT' in script
+
+    def test_emits_set_e_first(self) -> None:
+        assert build_browser_deny_internal_verify_script().splitlines()[0] == "set -e"
+
+
+class TestApplyBrowserDenyInternal:
+    """apply_browser_deny_internal applies + verifies via the operator sidecar."""
+
+    @staticmethod
+    def _sidecar_calls(backend: FakeBackend) -> list[dict[str, Any]]:
+        return [c[1] for c in backend.calls if c[0] == "run_netns_sidecar"]
+
+    @pytest.mark.asyncio
+    async def test_applies_and_verifies_via_sidecar(self) -> None:
+        backend = FakeBackend()
+        handle = make_handle()
+
+        await apply_browser_deny_internal(backend, handle)
+
+        calls = self._sidecar_calls(backend)
+        assert len(calls) == 2  # apply, then read-back verify
+        apply_call, verify_call = calls
+        assert '"$IPT" -A OUTPUT -d 169.254.0.0/16 -j DROP' in apply_call["script"]
+        assert "grep -qF -- '-d 169.254.0.0/16 -j DROP'" in verify_call["script"]
+        # The sidecar runs the OPERATOR image (ships iptables-legacy), joined to
+        # the browser's netns; the browser holds no NET_ADMIN itself.
+        assert apply_call["image"].endswith("aios-sandbox:latest")
+        assert apply_call["target_sandbox_id"] == handle.sandbox_id
+        # No runtime override: a browser is only ever provisioned under the
+        # default runtime (the registry rejects a custom one before create).
+        assert apply_call["runtime"] is None
+        assert verify_call["runtime"] is None
+
+
+class TestApplyBrowserDenyInternalFailsClosed:
+    """A browser whose egress lockdown didn't apply (or didn't verify) could
+    reach the cloud-metadata endpoint / internal services — so a nonzero apply,
+    a failed verify, or a sidecar infra error must raise, not log-and-continue."""
+
+    @pytest.mark.asyncio
+    async def test_nonzero_apply_raises(self) -> None:
+        backend = FakeBackend()
+        backend.sidecar_results = [
+            CommandResult(
+                exit_code=3,
+                stdout="",
+                stderr="iptables: command not found",
+                timed_out=False,
+                truncated=False,
+            )
+        ]
+        with pytest.raises(SandboxBackendError, match="egress failed"):
+            await apply_browser_deny_internal(backend, make_handle())
+
+    @pytest.mark.asyncio
+    async def test_failed_verify_raises(self) -> None:
+        backend = FakeBackend()
+        ok = CommandResult(exit_code=0, stdout="", stderr="", timed_out=False, truncated=False)
+        bad = CommandResult(exit_code=1, stdout="", stderr="", timed_out=False, truncated=False)
+        backend.sidecar_results = [ok, bad]  # apply ok, verify fails
+        with pytest.raises(SandboxBackendError, match="verification failed"):
+            await apply_browser_deny_internal(backend, make_handle())
+
+    @pytest.mark.asyncio
+    async def test_sidecar_error_propagates(self) -> None:
+        backend = FakeBackend()
+        backend.run_netns_sidecar = AsyncMock(  # type: ignore[method-assign]
+            side_effect=SandboxBackendError("daemon hiccup")
+        )
+        with pytest.raises(SandboxBackendError, match="daemon hiccup"):
+            await apply_browser_deny_internal(backend, make_handle())
+
+    @pytest.mark.asyncio
+    async def test_zero_exit_does_not_raise(self) -> None:
+        backend = FakeBackend()  # default sidecar returns exit 0 for both calls
+        await apply_browser_deny_internal(backend, make_handle())  # must not raise

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -39,7 +39,7 @@ from aios.sandbox.backends.base import (
     SandboxSpec,
 )
 from aios.sandbox.registry import SandboxRegistry
-from aios.sandbox.spec import ProvisioningPlan
+from aios.sandbox.spec import BrowserRuntimeUnsupportedError, ProvisioningPlan
 from aios.services.vaults import ResolvedEnvVarCredential
 from tests.helpers.sandbox import FakeBackend, FakePool, make_handle
 
@@ -1912,3 +1912,130 @@ class TestSalvageBreaker:
         with pytest.raises(SandboxBackendError, match="breaker open"):
             await registry._salvage_session_corpses("sess_B")
         assert self._snapshot_count(backend) == snaps_before
+
+
+class TestBrowserEgressProvision:
+    """``_provision_browser`` locks the browser's egress down to deny-internal
+    after create, fails the provision (tearing the container down) if it doesn't
+    land, and refuses a custom container runtime up front (its netns iptables
+    path does not initialize under runsc)."""
+
+    @staticmethod
+    def _browser_spec(account_id: str) -> SandboxSpec:
+        return SandboxSpec(
+            session_id=account_id,
+            instance_id="inst_TEST",
+            workspace=Mount(host_path=Path("/tmp/plane"), sandbox_path="/workspace"),
+            extra_mounts=(),
+            environment={},
+            labels={},
+            network_policy=None,
+            host_gateway_alias=None,
+            image="aios-browser:test",
+        )
+
+    async def test_custom_runtime_rejected_before_create(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A custom runtime is refused up front — never created and left running
+        # WITHOUT egress isolation (the sidecar iptables path fails under runsc).
+        monkeypatch.setattr(get_settings(), "sandbox_browser_runtime", "runsc")
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+
+        with pytest.raises(BrowserRuntimeUnsupportedError):
+            await registry._provision_browser("acc_X")
+
+        assert not any(c[0] == "create" for c in backend.calls)
+
+    async def test_egress_applied_after_create(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(get_settings(), "sandbox_browser_runtime", None)
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+
+        with patch(
+            "aios.sandbox.registry.build_spec_from_browser",
+            return_value=self._browser_spec("acc_X"),
+        ):
+            handle = await registry._provision_browser("acc_X")
+
+        verbs = [c[0] for c in backend.calls]
+        # create, then the apply + read-back-verify sidecars, in that order, and
+        # NO teardown on the happy path.
+        assert verbs == ["create", "run_netns_sidecar", "run_netns_sidecar"]
+        assert handle.owner_id == "acc_X"
+
+    async def test_egress_failure_destroys_and_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(get_settings(), "sandbox_browser_runtime", None)
+        backend = FakeBackend()
+        backend.sidecar_results = [
+            CommandResult(
+                exit_code=2,
+                stdout="",
+                stderr="iptables: not found",
+                timed_out=False,
+                truncated=False,
+            )
+        ]
+        registry = SandboxRegistry(backend=backend)
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_browser",
+                return_value=self._browser_spec("acc_X"),
+            ),
+            pytest.raises(SandboxBackendError, match="egress failed"),
+        ):
+            await registry._provision_browser("acc_X")
+
+        verbs = [c[0] for c in backend.calls]
+        # create, the apply sidecar (which fails so verify never runs), then the
+        # fail-closed teardown — in that exact order.
+        assert verbs == ["create", "run_netns_sidecar", "destroy"]
+
+    async def test_public_path_rejects_custom_runtime_without_caching(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Route through the PUBLIC entry point (get_or_provision_browser wraps
+        # _provision_browser with capacity admission + handle caching): the
+        # refusal must propagate unwrapped AND leave no cached handle, so a later
+        # call reprovisions cleanly rather than serving/looping on a poisoned entry.
+        monkeypatch.setattr(get_settings(), "sandbox_browser_runtime", "runsc")
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+
+        with pytest.raises(BrowserRuntimeUnsupportedError):
+            await registry.get_or_provision_browser("acc_X")
+
+        assert "acc_X" not in registry._handles
+        assert not any(c[0] == "create" for c in backend.calls)
+
+    async def test_public_path_egress_failure_leaves_no_cached_handle(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(get_settings(), "sandbox_browser_runtime", None)
+        backend = FakeBackend()
+        backend.sidecar_results = [
+            CommandResult(
+                exit_code=2,
+                stdout="",
+                stderr="iptables: not found",
+                timed_out=False,
+                truncated=False,
+            )
+        ]
+        registry = SandboxRegistry(backend=backend)
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_browser",
+                return_value=self._browser_spec("acc_X"),
+            ),
+            pytest.raises(SandboxBackendError, match="egress failed"),
+        ):
+            await registry.get_or_provision_browser("acc_X")
+
+        assert "acc_X" not in registry._handles
+        assert [c[0] for c in backend.calls].count("destroy") == 1


### PR DESCRIPTION
## Phase 2, F2 — L3 deny-internal egress for the account browser

The per-account browser (jarbot#106) renders **untrusted web content**, but its only outbound guard was the driver's userspace navigate check — navigate-only, and defeated by DNS rebinding. This adds an **L3 destination-IP DROP** applied at provision so the browser cannot reach the cloud-metadata endpoint (`169.254.169.254`), RFC1918, or CGNAT, while the public web stays open. Because it filters on the **resolved destination at connect time**, it holds against the rebinding the navigate guard can't catch.

**Ships dark** with the rest of Phase 2; the rollout gate (`test_browser_network_isolation.py` green per environment before any `browser_*` grant) is unchanged — now extended with the outbound assertions.

> Branches off master (`ceed44fb`). F4 (the gVisor opt-in) is **deferred** — see the bottom.

### Mechanism — reuse, not reinvention

Mirrors the existing **default-ACCEPT** sibling `apply_secret_egress_dnat` / `build_secret_egress_dnat_script`, **not** the allow-list `apply_network_lockdown` (whose `-P OUTPUT DROP` would break the public web):

- `build_browser_deny_internal_script` / `_verify_script` + `apply_browser_deny_internal` run the same operator-image netns sidecar (the browser holds no `NET_ADMIN`; the sidecar joins its netns with it), leave the filter policy at `ACCEPT`, and append targeted `-A OUTPUT -d <cidr> -j DROP` rules, with their own `sandbox.browser_egress_*` log family and the same fail-closed apply + read-back-verify posture.
- DROP set: `169.254.0.0/16` (link-local + metadata), `10/8`, `172.16/12`, `192.168/16` (RFC1918), `100.64.0.0/10` (CGNAT — not in `ipaddress.is_private`). `127.0.0.0/8` is deliberately **kept open** — the embedded DNS resolver `127.0.0.11` is netns-local and the browser needs it. The docker bridge gateway is RFC1918, so "reach the host via the gateway" is already covered.
- `_provision_browser` applies the lockdown right after create and **fails closed** — tears the container down and re-raises on any failure, rather than handing back a browser that can reach internal services.

### Custom runtime rejected up front (and why F4 is deferred)

This exact netns-sidecar iptables path is **empirically broken under runsc**: `gvisor-validation.yml` has exercised it under `AIOS_SANDBOX_RUNTIME=runsc` and been red for months (`can't initialize iptables table 'filter'`, fail-closed) — two runsc containers sharing a netns via Docker `--network container:` get separate netstacks. So `_provision_browser` **rejects a configured `sandbox_browser_runtime`** with a clean, model-visible `BrowserRuntimeUnsupportedError` before create, instead of an opaque mid-provision iptables failure. **F4** (the gVisor opt-in) and the egress-under-gVisor redesign it needs are tracked as a separate blocked follow-up.

### IPv6 closed by enforcement

`ensure_browser_network` now hard-fails a pre-existing `aios-browser` network with IPv6 enabled (mirroring its existing ICC hard-check), so the IPv4-only lockdown's "no v6 route" premise is **guaranteed**, not trusting the inert `--ipv6=false` create flag on a live network (the #1207 doctrine: per-network v6 must be enforced, not assumed).

### Closing review

The usual **8-agent uncorrelated closing review** (reuse / simplification / efficiency / altitude + security-egress / correctness / test-coverage / shell-iptables). The security agent confirmed the IPv4 hole is genuinely closed (metadata + all RFC1918 + CGNAT dropped, no shadowing ACCEPT, keeping 127/8 open is safe, the guard is the sole prod gate and load-bearing). Folded: **fail-closed teardown now catches `BaseException`** (a provision cancel/timeout still tears the container down, matching the session path); the runsc-reject error renders an **accurate model-facing message** on the tool path instead of the inherited "no browser image" text; the IPv6 enforcement above; a unit assertion that **pins the DROP set EXACTLY** so a "block-everything" regression can't pass green; and driver_call is proven to pass the runtime error through **non-retryably**. Skipped with rationale: extracting a shared apply-sidecar helper (house style + the sibling docstring explicitly reject that factoring), adding multicast/broadcast DROPs (not the SSRF threat), and effective-runtime detection for a daemon-default-runsc host (documented residual; not eumemic's topology).

### Checks

`ruff` / `mypy` clean; **5571 unit** pass; no openapi/SDK drift (all changes internal). The new e2e (`test_real_browser_egress_denies_internal`) reads back every DROP rule from the OUTPUT chain via the operator sidecar (environment-independent proof) and corroborates with a socket probe that cannot reach `169.254.169.254` from inside the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
