### PR TITLE
/v1/runs?workflow_id= returns stale runs with no ordering contract — it produced a false 'the launch path is dead' incident

### DIFF
--- a/migrations/versions/0176_wf_runs_recency_indexes.py
+++ b/migrations/versions/0176_wf_runs_recency_indexes.py
@@ -2,6 +2,13 @@
 
 Revision ID: 0176
 Revises: 0175
+
+The indexes are built and removed concurrently so this migration remains online
+on a populated ``wf_runs`` table. Each build drops any same-named index first:
+a cancelled ``CREATE INDEX CONCURRENTLY`` can leave an invalid index behind,
+and ``IF NOT EXISTS`` alone would incorrectly preserve that unusable index on
+retry. Both operations run in an autocommit block because PostgreSQL forbids
+concurrent index DDL inside a transaction block.
 """
 
 from alembic import op
@@ -11,20 +18,29 @@ down_revision = "0175"
 branch_labels = None
 depends_on = None
 
+_INDEXES = (
+    (
+        "wf_runs_account_recency_idx",
+        "ON wf_runs (account_id, created_at DESC, id DESC) WHERE archived_at IS NULL",
+    ),
+    (
+        "wf_runs_account_workflow_recency_idx",
+        "ON wf_runs (account_id, workflow_id, created_at DESC, id DESC) "
+        "WHERE archived_at IS NULL",
+    ),
+)
+
 
 def upgrade() -> None:
-    op.execute(
-        "CREATE INDEX wf_runs_account_recency_idx "
-        "ON wf_runs (account_id, created_at DESC, id DESC) "
-        "WHERE archived_at IS NULL"
-    )
-    op.execute(
-        "CREATE INDEX wf_runs_account_workflow_recency_idx "
-        "ON wf_runs (account_id, workflow_id, created_at DESC, id DESC) "
-        "WHERE archived_at IS NULL"
-    )
+    with op.get_context().autocommit_block():
+        for name, definition in _INDEXES:
+            # Remove an invalid remnant from an interrupted concurrent build so
+            # rerunning the migration performs a real rebuild.
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+            op.execute(f"CREATE INDEX CONCURRENTLY {name} {definition}")
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX wf_runs_account_workflow_recency_idx")
-    op.execute("DROP INDEX wf_runs_account_recency_idx")
+    with op.get_context().autocommit_block():
+        for name, _definition in reversed(_INDEXES):
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")

--- a/migrations/versions/0176_wf_runs_recency_indexes.py
+++ b/migrations/versions/0176_wf_runs_recency_indexes.py
@@ -1,0 +1,30 @@
+"""Index workflow-run collection recency ordering.
+
+Revision ID: 0176
+Revises: 0175
+"""
+
+from alembic import op
+
+revision = "0176"
+down_revision = "0175"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX wf_runs_account_recency_idx "
+        "ON wf_runs (account_id, created_at DESC, id DESC) "
+        "WHERE archived_at IS NULL"
+    )
+    op.execute(
+        "CREATE INDEX wf_runs_account_workflow_recency_idx "
+        "ON wf_runs (account_id, workflow_id, created_at DESC, id DESC) "
+        "WHERE archived_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX wf_runs_account_workflow_recency_idx")
+    op.execute("DROP INDEX wf_runs_account_recency_idx")

--- a/openapi.json
+++ b/openapi.json
@@ -11204,7 +11204,7 @@
           "runs"
         ],
         "summary": "List Runs",
-        "description": "List the account's runs, newest first. First page: optional ``workflow_id`` /\n``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:\n``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.",
+        "description": "List the account's unarchived runs in ``created_at DESC, id DESC`` order.\n\nThis ordering applies before ``limit`` to both filtered and unfiltered reads,\nso a first-page ``?workflow_id=...&limit=N`` query returns the N most recently\ncreated matching runs. ``id DESC`` is the stable tiebreaker for equal creation\ntimestamps. First page: optional ``workflow_id`` / ``status`` /\n``parent_run_id`` filters + ``limit``; subsequent pages:\n``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.",
         "operationId": "list_runs",
         "parameters": [
           {

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/list_runs.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/list_runs.py
@@ -114,8 +114,13 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | ListResponseWfRun]:
     """List Runs
 
-     List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+     List the account's unarchived runs in ``created_at DESC, id DESC`` order.
+
+    This ordering applies before ``limit`` to both filtered and unfiltered reads,
+    so a first-page ``?workflow_id=...&limit=N`` query returns the N most recently
+    created matching runs. ``id DESC`` is the stable tiebreaker for equal creation
+    timestamps. First page: optional ``workflow_id`` / ``status`` /
+    ``parent_run_id`` filters + ``limit``; subsequent pages:
     ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.
 
     Args:
@@ -162,8 +167,13 @@ def sync(
 ) -> HTTPValidationError | ListResponseWfRun | None:
     """List Runs
 
-     List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+     List the account's unarchived runs in ``created_at DESC, id DESC`` order.
+
+    This ordering applies before ``limit`` to both filtered and unfiltered reads,
+    so a first-page ``?workflow_id=...&limit=N`` query returns the N most recently
+    created matching runs. ``id DESC`` is the stable tiebreaker for equal creation
+    timestamps. First page: optional ``workflow_id`` / ``status`` /
+    ``parent_run_id`` filters + ``limit``; subsequent pages:
     ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.
 
     Args:
@@ -205,8 +215,13 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | ListResponseWfRun]:
     """List Runs
 
-     List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+     List the account's unarchived runs in ``created_at DESC, id DESC`` order.
+
+    This ordering applies before ``limit`` to both filtered and unfiltered reads,
+    so a first-page ``?workflow_id=...&limit=N`` query returns the N most recently
+    created matching runs. ``id DESC`` is the stable tiebreaker for equal creation
+    timestamps. First page: optional ``workflow_id`` / ``status`` /
+    ``parent_run_id`` filters + ``limit``; subsequent pages:
     ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.
 
     Args:
@@ -251,8 +266,13 @@ async def asyncio(
 ) -> HTTPValidationError | ListResponseWfRun | None:
     """List Runs
 
-     List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+     List the account's unarchived runs in ``created_at DESC, id DESC`` order.
+
+    This ordering applies before ``limit`` to both filtered and unfiltered reads,
+    so a first-page ``?workflow_id=...&limit=N`` query returns the N most recently
+    created matching runs. ``id DESC`` is the stable tiebreaker for equal creation
+    timestamps. First page: optional ``workflow_id`` / ``status`` /
+    ``parent_run_id`` filters + ``limit``; subsequent pages:
     ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.
 
     Args:

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -234,8 +234,13 @@ async def list_runs(
     parent_run_id: str | None = None,
     limit: PageLimit = None,
 ) -> ListResponse[WfRun]:
-    """List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+    """List the account's unarchived runs in ``created_at DESC, id DESC`` order.
+
+    This ordering applies before ``limit`` to both filtered and unfiltered reads,
+    so a first-page ``?workflow_id=...&limit=N`` query returns the N most recently
+    created matching runs. ``id DESC`` is the stable tiebreaker for equal creation
+    timestamps. First page: optional ``workflow_id`` / ``status`` /
+    ``parent_run_id`` filters + ``limit``; subsequent pages:
     ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs."""
     st = page_cursor(
         cursor,

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -568,26 +568,39 @@ async def list_wf_runs(
     parent run). The run-side analog of filtering sessions by
     ``parent_run_id`` for a run's ``agent()`` children.
 
+    Ordering is explicitly ``created_at DESC, id DESC``. The id tiebreaker makes
+    equal-timestamp pages stable, while the cursor remains the last run id: its
+    timestamp is resolved server-side to form the composite keyset.
+
     When ``launcher_session_id`` is set, the launcher filter lists ALL of a
     session's runs including terminal ones, so it is NOT fully served by the
     ``wf_runs_launcher_active_idx`` partial index (which covers only ``status IN
-    ('pending','running','suspended')``); the account-scoped ``ORDER BY id DESC``
-    keyset still applies.
+    ('pending','running','suspended')``).
     """
-    return await _list_scoped(
-        conn,
-        table="wf_runs",
-        account_id=account_id,
-        row=_row_to_wf_run,
-        limit=limit,
-        after=after,
-        filters=[
-            ("workflow_id", workflow_id),
-            ("status", status),
-            ("parent_run_id", parent_run_id),
-            ("launcher_session_id", launcher_session_id),
-        ],
+    args: list[Any] = [account_id]
+    where = ["archived_at IS NULL", "account_id = $1"]
+    for column, value in (
+        ("workflow_id", workflow_id),
+        ("status", status),
+        ("parent_run_id", parent_run_id),
+        ("launcher_session_id", launcher_session_id),
+    ):
+        if value is not None:
+            args.append(value)
+            where.append(f"{column} = ${len(args)}")
+    if after is not None:
+        args.append(after)
+        where.append(
+            f"(created_at, id) < (SELECT created_at, id FROM wf_runs "
+            f"WHERE id = ${len(args)} AND account_id = $1)"
+        )
+    args.append(limit)
+    rows = await conn.fetch(
+        f"SELECT * FROM wf_runs WHERE {' AND '.join(where)} "
+        f"ORDER BY created_at DESC, id DESC LIMIT ${len(args)}",
+        *args,
     )
+    return [_row_to_wf_run(row) for row in rows]
 
 
 async def archive_run(conn: asyncpg.Connection[Any], run_id: str, *, account_id: str) -> WfRun:

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -77,7 +77,14 @@ async def test_create_workflow_run_and_observe(http_client: httpx.AsyncClient) -
     assert r.status_code == 200, r.text
     assert [w["id"] for w in r.json()["data"]] == [workflow["id"]]
 
-    # Launch a run (201, pending).
+    # Seed an older matching run, then launch a new one. The immediate filtered
+    # read must return the mutation at the head of a limit-constrained page.
+    old_run = (
+        await http_client.post(
+            "/v1/runs",
+            json={"workflow_id": workflow["id"], "environment_id": env_id, "input": {"x": 0}},
+        )
+    ).json()
     r = await http_client.post(
         "/v1/runs",
         json={"workflow_id": workflow["id"], "environment_id": env_id, "input": {"x": 1}},
@@ -87,11 +94,17 @@ async def test_create_workflow_run_and_observe(http_client: httpx.AsyncClient) -
     assert run["workflow_id"] == workflow["id"] and run["status"] == "pending"
     assert run["input"] == {"x": 1}
 
+    newest = await http_client.get("/v1/runs", params={"workflow_id": workflow["id"], "limit": 1})
+    assert newest.status_code == 200, newest.text
+    assert [x["id"] for x in newest.json()["data"]] == [run["id"]]
+    assert old_run["id"] != run["id"]
+
     # Fetch + list it.
     r = await http_client.get(f"/v1/runs/{run['id']}")
     assert r.status_code == 200 and r.json()["id"] == run["id"]
     r = await http_client.get("/v1/runs", params={"workflow_id": workflow["id"]})
-    assert r.status_code == 200 and [x["id"] for x in r.json()["data"]] == [run["id"]]
+    assert r.status_code == 200
+    assert [x["id"] for x in r.json()["data"]] == [run["id"], old_run["id"]]
 
     # Its journal is readable (a fresh pending run has no events yet — the worker
     # isn't running in this ASGI test).

--- a/tests/unit/db/test_wf_runs_recency_order.py
+++ b/tests/unit/db/test_wf_runs_recency_order.py
@@ -1,0 +1,29 @@
+"""Regression coverage for the workflow-run collection ordering contract."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.db.queries import workflows
+
+
+@pytest.mark.asyncio
+async def test_list_wf_runs_orders_by_created_at_with_stable_keyset() -> None:
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+
+    await workflows.list_wf_runs(
+        conn,
+        account_id="acc_1",
+        workflow_id="wf_1",
+        after="wfr_anchor",
+        limit=10,
+    )
+
+    sql, *args = conn.fetch.await_args.args
+    normalized = " ".join(sql.split())
+    assert "(created_at, id) < (SELECT created_at, id FROM wf_runs" in normalized
+    assert "ORDER BY created_at DESC, id DESC" in normalized
+    assert args == ["acc_1", "wf_1", "wfr_anchor", 10]

--- a/tests/unit/test_check_migration_heads.py
+++ b/tests/unit/test_check_migration_heads.py
@@ -129,5 +129,5 @@ def test_known_good_repository_has_expected_revision_count_and_one_head() -> Non
     # branch was cut. A count pin resolved by PICKING A SIDE re-asserts a number
     # nobody re-measured -- which is how a pin meant to catch accidental
     # deletions becomes the thing that fails CI.
-    assert len(revisions) == 162
+    assert len(revisions) == 163
     assert check_history(revisions) in revisions

--- a/tests/unit/test_migration_0176_wf_runs_recency_indexes.py
+++ b/tests/unit/test_migration_0176_wf_runs_recency_indexes.py
@@ -1,0 +1,53 @@
+"""Regression tests for the online workflow-run recency indexes."""
+
+from __future__ import annotations
+
+import importlib.util
+from contextlib import nullcontext
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+_MIGRATION = (
+    Path(__file__).parents[2] / "migrations" / "versions" / "0176_wf_runs_recency_indexes.py"
+)
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_migration_0176", _MIGRATION)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _capture(operation: str) -> tuple[list[str], Mock]:
+    migration = _load()
+    context = Mock()
+    context.autocommit_block.return_value = nullcontext()
+    migration.op.get_context = Mock(return_value=context)
+    statements: list[str] = []
+    migration.op.execute = statements.append
+
+    getattr(migration, operation)()
+    return statements, context
+
+
+def test_upgrade_builds_both_indexes_concurrently_outside_transaction() -> None:
+    statements, context = _capture("upgrade")
+
+    creates = [statement for statement in statements if statement.startswith("CREATE INDEX")]
+    drops = [statement for statement in statements if statement.startswith("DROP INDEX")]
+    assert len(creates) == 2
+    assert all(statement.startswith("CREATE INDEX CONCURRENTLY ") for statement in creates)
+    assert len(drops) == 2
+    assert all(statement.startswith("DROP INDEX CONCURRENTLY IF EXISTS ") for statement in drops)
+    context.autocommit_block.assert_called_once_with()
+
+
+def test_downgrade_removes_both_indexes_concurrently_outside_transaction() -> None:
+    statements, context = _capture("downgrade")
+
+    assert len(statements) == 2
+    assert all(statement.startswith("DROP INDEX CONCURRENTLY IF EXISTS ") for statement in statements)
+    context.autocommit_block.assert_called_once_with()

--- a/tests/unit/test_migration_0176_wf_runs_recency_indexes.py
+++ b/tests/unit/test_migration_0176_wf_runs_recency_indexes.py
@@ -36,18 +36,23 @@ def _capture(operation: str) -> tuple[list[str], Mock]:
 def test_upgrade_builds_both_indexes_concurrently_outside_transaction() -> None:
     statements, context = _capture("upgrade")
 
-    creates = [statement for statement in statements if statement.startswith("CREATE INDEX")]
-    drops = [statement for statement in statements if statement.startswith("DROP INDEX")]
-    assert len(creates) == 2
-    assert all(statement.startswith("CREATE INDEX CONCURRENTLY ") for statement in creates)
-    assert len(drops) == 2
-    assert all(statement.startswith("DROP INDEX CONCURRENTLY IF EXISTS ") for statement in drops)
+    assert statements == [
+        "DROP INDEX CONCURRENTLY IF EXISTS wf_runs_account_recency_idx",
+        "CREATE INDEX CONCURRENTLY wf_runs_account_recency_idx "
+        "ON wf_runs (account_id, created_at DESC, id DESC) WHERE archived_at IS NULL",
+        "DROP INDEX CONCURRENTLY IF EXISTS wf_runs_account_workflow_recency_idx",
+        "CREATE INDEX CONCURRENTLY wf_runs_account_workflow_recency_idx "
+        "ON wf_runs (account_id, workflow_id, created_at DESC, id DESC) "
+        "WHERE archived_at IS NULL",
+    ]
     context.autocommit_block.assert_called_once_with()
 
 
 def test_downgrade_removes_both_indexes_concurrently_outside_transaction() -> None:
     statements, context = _capture("downgrade")
 
-    assert len(statements) == 2
-    assert all(statement.startswith("DROP INDEX CONCURRENTLY IF EXISTS ") for statement in statements)
+    assert statements == [
+        "DROP INDEX CONCURRENTLY IF EXISTS wf_runs_account_workflow_recency_idx",
+        "DROP INDEX CONCURRENTLY IF EXISTS wf_runs_account_recency_idx",
+    ]
     context.autocommit_block.assert_called_once_with()


### PR DESCRIPTION
Automated dev-pipeline build for issue #2177.