### PR TITLE
fix(browser): admit peek in browser_calls' method CHECK (migration 0178)

### DIFF
--- a/migrations/versions/0178_browser_calls_peek_method.py
+++ b/migrations/versions/0178_browser_calls_peek_method.py
@@ -1,0 +1,47 @@
+"""browser_calls: admit the ``peek`` control method.
+
+0175 pinned ``browser_calls.method`` to the five control-plane methods of
+the day with a CHECK. #2336 added ``peek`` (the product's read-only look at
+a page) to the dispatcher and the API but not to the constraint, so every
+``GET /v1/browser/peek`` failed at the INSERT with a CheckViolationError —
+a 500 the mocked route/dispatch tests could not see. Found the first time
+the route hit a real database (the jarbot local devstack, 2026-09-02).
+
+Revision ID: 0178
+Revises: 0177
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0178"
+down_revision: str = "0177"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_METHODS_WITH_PEEK = "('open', 'close', 'status', 'revoke_site', 'clear_state', 'peek')"
+_METHODS_WITHOUT_PEEK = "('open', 'close', 'status', 'revoke_site', 'clear_state')"
+
+
+def _swap_check(methods: str) -> None:
+    # A tiny table with short-lived rows: the ACCESS EXCLUSIVE lock is
+    # momentary, and there is no backfill.
+    op.execute("ALTER TABLE browser_calls DROP CONSTRAINT browser_calls_method_check")
+    op.execute(
+        "ALTER TABLE browser_calls ADD CONSTRAINT browser_calls_method_check "
+        f"CHECK (method IN {methods})"
+    )
+
+
+def upgrade() -> None:
+    _swap_check(_METHODS_WITH_PEEK)
+
+
+def downgrade() -> None:
+    # Any peek rows still pending would violate the narrower check; they are
+    # ephemeral (the submitter's wait is seconds), so clear them first.
+    op.execute("DELETE FROM browser_calls WHERE method = 'peek'")
+    _swap_check(_METHODS_WITHOUT_PEEK)

--- a/migrations/versions/0179_browser_calls_peek_method.py
+++ b/migrations/versions/0179_browser_calls_peek_method.py
@@ -7,7 +7,7 @@ a page) to the dispatcher and the API but not to the constraint, so every
 a 500 the mocked route/dispatch tests could not see. Found the first time
 the route hit a real database (the jarbot local devstack, 2026-09-02).
 
-Revision ID: 0178
+Revision ID: 0179
 Revises: 0177
 """
 
@@ -17,7 +17,7 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0178"
+revision: str = "0179"
 down_revision: str = "0177"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/tests/unit/test_check_migration_heads.py
+++ b/tests/unit/test_check_migration_heads.py
@@ -129,5 +129,5 @@ def test_known_good_repository_has_expected_revision_count_and_one_head() -> Non
     # branch was cut. A count pin resolved by PICKING A SIDE re-asserts a number
     # nobody re-measured -- which is how a pin meant to catch accidental
     # deletions becomes the thing that fails CI.
-    assert len(revisions) == 164
+    assert len(revisions) == 165
     assert check_history(revisions) in revisions


### PR DESCRIPTION
Follow-up to #2336. `0175` pinned `browser_calls.method` to the five control methods of the day with a CHECK; #2336 added `peek` to the dispatcher and the API but not to the constraint, so every `GET /v1/browser/peek` fails at the INSERT:

```
asyncpg.exceptions.CheckViolationError: new row for relation "browser_calls" violates check constraint "browser_calls_method_check"
```

The route and dispatch tests mock `submit_browser_call`, so nothing saw it until the route hit a real database — the jarbot local devstack, first run.

**Migration 0178**: drop-and-recreate the CHECK with `peek` admitted. Tiny table, short-lived rows: momentary lock, no backfill. Downgrade clears pending `peek` rows first. Revision-count pin 164 → 165.

**Prod impact meanwhile**: `peek` 500s → jarbot's sidebar shows "Not available yet." for the live view. Nothing else affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)