### PR TITLE
feat(browser): read-only peek — a JPEG of a session's page for the product's live view

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2004,6 +2004,72 @@
         }
       }
     },
+    "/v1/browser/peek": {
+      "get": {
+        "tags": [
+          "browser"
+        ],
+        "summary": "Browser Peek",
+        "description": "A read-only look at a page: one JPEG of the viewport plus the trusted\nchrome, from ``session_id``'s page when given, else the last-active one.\nNever provisions and never creates a page; refused (409) while a human\nholds the computer.",
+        "operationId": "browser_peek_v1_browser_peek_get",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowserPeekResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/browser/sites/{host}": {
       "delete": {
         "tags": [
@@ -13282,6 +13348,102 @@
         ],
         "title": "BoundChat",
         "description": "Read view of one ``chat_sessions`` row.\n\nReturned by ``GET /v1/connections/{id}/bound-chats``.  Operator-bound\nrows and per-chat-spawned rows are returned together \u2014 the table\ndoesn't tag the writer.\n\n``chat_id`` is the **authoritative, gate-relevant identifier** \u2014 it is\nwhat the inbound-admission gate (``AllowList.chat_ids``) matches on.\nThis view deliberately does not surface a connector-supplied\n``display_name`` / ``sender_name``: that value is self-reported by the\nconnector and forgeable, so an operator copying an allowlist entry from\nthis view trusts the ``chat_id``, never a display name."
+      },
+      "BrowserPeekPage": {
+        "properties": {
+          "jpeg_b64": {
+            "type": "string",
+            "title": "Jpeg B64"
+          },
+          "w": {
+            "type": "integer",
+            "title": "W"
+          },
+          "h": {
+            "type": "integer",
+            "title": "H"
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Origin"
+          },
+          "security": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "secure",
+                  "insecure"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Security"
+          }
+        },
+        "type": "object",
+        "required": [
+          "jpeg_b64",
+          "w",
+          "h"
+        ],
+        "title": "BrowserPeekPage",
+        "description": "One JPEG of a page's viewport plus its trusted chrome. ``origin`` and\n``security`` come from the driver's committed URL, never the pixels."
+      },
+      "BrowserPeekResponse": {
+        "properties": {
+          "running": {
+            "type": "boolean",
+            "title": "Running"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BrowserPeekPage"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "running"
+        ],
+        "title": "BrowserPeekResponse",
+        "description": "A read-only look at the computer: not running, running with no page\nto show, or running with the page. Never provisions, never creates a\npage, and is refused while a human holds the computer."
       },
       "BrowserStatusResponse": {
         "properties": {

--- a/packages/aios-browser-driver/aios_browser_driver/browser_protocol.py
+++ b/packages/aios-browser-driver/aios_browser_driver/browser_protocol.py
@@ -133,6 +133,7 @@ BrowserOp = Literal[
     "takeover_open",
     "takeover_close",
     "status",
+    "peek",
     "revoke_site",
 ]
 

--- a/packages/aios-browser-driver/aios_browser_driver/host.py
+++ b/packages/aios-browser-driver/aios_browser_driver/host.py
@@ -27,6 +27,7 @@ crash-looping container beats a live one that answers nothing.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import json
 import logging
@@ -56,7 +57,7 @@ from aios_browser_driver.errors import ActionError, error_response, first_line, 
 from aios_browser_driver.hosts import normalize_host, signed_in_hosts
 from aios_browser_driver.snapshot.snapshot import take_snapshot
 from aios_browser_driver.takeover.injector import InputInjector
-from aios_browser_driver.takeover.screencast import Screencast
+from aios_browser_driver.takeover.screencast import Screencast, chrome_of
 from aios_browser_driver.takeover.spool import SpoolTailer
 from aios_browser_driver.takeover.state import AdmissionGate, ReplayCache, Takeover, now
 
@@ -301,6 +302,8 @@ class BrowserHost:
                 return await self._takeover_close(request, boot, epoch)
             if request.op == "status":
                 return await self._status(boot, epoch)
+            if request.op == "peek":
+                return await self._peek(request, boot, epoch)
             if request.op == "revoke_site":
                 if self._standing is not None:
                     # Never clear cookies under the human — the product polls
@@ -569,6 +572,44 @@ class BrowserHost:
             url=url,
             title=title,
             data={"signed_in_hosts": await self._signed_in_hosts()},
+        )
+
+    async def _peek(self, request: BrowserRequest, boot: str, epoch: int) -> BrowserResponse:
+        """A read-only look at a page for the product's live view: one JPEG
+        of the current viewport plus the trusted chrome, taken from the
+        session's page when ``session_id`` is given, else the last-active
+        page. Never creates a page (``data.page`` is ``None`` when there is
+        nothing to look at) and never admits through the gate — it neither
+        moves the page nor competes with an action. Refused during a
+        takeover: the human's live page is theirs alone."""
+        if self._standing is not None:
+            return error_response(
+                boot, epoch, "takeover_active", "a human has taken over the computer"
+            )
+        session_id = request.session_id or self._last_session
+        entry = self._entries.get(session_id) if session_id else None
+        page = entry.active_page if entry else None
+        if page is None:
+            return BrowserResponse(ok=True, boot=boot, epoch=epoch, data={"page": None})
+        url = page.url
+        origin, security = chrome_of(url)
+        jpeg = await page.screenshot(type="jpeg", quality=55, scale="css")
+        viewport = page.viewport_size or {"width": 0, "height": 0}
+        return BrowserResponse(
+            ok=True,
+            boot=boot,
+            epoch=epoch,
+            url=url,
+            title=await page.title(),
+            data={
+                "page": {
+                    "jpeg_b64": base64.b64encode(jpeg).decode("ascii"),
+                    "w": viewport["width"],
+                    "h": viewport["height"],
+                    "origin": origin,
+                    "security": security,
+                }
+            },
         )
 
     async def _revoke_site(self, args: dict[str, Any], boot: str, epoch: int) -> BrowserResponse:

--- a/packages/aios-browser-driver/aios_browser_driver/takeover/screencast.py
+++ b/packages/aios-browser-driver/aios_browser_driver/takeover/screencast.py
@@ -80,7 +80,7 @@ class Screencast:
         # persists a stale old-page frame under the new page's origin.
         self._queue = asyncio.Queue()
         self._last_persist = 0.0
-        self._origin, self._security = _chrome_of(page.url)
+        self._origin, self._security = chrome_of(page.url)
         self._url = page.url or None
         cdp = await self._context.new_cdp_session(page)
         self._cdp = cdp
@@ -126,7 +126,7 @@ class Screencast:
     def _on_nav(self, params: dict[str, Any]) -> None:
         frame = params.get("frame") or {}
         if not frame.get("parentId"):  # main frame only
-            self._origin, self._security = _chrome_of(frame.get("url") or "")
+            self._origin, self._security = chrome_of(frame.get("url") or "")
             self._url = frame.get("url") or None
 
     # ── the pump ──────────────────────────────────────────────────────────
@@ -178,7 +178,7 @@ class Screencast:
         self._last_frame = name
 
 
-def _chrome_of(url: str) -> tuple[str | None, str | None]:
+def chrome_of(url: str) -> tuple[str | None, str | None]:
     """The trusted-chrome (origin, security) for a URL, both from the committed
     URL alone — origin is scheme+host, security is ``secure`` for https,
     ``insecure`` for http, ``None`` for anything else (about:blank, data:)."""

--- a/packages/aios-browser-driver/tests/test_screencast_writer.py
+++ b/packages/aios-browser-driver/tests/test_screencast_writer.py
@@ -8,7 +8,7 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
-from aios_browser_driver.takeover.screencast import Screencast, _chrome_of
+from aios_browser_driver.takeover.screencast import Screencast, chrome_of
 
 _JPEG = base64.b64encode(b"\xff\xd8\xff\xe0jpegbytes\xff\xd9").decode("ascii")
 
@@ -93,10 +93,10 @@ def test_on_frame_enqueues_int_session_ids(tmp_path: Path) -> None:
 def test_chrome_derives_security_from_the_url_scheme() -> None:
     # Chromium stopped emitting Security.securityStateChanged, so security is
     # derived from the committed URL's scheme, not a dead CDP event.
-    assert _chrome_of("https://bank.example/login") == ("https://bank.example", "secure")
-    assert _chrome_of("http://shop.example/") == ("http://shop.example", "insecure")
-    assert _chrome_of("about:blank") == (None, None)
-    assert _chrome_of("data:text/html,x") == (None, None)
+    assert chrome_of("https://bank.example/login") == ("https://bank.example", "secure")
+    assert chrome_of("http://shop.example/") == ("http://shop.example", "insecure")
+    assert chrome_of("about:blank") == (None, None)
+    assert chrome_of("data:text/html,x") == (None, None)
 
 
 def test_manifest_carries_the_committed_url(tmp_path: Path) -> None:

--- a/packages/aios-browser-driver/tests/test_takeover_host_browser.py
+++ b/packages/aios-browser-driver/tests/test_takeover_host_browser.py
@@ -6,6 +6,7 @@ fixture page."""
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import http.server
 import json
@@ -222,3 +223,31 @@ async def test_status_answers_during_a_takeover(host: BrowserHost, server: str) 
     # revoke_site, by contrast, refuses during a takeover.
     revoke = await _handle(host, "revoke_site", host="example.com")
     assert revoke.error.code == "takeover_active"
+
+
+async def test_peek_shows_a_session_page_without_touching_it(
+    host: BrowserHost, server: str
+) -> None:
+    # Nothing open yet: a running computer with no page is not a page.
+    empty = await _handle(host, "peek", session_id="s1")
+    assert empty.ok and empty.data == {"page": None}
+    assert "s1" not in host._entries  # a look never creates a page
+
+    await _land_on_fixture(host, server, "s1")
+    peek = await _handle(host, "peek", session_id="s1")
+    assert peek.ok and peek.url == server
+    page = peek.data["page"]
+    assert page["w"] > 0 and page["h"] > 0
+    assert base64.b64decode(page["jpeg_b64"])[:3] == b"\xff\xd8\xff"  # a JPEG
+    # Trusted chrome is derived from the committed URL, not the pixels.
+    assert page["origin"] == server.rstrip("/")
+    assert page["security"] == "insecure"
+
+    # Without a session it falls back to the last-active page.
+    last = await _handle(host, "peek")
+    assert last.ok and last.url == server
+
+    # A human holding the computer is theirs alone.
+    await _handle(host, "takeover_open", session_id="s1", grant_id="g1")
+    held = await _handle(host, "peek", session_id="s1")
+    assert held.error.code == "takeover_active"

--- a/packages/aios-sdk/aios_sdk/_generated/api/browser/browser_peek_v1_browser_peek_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/browser/browser_peek_v1_browser_peek_get.py
@@ -1,0 +1,208 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.browser_peek_response import BrowserPeekResponse
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_session_id: None | str | Unset
+    if isinstance(session_id, Unset):
+        json_session_id = UNSET
+    else:
+        json_session_id = session_id
+    params["session_id"] = json_session_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/browser/peek",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> BrowserPeekResponse | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = BrowserPeekResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[BrowserPeekResponse | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[BrowserPeekResponse | HTTPValidationError]:
+    """Browser Peek
+
+     A read-only look at a page: one JPEG of the viewport plus the trusted
+    chrome, from ``session_id``'s page when given, else the last-active one.
+    Never provisions and never creates a page; refused (409) while a human
+    holds the computer.
+
+    Args:
+        session_id (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[BrowserPeekResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> BrowserPeekResponse | HTTPValidationError | None:
+    """Browser Peek
+
+     A read-only look at a page: one JPEG of the viewport plus the trusted
+    chrome, from ``session_id``'s page when given, else the last-active one.
+    Never provisions and never creates a page; refused (409) while a human
+    holds the computer.
+
+    Args:
+        session_id (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        BrowserPeekResponse | HTTPValidationError
+    """
+
+    return sync_detailed(
+        client=client,
+        session_id=session_id,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[BrowserPeekResponse | HTTPValidationError]:
+    """Browser Peek
+
+     A read-only look at a page: one JPEG of the viewport plus the trusted
+    chrome, from ``session_id``'s page when given, else the last-active one.
+    Never provisions and never creates a page; refused (409) while a human
+    holds the computer.
+
+    Args:
+        session_id (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[BrowserPeekResponse | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    session_id: None | str | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> BrowserPeekResponse | HTTPValidationError | None:
+    """Browser Peek
+
+     A read-only look at a page: one JPEG of the viewport plus the trusted
+    chrome, from ``session_id``'s page when given, else the last-active one.
+    Never provisions and never creates a page; refused (409) while a human
+    holds the computer.
+
+    Args:
+        session_id (None | str | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        BrowserPeekResponse | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            session_id=session_id,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -42,6 +42,9 @@ from .body_upload_session_file import BodyUploadSessionFile
 from .bootstrap_request import BootstrapRequest
 from .bootstrap_response import BootstrapResponse
 from .bound_chat import BoundChat
+from .browser_peek_page import BrowserPeekPage
+from .browser_peek_page_security_type_0 import BrowserPeekPageSecurityType0
+from .browser_peek_response import BrowserPeekResponse
 from .browser_status_response import BrowserStatusResponse
 from .browser_takeover_status import BrowserTakeoverStatus
 from .capabilities_update import CapabilitiesUpdate
@@ -430,6 +433,9 @@ __all__ = (
     "BootstrapRequest",
     "BootstrapResponse",
     "BoundChat",
+    "BrowserPeekPage",
+    "BrowserPeekPageSecurityType0",
+    "BrowserPeekResponse",
     "BrowserStatusResponse",
     "BrowserTakeoverStatus",
     "CapabilitiesUpdate",

--- a/packages/aios-sdk/aios_sdk/_generated/models/browser_peek_page.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/browser_peek_page.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.browser_peek_page_security_type_0 import BrowserPeekPageSecurityType0
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="BrowserPeekPage")
+
+
+@_attrs_define
+class BrowserPeekPage:
+    """One JPEG of a page's viewport plus its trusted chrome. ``origin`` and
+    ``security`` come from the driver's committed URL, never the pixels.
+
+        Attributes:
+            jpeg_b64 (str):
+            w (int):
+            h (int):
+            origin (None | str | Unset):
+            security (BrowserPeekPageSecurityType0 | None | Unset):
+    """
+
+    jpeg_b64: str
+    w: int
+    h: int
+    origin: None | str | Unset = UNSET
+    security: BrowserPeekPageSecurityType0 | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        jpeg_b64 = self.jpeg_b64
+
+        w = self.w
+
+        h = self.h
+
+        origin: None | str | Unset
+        if isinstance(self.origin, Unset):
+            origin = UNSET
+        else:
+            origin = self.origin
+
+        security: None | str | Unset
+        if isinstance(self.security, Unset):
+            security = UNSET
+        elif isinstance(self.security, BrowserPeekPageSecurityType0):
+            security = self.security.value
+        else:
+            security = self.security
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "jpeg_b64": jpeg_b64,
+                "w": w,
+                "h": h,
+            }
+        )
+        if origin is not UNSET:
+            field_dict["origin"] = origin
+        if security is not UNSET:
+            field_dict["security"] = security
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        jpeg_b64 = d.pop("jpeg_b64")
+
+        w = d.pop("w")
+
+        h = d.pop("h")
+
+        def _parse_origin(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        origin = _parse_origin(d.pop("origin", UNSET))
+
+        def _parse_security(
+            data: object,
+        ) -> BrowserPeekPageSecurityType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                security_type_0 = BrowserPeekPageSecurityType0(data)
+
+                return security_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(BrowserPeekPageSecurityType0 | None | Unset, data)
+
+        security = _parse_security(d.pop("security", UNSET))
+
+        browser_peek_page = cls(
+            jpeg_b64=jpeg_b64,
+            w=w,
+            h=h,
+            origin=origin,
+            security=security,
+        )
+
+        browser_peek_page.additional_properties = d
+        return browser_peek_page
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/browser_peek_page_security_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/browser_peek_page_security_type_0.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class BrowserPeekPageSecurityType0(str, Enum):
+    INSECURE = "insecure"
+    SECURE = "secure"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/browser_peek_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/browser_peek_response.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.browser_peek_page import BrowserPeekPage
+
+
+T = TypeVar("T", bound="BrowserPeekResponse")
+
+
+@_attrs_define
+class BrowserPeekResponse:
+    """A read-only look at the computer: not running, running with no page
+    to show, or running with the page. Never provisions, never creates a
+    page, and is refused while a human holds the computer.
+
+        Attributes:
+            running (bool):
+            url (None | str | Unset):
+            title (None | str | Unset):
+            page (BrowserPeekPage | None | Unset):
+    """
+
+    running: bool
+    url: None | str | Unset = UNSET
+    title: None | str | Unset = UNSET
+    page: BrowserPeekPage | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.browser_peek_page import BrowserPeekPage
+
+        running = self.running
+
+        url: None | str | Unset
+        if isinstance(self.url, Unset):
+            url = UNSET
+        else:
+            url = self.url
+
+        title: None | str | Unset
+        if isinstance(self.title, Unset):
+            title = UNSET
+        else:
+            title = self.title
+
+        page: dict[str, Any] | None | Unset
+        if isinstance(self.page, Unset):
+            page = UNSET
+        elif isinstance(self.page, BrowserPeekPage):
+            page = self.page.to_dict()
+        else:
+            page = self.page
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "running": running,
+            }
+        )
+        if url is not UNSET:
+            field_dict["url"] = url
+        if title is not UNSET:
+            field_dict["title"] = title
+        if page is not UNSET:
+            field_dict["page"] = page
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.browser_peek_page import BrowserPeekPage
+
+        d = dict(src_dict)
+        running = d.pop("running")
+
+        def _parse_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url = _parse_url(d.pop("url", UNSET))
+
+        def _parse_title(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        title = _parse_title(d.pop("title", UNSET))
+
+        def _parse_page(data: object) -> BrowserPeekPage | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                page_type_0 = BrowserPeekPage.from_dict(data)
+
+                return page_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(BrowserPeekPage | None | Unset, data)
+
+        page = _parse_page(d.pop("page", UNSET))
+
+        browser_peek_response = cls(
+            running=running,
+            url=url,
+            title=title,
+            page=page,
+        )
+
+        browser_peek_response.additional_properties = d
+        return browser_peek_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/browser.py
+++ b/src/aios/api/routers/browser.py
@@ -40,6 +40,8 @@ from aios.errors import (
 from aios.ids import BROWSER_GRANT, make_id
 from aios.logging import get_logger
 from aios.models.browser import (
+    BrowserPeekPage,
+    BrowserPeekResponse,
     BrowserStatusResponse,
     BrowserTakeoverStatus,
     HandbackPayload,
@@ -446,6 +448,30 @@ async def browser_status(
         title=result.get("title"),
         signed_in_hosts=result.get("signed_in_hosts") or [],
         takeover=takeover,
+    )
+
+
+@router.get("/peek")
+async def browser_peek(
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    session_id: str | None = None,
+) -> BrowserPeekResponse:
+    """A read-only look at a page: one JPEG of the viewport plus the trusted
+    chrome, from ``session_id``'s page when given, else the last-active one.
+    Never provisions and never creates a page; refused (409) while a human
+    holds the computer."""
+    result = await _call(
+        db_url, pool, account_id, "peek", {"session_id": session_id} if session_id else {}
+    )
+    raw = result.get("page")
+    page = BrowserPeekPage.model_validate(raw) if isinstance(raw, dict) else None
+    return BrowserPeekResponse(
+        running=bool(result.get("running")),
+        url=result.get("url"),
+        title=result.get("title"),
+        page=page,
     )
 
 

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -44,6 +44,9 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
     "browser_status_v1_browser_status_get": (
         "Product-layer computer-status read, surfaced in the app, not operators."
     ),
+    "browser_peek_v1_browser_peek_get": (
+        "Product-layer live view of a page (a JPEG polled by the app's Bot sidebar), not operators."
+    ),
     "revoke_site_v1_browser_sites__host__delete": (
         "Product-layer sign-out control, surfaced in the app, not operators."
     ),

--- a/src/aios/harness/browser_control.py
+++ b/src/aios/harness/browser_control.py
@@ -240,6 +240,31 @@ async def _dispatch(
             "epoch": response.epoch,
         }
 
+    if method == "peek":
+        # The product's live view: one JPEG of a page plus its trusted
+        # chrome. Same no-provision rule as status — a cold computer has
+        # nothing to look at — and the driver refuses it during a takeover.
+        if registry.peek(account_id) is None:
+            return {"running": False, "page": None}
+        peek_session = params.get("session_id")
+        response = await _driver(
+            registry,
+            account_id,
+            "peek",
+            {},
+            timeout_s=action_timeout,
+            session_id=str(peek_session) if peek_session else None,
+        )
+        page = response.data.get("page")
+        return {
+            "running": True,
+            "url": response.url,
+            "title": response.title,
+            "boot": response.boot,
+            "epoch": response.epoch,
+            "page": page if isinstance(page, dict) else None,
+        }
+
     if method == "revoke_site":
         host = str(params["host"])
         response = await _driver(

--- a/src/aios/models/browser.py
+++ b/src/aios/models/browser.py
@@ -119,3 +119,25 @@ class BrowserStatusResponse(BaseModel):
     title: str | None = None
     signed_in_hosts: list[str] = Field(default_factory=list)
     takeover: BrowserTakeoverStatus | None = None
+
+
+class BrowserPeekPage(BaseModel):
+    """One JPEG of a page's viewport plus its trusted chrome. ``origin`` and
+    ``security`` come from the driver's committed URL, never the pixels."""
+
+    jpeg_b64: str
+    w: int
+    h: int
+    origin: str | None = None
+    security: Literal["secure", "insecure"] | None = None
+
+
+class BrowserPeekResponse(BaseModel):
+    """A read-only look at the computer: not running, running with no page
+    to show, or running with the page. Never provisions, never creates a
+    page, and is refused while a human holds the computer."""
+
+    running: bool
+    url: str | None = None
+    title: str | None = None
+    page: BrowserPeekPage | None = None

--- a/src/aios/sandbox/browser_protocol.py
+++ b/src/aios/sandbox/browser_protocol.py
@@ -133,6 +133,7 @@ BrowserOp = Literal[
     "takeover_open",
     "takeover_close",
     "status",
+    "peek",
     "revoke_site",
 ]
 

--- a/tests/unit/test_browser_control.py
+++ b/tests/unit/test_browser_control.py
@@ -207,3 +207,78 @@ class TestStatusAssembly:
         assert result["boot"] == "01REALBOOT"
         assert result["epoch"] == 4
         assert result["signed_in_hosts"] == ["real.example"]  # driver data still flows
+
+
+class TestPeek:
+    """The product's live view: a read-only JPEG of a page. Same no-provision
+    rule as status, threads the session so a Bot's sidebar sees that Bot's
+    page, and the control-plane fields come from the envelope, never from
+    ``data``."""
+
+    async def test_cold_computer_is_not_provisioned_for_a_look(self) -> None:
+        registry = MagicMock()
+        registry.peek.return_value = None
+        result = await browser_control._dispatch(
+            cast(SandboxRegistry, registry), MagicMock(), "peek", "acc_x", {"session_id": "s1"}
+        )
+        assert result == {"running": False, "page": None}
+        registry.get_or_provision_browser.assert_not_called()
+
+    async def test_live_peek_threads_the_session_and_returns_the_page(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[BrowserRequest] = []
+
+        async def _fake_driver_call(
+            registry: object, account_id: str, request: BrowserRequest, *, timeout_s: float
+        ) -> BrowserResponse:
+            seen.append(request)
+            return BrowserResponse(
+                ok=True,
+                boot="01B",
+                epoch=3,
+                url="https://bank.example/accounts",
+                title="Accounts",
+                data={
+                    "page": {
+                        "jpeg_b64": "AAAA",
+                        "w": 1280,
+                        "h": 800,
+                        "origin": "https://bank.example",
+                        "security": "secure",
+                    },
+                    "running": False,  # a hostile driver key must not win
+                },
+            )
+
+        monkeypatch.setattr(browser_control, "driver_call", _fake_driver_call)
+        registry = MagicMock()
+        registry.peek.return_value = MagicMock()
+
+        result = await browser_control._dispatch(
+            cast(SandboxRegistry, registry), MagicMock(), "peek", "acc_x", {"session_id": "s1"}
+        )
+
+        assert seen[0].op == "peek" and seen[0].session_id == "s1"
+        assert result["running"] is True
+        assert result["url"] == "https://bank.example/accounts"
+        assert result["boot"] == "01B" and result["epoch"] == 3
+        assert result["page"]["jpeg_b64"] == "AAAA"
+        assert result["page"]["origin"] == "https://bank.example"
+
+    async def test_no_page_is_a_running_computer_with_nothing_to_show(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _fake_driver_call(
+            registry: object, account_id: str, request: BrowserRequest, *, timeout_s: float
+        ) -> BrowserResponse:
+            return BrowserResponse(ok=True, boot="01B", epoch=3, data={"page": None})
+
+        monkeypatch.setattr(browser_control, "driver_call", _fake_driver_call)
+        registry = MagicMock()
+        registry.peek.return_value = MagicMock()
+        result = await browser_control._dispatch(
+            cast(SandboxRegistry, registry), MagicMock(), "peek", "acc_x", {}
+        )
+        assert result["running"] is True
+        assert result["page"] is None

--- a/tests/unit/test_browser_routes.py
+++ b/tests/unit/test_browser_routes.py
@@ -497,3 +497,66 @@ class TestFramesEpochFence:
         body = self._stream_body(client, monkeypatch)
         assert "event: frame" in body
         assert "event: end" in body
+
+
+class TestPeek:
+    """``GET /v1/browser/peek``: the product's read-only look at a page."""
+
+    def test_threads_the_session_and_returns_the_page(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        submit = AsyncMock(
+            return_value=(
+                {
+                    "running": True,
+                    "url": "https://bank.example/accounts",
+                    "title": "Accounts",
+                    "boot": "01B",
+                    "epoch": 3,
+                    "page": {
+                        "jpeg_b64": "AAAA",
+                        "w": 1280,
+                        "h": 800,
+                        "origin": "https://bank.example",
+                        "security": "secure",
+                    },
+                },
+                False,
+            )
+        )
+        monkeypatch.setattr(browser_router, "submit_browser_call", submit)
+        resp = client.get("/v1/browser/peek", params={"session_id": "sess_1"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["running"] is True
+        assert body["url"] == "https://bank.example/accounts"
+        assert body["page"]["origin"] == "https://bank.example"
+        assert body["page"]["security"] == "secure"
+        # boot/epoch are takeover-plane tokens and never leave the plane here.
+        assert "boot" not in body and "epoch" not in body
+        assert submit.call_args.kwargs["method"] == "peek"
+        assert submit.call_args.kwargs["params"] == {"session_id": "sess_1"}
+
+    def test_cold_computer_is_not_running_and_has_no_page(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            browser_router,
+            "submit_browser_call",
+            AsyncMock(return_value=({"running": False, "page": None}, False)),
+        )
+        resp = client.get("/v1/browser/peek")
+        assert resp.status_code == 200
+        assert resp.json() == {"running": False, "url": None, "title": None, "page": None}
+
+    def test_a_human_holding_the_computer_is_409(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            browser_router,
+            "submit_browser_call",
+            AsyncMock(return_value=({"code": "takeover_active", "message": "held"}, True)),
+        )
+        resp = client.get("/v1/browser/peek")
+        assert resp.status_code == 409
+        assert resp.json()["error"]["detail"]["code"] == "takeover_active"


### PR DESCRIPTION
jarbot's Bot sidebar needs to show the computer's screen without a person taking it over (Tom's ask, 2026-09-02). The only frame source today is the takeover screencast, which exists for a grant's lifetime, and the page-scoped `screenshot` op would create a page as a side effect. So: a control op.

## Driver — `peek`
- Returns a viewport JPEG (quality 55, CSS scale) of the session's page when `session_id` is given, else the last-active page, plus the trusted chrome (`origin`/`security` from the committed URL — `chrome_of`, now shared with the screencast).
- Never creates a page (`data.page` is `null` when there is nothing to look at), never admits through the gate, and refuses `takeover_active` while a human holds the computer — the human's live page is theirs alone.

## Control plane
`peek` mirrors `status`'s no-provision rule: a cold computer is `{running: false, page: null}`. Envelope fields (url/title/boot/epoch) win over driver data.

## API
`GET /v1/browser/peek?session_id=` → `BrowserPeekResponse {running, url, title, page: {jpeg_b64, w, h, origin, security} | null}`. `openapi.json` + SDK regenerated; CLI-allowlisted like the other product-layer browser routes.

## Tests
- Driver, real Chromium (`-m browser`): no page → `null` without creating one; page → JPEG + chrome; session fallback; refused during a takeover.
- Control dispatch: cold, live (session threaded, hostile `running` key in data cannot win), no-page.
- Route: threads session, cold, 409 on `takeover_active`.

Consumer: jarbot relays it as `GET /v1/computer/peek?bot_id=` and the sidebar polls it while the computer is awake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)