### PR TITLE
fix(mcp): structural schema walk in sanitize_mcp_schema (Notion properties-named-property mangling)

### DIFF
--- a/src/aios/mcp/schema.py
+++ b/src/aios/mcp/schema.py
@@ -29,10 +29,30 @@ MCP_ORIGIN_KEY = "_mcp_origin"
 MCP_ANNOTATIONS_KEY = "_mcp_annotations"
 
 
+# Structural-walk keyword sets, mirroring ``aios.tools.schema_diet``'s
+# ``_walk_schemas`` (see its docstring for why a blind ``dict`` walk is wrong:
+# inside ``properties`` the KEYS are field names, never schema keywords).
+#: Keywords whose value is a NAME → schema mapping.
+_SCHEMA_MAPS = ("properties", "$defs", "patternProperties", "definitions")
+#: Keywords whose value is a list of schemas.
+_SCHEMA_LISTS = ("anyOf", "oneOf", "allOf", "prefixItems")
+#: Keywords whose value is a single schema.
+_SCHEMA_VALUES = ("items", "not", "contains", "additionalProperties", "propertyNames")
+
+
 def sanitize_mcp_schema(node: Any) -> Any:
     """Rewrite an untrusted schema into the subset litellm + providers tolerate.
 
-    Three repairs, applied recursively:
+    Three repairs, applied along a **structural** walk that descends only
+    through known schema-composition keywords (``properties`` values,
+    ``items``, ``$defs``, ``anyOf``/``oneOf``/``allOf`` members,
+    ``additionalProperties``/``propertyNames`` when dicts, …). The distinction
+    is load-bearing: a properties MAP whose keys happen to include ``properties``
+    or ``type`` (a tool parameter literally named after a keyword — Notion's
+    ``notion-create-pages`` has a page ``properties`` field) must never be
+    mistaken for a schema node, or its legal keyword values (``"type":
+    "object"``) get mangled into ``{}`` and Anthropic 400s the whole request
+    (draft 2020-12 validation).
 
     * Drop the ``type`` keyword next to ``anyOf``/``oneOf`` (the union carries
       the real shape). Only the JSON Schema ``type`` **keyword** — whose value is
@@ -53,27 +73,52 @@ def sanitize_mcp_schema(node: Any) -> Any:
 
     * Coerce non-dict ``properties`` values (boolean schemas like ``"foo": true``)
       to ``{}`` — litellm's ``_format_object_parameters`` calls ``.get`` on every
-      property value.
+      property value. Applied only to a genuine ``properties`` map on a schema
+      node reached through the structural walk.
     """
     if isinstance(node, dict):
-        has_union = "anyOf" in node or "oneOf" in node
-        drop_type = has_union and isinstance(node.get("type"), (str, list))
-        cleaned = {
-            key: sanitize_mcp_schema(value)
-            for key, value in node.items()
-            if not (drop_type and key == "type")
-        }
-        if cleaned.get("type") == "array" and not isinstance(cleaned.get("items"), dict):
-            cleaned["items"] = {}
-        properties = cleaned.get("properties")
-        if isinstance(properties, dict):
-            cleaned["properties"] = {
-                name: prop if isinstance(prop, dict) else {} for name, prop in properties.items()
-            }
-        return cleaned
+        return _sanitize_schema(node)
     if isinstance(node, list):
         return [sanitize_mcp_schema(item) for item in node]
     return node
+
+
+def _sanitize_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Repair one schema node and recurse structurally into its subschemas."""
+    has_union = "anyOf" in schema or "oneOf" in schema
+    drop_type = has_union and isinstance(schema.get("type"), (str, list))
+    cleaned = {
+        key: _sanitize_keyword_value(key, value)
+        for key, value in schema.items()
+        if not (drop_type and key == "type")
+    }
+    if cleaned.get("type") == "array" and not isinstance(cleaned.get("items"), dict):
+        cleaned["items"] = {}
+    return cleaned
+
+
+def _sanitize_keyword_value(key: str, value: Any) -> Any:
+    """Recurse into ``value`` only when ``key`` is a schema-composition keyword.
+
+    Anything else (``description``, ``default``, ``enum``, ``const``, unknown
+    keywords) is data, not schema — deep-copied untouched so the sanitized
+    result never aliases the caller's input.
+    """
+    if key in _SCHEMA_MAPS and isinstance(value, dict):
+        coerce = key == "properties"
+        return {
+            name: _sanitize_schema(sub)
+            if isinstance(sub, dict)
+            else ({} if coerce else copy.deepcopy(sub))
+            for name, sub in value.items()
+        }
+    if key in _SCHEMA_LISTS and isinstance(value, list):
+        return [
+            _sanitize_schema(arm) if isinstance(arm, dict) else copy.deepcopy(arm) for arm in value
+        ]
+    if key in _SCHEMA_VALUES and isinstance(value, dict):
+        return _sanitize_schema(value)
+    return copy.deepcopy(value)
 
 
 def _sanitize_name_segment(raw: str) -> str:

--- a/tests/unit/test_mcp_schema_sanitize.py
+++ b/tests/unit/test_mcp_schema_sanitize.py
@@ -3,10 +3,54 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+import jsonschema
 from litellm import token_counter
 from mcp.types import Tool
 
 from aios.mcp.schema import make_function_tool, sanitize_mcp_schema
+
+
+def _assert_valid_draft202012(schema: Any) -> None:
+    """The assertion that would have caught the production 400.
+
+    Anthropic validates every ``input_schema`` against JSON Schema draft
+    2020-12 and rejects the ENTIRE request when any tool's schema fails
+    (``tools.N.custom.input_schema: JSON schema is invalid``). The sanitizer
+    must therefore never emit an invalid schema — e.g. ``"type": {}``.
+    """
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+# The real-world trap (Notion MCP ``notion-create-pages``): a property literally
+# named ``properties`` — a page's ``properties`` field — whose SCHEMA carries
+# legal non-dict keyword values (``"type": "object"``, a string ``description``)
+# plus dict-valued ``additionalProperties``/``propertyNames``. A walker that is
+# not structure-aware sees the properties MAP ``{"properties": <schema>}`` as a
+# schema node with a ``properties`` keyword and coerces the inner schema's
+# keywords to ``{}`` (``"type": {}``), which Anthropic 400s.
+_NOTION_CREATE_PAGES_SHAPE: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "pages": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "properties": {
+                        "type": "object",
+                        "description": "Page properties, keyed by property name.",
+                        "propertyNames": {"type": "string"},
+                        "additionalProperties": {"anyOf": [{"type": "string"}, {"type": "number"}]},
+                    },
+                    "content": {"type": "string"},
+                },
+                "required": ["properties"],
+            },
+        },
+    },
+    "required": ["pages"],
+}
+
 
 _MALFORMED_OPTIONAL_LIST_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -154,6 +198,84 @@ class TestSanitizer:
         assert cleaned["properties"]["foo"] == {}
         assert cleaned["properties"]["bar"] == {"type": "string"}
 
+    # --- Structural discipline: a property NAMED like a schema keyword is a
+    # parameter, and its schema's keywords must survive untouched. The mutating
+    # passes may only treat a ``properties`` dict as a name→schema map when the
+    # containing node is a schema node reached through the structural walk.
+
+    def test_notion_shape_property_named_properties_survives_byte_identical(self) -> None:
+        # Red on the pre-fix sanitizer: the blind walk coerced the inner
+        # schema's ``"type": "object"`` and string ``description`` to ``{}``.
+        cleaned = sanitize_mcp_schema(_NOTION_CREATE_PAGES_SHAPE)
+        assert cleaned == _NOTION_CREATE_PAGES_SHAPE
+        _assert_valid_draft202012(cleaned)
+
+    def test_keyword_named_properties_survive_at_depth(self) -> None:
+        # Properties named ``properties`` / ``type`` / ``items`` /
+        # ``description`` at several nesting depths (under ``items``, ``anyOf``
+        # arms, ``additionalProperties``) are parameters, not keywords.
+        node: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string", "description": "a kind"},
+                "items": {"type": "array", "items": {"type": "string"}},
+                "description": {"type": "string"},
+                "nested": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "properties": {
+                                    "type": "object",
+                                    "description": "inner map",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {"type": "string"},
+                                            "description": {"type": "string"},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        {"type": "null"},
+                    ],
+                },
+            },
+        }
+        cleaned = sanitize_mcp_schema(node)
+        assert cleaned == node
+        _assert_valid_draft202012(cleaned)
+
+    def test_items_repair_does_not_inject_phantom_property_into_properties_map(self) -> None:
+        # Same trap for the ``items``-repair pass from #2308: a properties map
+        # holding a (malformed, non-dict) property named ``type`` with value
+        # "array" must not be mistaken for an array schema node — the blind
+        # walk injected a phantom property ``items: {}`` into the map.
+        node = {"type": "object", "properties": {"type": "array"}}
+        cleaned = sanitize_mcp_schema(node)
+        assert "items" not in cleaned["properties"]
+        # The malformed non-dict value itself is still coerced (real map).
+        assert cleaned["properties"]["type"] == {}
+        _assert_valid_draft202012(cleaned)
+
+    def test_every_fixture_sanitizes_to_a_valid_draft202012_schema(self) -> None:
+        fixtures: list[Any] = [
+            _NOTION_CREATE_PAGES_SHAPE,
+            _MALFORMED_OPTIONAL_LIST_SCHEMA,
+            {"type": "array"},
+            {"type": "array", "items": [{"type": "string"}]},
+            {"type": "array", "items": True},
+            {"type": "object", "properties": {"foo": True, "bar": {"type": "string"}}},
+            {"type": "object", "properties": {"type": "array"}},
+            {
+                "oneOf": [{"type": "string"}, {"type": "null"}],
+                "type": "string",
+            },
+        ]
+        for fixture in fixtures:
+            _assert_valid_draft202012(sanitize_mcp_schema(fixture))
+
     def test_returns_non_dict_unchanged(self) -> None:
         assert sanitize_mcp_schema("string") == "string"
         assert sanitize_mcp_schema(42) == 42
@@ -218,6 +340,18 @@ class TestMakeFunctionToolIntegration:
         tool = Tool(name="t", description="d", inputSchema=schema)
         envelope = make_function_tool("mcp__s__t", tool)
 
+        count = token_counter(messages=[{"role": "user", "content": "hi"}], tools=[envelope])
+        assert count > 0
+
+    def test_notion_shape_survives_token_counter(self) -> None:
+        tool = Tool(
+            name="notion-create-pages",
+            description="Create pages",
+            inputSchema=_NOTION_CREATE_PAGES_SHAPE,
+        )
+        envelope = make_function_tool("mcp__notion__notion-create-pages", tool)
+
+        assert envelope["function"]["parameters"] == _NOTION_CREATE_PAGES_SHAPE
         count = token_counter(messages=[{"role": "user", "content": "hi"}], tools=[envelope])
         assert count > 0
 


### PR DESCRIPTION
## Problem

Introduced by [#2308](https://github.com/eumemic/aios/pull/2308): the new "coerce non-dict `properties` values to `{}`" pass in `sanitize_mcp_schema` is not structure-aware. When a schema contains a property literally **named** `properties` — Notion MCP's `notion-create-pages` does (a page's `properties` field) — the blind dict walk treats that property's SCHEMA as a name→schema map and coerces its legal non-dict keyword values: `"type": "object"` → `{}`, `"description": "..."` → `{}`.

The mangled output (`"type": {}`) violates JSON Schema draft 2020-12 and Anthropic rejects the **entire request**:

```
tools.99.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12
```

**Why it unmasked in prod only now:** before #2308, the same schemas crashed litellm's `token_counter` with a `KeyError` before the provider ever saw them; #2308 fixed the crash, so the (now-mangled) schemas reached Anthropic for the first time and started 400ing every Notion-MCP agent's turns.

**Mitigation in place:** Notion MCP disabled on 12 agents pending this fix.

## Fix

Every mutating pass now runs along a **structural** walk that descends only through schema-composition keywords (`properties`/`$defs` values, `items`, `anyOf`/`oneOf`/`allOf` members, `additionalProperties`/`propertyNames` when dicts, ...), mirroring the `_walk_schemas` structural walker `src/aios/tools/schema_diet.py` already uses for exactly this reason (mirrored rather than imported to avoid an `aios.mcp` → `aios.tools` dependency). A `properties` dict is treated as a name→schema map ONLY when its containing node is a schema node reached through that walk.

The `items`-repair pass from #2308 had the same trap (verified red): a properties map holding a malformed property named `type` with value `"array"` got a phantom `items: {}` **property** injected. It is now confined to real schema nodes; the coercion pass is kept (it still guards litellm's `_format_object_parameters` `.get` on boolean property schemas) but applied only to genuine properties maps.

## Tests (red-first)

All five new tests FAIL on unmodified master, reproducing the exact live mangling (`'description': {}, 'type': {}`):

- Notion-shape fixture (property named `properties` with string `type`/`description`, dict `additionalProperties`/`propertyNames`) survives sanitization byte-identical.
- `jsonschema.Draft202012Validator.check_schema` helper — the assertion that would have caught the 400 — applied to every fixture's sanitized output.
- Keyword-named properties (`properties`, `type`, `items`, `description`) survive at nesting depth (under `items`, `anyOf` arms, `additionalProperties`).
- Phantom-`items` injection into a properties map is prevented; the legit #2308 repairs still hold (bare `{"type":"array"}` gains `items: {}`; genuinely non-dict values in a REAL properties map still coerce).
- Sanitized Notion fixture survives the real `litellm.token_counter`.

`jsonschema` was already a dependency (dispatch-time validation) — no new deps.

## Verification

- `uv run pytest tests/unit/test_mcp_schema_sanitize.py tests/unit/test_schema_diet.py tests/unit/test_workflow_tool_schema_budget.py -q` — 126 passed
- `uv run mypy src tests` — clean; `ruff check` + `ruff format --check` — clean
- `uv run pytest tests/unit -q` — 5734 passed

## Substrate state changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
