### PR TITLE
fix(worker): the startup attachment sweep can no longer stop the worker booting

### DIFF
--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -147,6 +147,39 @@ class StartupRecoveryResult:
     woken_runs: int
 
 
+async def sweep_orphan_attachments_best_effort(pool: asyncpg.Pool[Any]) -> int | None:
+    """Startup orphan-attachment sweep that can never stop the worker booting.
+
+    Extracted from :func:`worker_main` for the same reason as
+    :func:`run_startup_recovery` — so the contract is unit-testable without
+    booting a full worker process. The contract here is one line: **this
+    never raises.**
+
+    It used to. The sweep runs before the maintenance-loop tasks are created,
+    so any failure killed the process, which meant the worker could not start
+    while Postgres was busy — exactly when its maintenance loops (journal
+    prune, sandbox GC, host-dir reapers) are most needed. Observed 2026-08-28:
+    a journal drain loaded the database enough that
+    ``list_attachment_paths_for_sessions`` hit the statement timeout, and the
+    worker crash-looped three times before happening to catch a quiet moment.
+
+    The asymmetry justifies failing open: a skipped sweep only defers orphan
+    reclamation to the next successful boot (disk hygiene, bounded by
+    ``_IN_FLIGHT_AGE_S`` staging semantics), whereas a dead worker halts every
+    session, run, trigger and reaper on the instance.
+
+    Returns the number of files reclaimed, or ``None`` when the sweep failed.
+    """
+    log = get_logger("aios.worker")
+    try:
+        return await sweep_orphan_attachments(pool)
+    except Exception:
+        # `exception`, never a bare warning: a silently skipped sweep would
+        # let orphans accumulate with nothing in the log to point at.
+        log.exception("worker.orphan_attachment_sweep_failed")
+        return None
+
+
 async def run_startup_recovery(
     pool: asyncpg.Pool[Any],
     inflight_tool_registry: InflightToolRegistry,
@@ -507,7 +540,9 @@ async def worker_main() -> None:
         # is invisible to the events table until its dedup transaction
         # commits, so commit-happens-before-sweep ordering is governed
         # by Postgres snapshot isolation rather than wall-clock.
-        deleted_attachments = await sweep_orphan_attachments(pool)
+        #
+        # Never fatal — see :func:`sweep_orphan_attachments_best_effort`.
+        deleted_attachments = await sweep_orphan_attachments_best_effort(pool)
         if deleted_attachments:
             log.info("worker.reaped_orphan_attachments", count=deleted_attachments)
 

--- a/tests/unit/test_worker_boot_sweep_nonfatal.py
+++ b/tests/unit/test_worker_boot_sweep_nonfatal.py
@@ -1,0 +1,120 @@
+"""The startup orphan-attachment sweep must never stop the worker booting.
+
+Regression for 2026-08-28: ``sweep_orphan_attachments`` runs in ``worker_main``
+*before* the maintenance-loop tasks are created, and any exception propagated
+out of it killed the process. A journal drain loaded Postgres enough that
+``list_attachment_paths_for_sessions`` hit the statement timeout, so the worker
+crash-looped three times before catching a quiet moment — i.e. **the worker
+could not start while the database was busy, which is precisely when its
+maintenance loops (journal prune, sandbox GC, reapers) were most needed.**
+
+The asymmetry that makes failing open correct: a skipped sweep defers orphan
+reclamation to the next successful boot (disk hygiene); a dead worker halts
+every session, run, trigger and reaper on the instance.
+
+These tests pin the CONSTRAINT (never raises), not just the capability — the
+incident's failure mode was an exception escaping, so the load-bearing
+assertions are the ones that let a raising sweep through and demand a return.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import asyncpg
+import pytest
+
+from aios.harness.worker import sweep_orphan_attachments_best_effort
+
+_TARGET = "aios.harness.worker.sweep_orphan_attachments"
+
+
+@pytest.mark.asyncio
+async def test_returns_count_on_success() -> None:
+    """The happy path is unchanged: the reclaimed count is passed through."""
+    pool = mock.Mock(spec=asyncpg.Pool)
+    with mock.patch(_TARGET, new=mock.AsyncMock(return_value=7)):
+        assert await sweep_orphan_attachments_best_effort(pool) == 7
+
+
+@pytest.mark.asyncio
+async def test_zero_is_preserved_not_coerced() -> None:
+    """0 must stay 0, distinct from the None that signals failure."""
+    pool = mock.Mock(spec=asyncpg.Pool)
+    with mock.patch(_TARGET, new=mock.AsyncMock(return_value=0)):
+        result = await sweep_orphan_attachments_best_effort(pool)
+    assert result == 0
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_statement_timeout_does_not_propagate() -> None:
+    """The exact incident shape: QueryCanceledError must be swallowed."""
+    pool = mock.Mock(spec=asyncpg.Pool)
+    boom = asyncpg.exceptions.QueryCanceledError("canceling statement due to statement timeout")
+    with mock.patch(_TARGET, new=mock.AsyncMock(side_effect=boom)):
+        assert await sweep_orphan_attachments_best_effort(pool) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        asyncpg.exceptions.QueryCanceledError("statement timeout"),
+        asyncpg.exceptions.TooManyConnectionsError("pool exhausted"),
+        OSError("workspace root gone read-only"),
+        RuntimeError("anything at all"),
+    ],
+    ids=["timeout", "pool-exhausted", "fs-error", "arbitrary"],
+)
+async def test_no_exception_type_escapes(exc: BaseException) -> None:
+    """Fail open for ANY failure, not just the one class we happened to see.
+
+    Pinning only ``QueryCanceledError`` would re-open the hole for the next
+    DB-pressure symptom (pool exhaustion, a read-only FS during the walk).
+    """
+    pool = mock.Mock(spec=asyncpg.Pool)
+    with mock.patch(_TARGET, new=mock.AsyncMock(side_effect=exc)):
+        assert await sweep_orphan_attachments_best_effort(pool) is None
+
+
+@pytest.mark.asyncio
+async def test_failure_is_logged_at_exception_level() -> None:
+    """A skipped sweep must be loud — silence would let orphans accumulate
+    with nothing in the log to point at."""
+    pool = mock.Mock(spec=asyncpg.Pool)
+    logger = mock.Mock()
+    with (
+        mock.patch(_TARGET, new=mock.AsyncMock(side_effect=RuntimeError("boom"))),
+        mock.patch("aios.harness.worker.get_logger", return_value=logger),
+    ):
+        await sweep_orphan_attachments_best_effort(pool)
+
+    logger.exception.assert_called_once()
+    assert logger.exception.call_args.args[0] == "worker.orphan_attachment_sweep_failed"
+    # never downgraded to a warning that an operator would scroll past
+    logger.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_worker_main_calls_the_guarded_helper() -> None:
+    """Guard against the fix being undone by a future edit reverting the call
+    site to the raw sweep — the helper is worthless if worker_main stops using
+    it.  Asserted on the source, since booting worker_main is not unit-scale.
+    """
+    import inspect
+
+    from aios.harness import worker
+
+    src = inspect.getsource(worker.worker_main)
+    assert "sweep_orphan_attachments_best_effort(pool)" in src
+    # the raw, raising call must not be reachable from worker_main
+    assert "await sweep_orphan_attachments(pool)" not in src
+
+
+def test_helper_signature_is_optional_int() -> None:
+    """``None`` is the failure signal and callers must treat it as falsy."""
+    import inspect
+
+    sig = inspect.signature(sweep_orphan_attachments_best_effort)
+    assert sig.return_annotation in ("int | None", int | None)


### PR DESCRIPTION
## The bug

`sweep_orphan_attachments` runs in `worker_main` **before** the maintenance-loop tasks are created, and any exception it raised killed the process.

That made the worker unstartable while Postgres was busy — precisely when its maintenance loops (journal prune, sandbox GC, host-dir reapers) are most needed.

## Observed

aios-hil-01, 2026-08-28. A journal-retention drain loaded the database enough that `list_attachment_paths_for_sessions` hit the statement timeout:

```
File "/app/src/aios/harness/worker.py", line 510, in worker_main
    deleted_attachments = await sweep_orphan_attachments(pool)
File "/app/src/aios/harness/attachment_gc.py", line 102, in sweep_orphan_attachments
    referenced_by_session = await queries.list_attachment_paths_for_sessions(...)
asyncpg.exceptions.QueryCanceledError: canceling statement due to statement timeout
```

`worker.unexpected_exit` twice, `RestartCount=3`. It came up on the third attempt by catching a quiet moment — luck, not design. The drain that caused the load exists to *relieve* database pressure, so the failure mode is self-reinforcing.

## The fix

Fail open. The asymmetry is lopsided:

- a **skipped sweep** defers orphan reclamation to the next successful boot — disk hygiene, already bounded by the existing `_IN_FLIGHT_AGE_S` staging semantics
- a **dead worker** halts every session, run, trigger and reaper on the instance

Extracted as `sweep_orphan_attachments_best_effort` rather than an inline `try/except`, following the precedent this file already set with `run_startup_recovery` — pulled out of `worker_main` specifically so the contract is testable without booting a full worker process.

Behaviour: failure logs at `exception` level and returns `None`; success passes the count through unchanged, with `0` preserved as distinct from the `None` failure signal. The boot-ordering property (sweep before inbound POSTs can land) is unchanged when the sweep succeeds.

## Tests

Pin the **constraint**, not the capability — the incident's failure mode was an exception escaping, so the load-bearing cases feed a raising sweep through and demand a return:

- parametrised across timeout / pool-exhaustion / FS-error / arbitrary, so the guard isn't narrowed to the one class we happened to see
- failure must log at `exception` level and never be downgraded to a warning
- `worker_main` must still call the guarded helper, so a future edit can't silently revert the call site
- `0` is preserved rather than coerced

**Mutation-checked:** removing the guard fails 6 of the 10.

## Residue

If boot sweeps keep failing under sustained load, orphans accumulate with nothing reaping them — there is no periodic attachment sweep, only this one boot call. That is now loud (`worker.orphan_attachment_sweep_failed`) rather than fatal, but converting it to a supervised background loop like `_reclaimable_prune_loop` would close it properly. Deliberately out of scope here: that would move the sweep after inbound traffic can land, which weakens the GC's ordering argument and deserves its own change.
