### PR TITLE
Telegram connector worker terminated on a transient 500 and never reconnected — 4h dead, every surface green, error says 'retry shortly'

### DIFF
--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -1250,9 +1250,13 @@ class HttpConnector:
                             # off. Never pin a failed worker to its original snapshot.
                             secrets = await self._fetch_runtime_secrets(connection_id)
                             state.secrets = secrets
+                    # A reconnect attempt is not evidence that the connector is
+                    # ready to serve this connection.  Keep the degraded status
+                    # until the serve exits cleanly; long-running serves restore
+                    # their per-connection state before handling tool calls.
+                    await self.serve_connection(connection_id, secrets)
                     if state is not None:
                         state.serve_status = "serving"
-                    await self.serve_connection(connection_id, secrets)
                     break
                 except asyncio.CancelledError:
                     raise

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -295,6 +295,9 @@ class HttpConnector:
     # subsequent delay up to ``RECONNECT_BACKOFF_MAX``.
     RECONNECT_BACKOFF_INITIAL: float = 1.0
     RECONNECT_BACKOFF_MAX: float = 60.0
+    # After this many consecutive failures, tool calls report the connector as
+    # down instead of presenting the missing subclass state as a startup race.
+    RECONNECT_FAILURE_THRESHOLD: int = 3
     # Appservice-style connectors receive credentials via container env.
     uses_connection_secrets: bool = True
 
@@ -1235,11 +1238,18 @@ class HttpConnector:
             while True:
                 try:
                     state = self._connections.get(connection_id)
-                    if retrying and state is not None:
-                        # Credentials can be corrected while this worker is backing
-                        # off. Never pin a failed worker to its original snapshot.
-                        secrets = await self._fetch_runtime_secrets(connection_id)
-                        state.secrets = secrets
+                    if retrying:
+                        log.info(
+                            "connector.connection.reconnect_attempt",
+                            connector=self.connector,
+                            connection_id=connection_id,
+                            attempt=state.serve_restart_count if state is not None else None,
+                        )
+                        if state is not None:
+                            # Credentials can be corrected while this worker is backing
+                            # off. Never pin a failed worker to its original snapshot.
+                            secrets = await self._fetch_runtime_secrets(connection_id)
+                            state.secrets = secrets
                     if state is not None:
                         state.serve_status = "serving"
                     await self.serve_connection(connection_id, secrets)
@@ -1516,11 +1526,25 @@ class HttpConnector:
                 and isinstance(exc.args[0], str)
                 and exc.args[0] == connection_id
             ):
-                error_payload = {
-                    "error": "connection not yet active; retry shortly",
-                    "connection_id": connection_id,
-                }
-                reason = "connection_state_race"
+                connection = self._connections.get(connection_id)
+                if (
+                    connection is not None
+                    and connection.serve_status == "restarting"
+                    and connection.serve_restart_count >= self.RECONNECT_FAILURE_THRESHOLD
+                ):
+                    error_payload = {
+                        "error": "connector is down; operator intervention required",
+                        "code": "connector_down",
+                        "connection_id": connection_id,
+                        "reconnect_attempts": connection.serve_restart_count,
+                    }
+                    reason = "connector_down"
+                else:
+                    error_payload = {
+                        "error": "connection not yet active; retry shortly",
+                        "connection_id": connection_id,
+                    }
+                    reason = "connection_state_race"
             elif meta.delivery:
                 # #1722: a delivery tool (a send/react — the turn is
                 # "over" once it runs) that raises mid-dispatch is a connector-side

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -1185,6 +1185,41 @@ class TestIsolatedServeConnection:
         assert state.serve_restart_count == 2
         assert state.last_serve_error == "RuntimeError: failure 2"
 
+    async def test_reconnect_stays_degraded_until_serve_is_ready(self) -> None:
+        attempts = 0
+        fourth_attempt_started = asyncio.Event()
+
+        class _DegradedConnector(HttpConnector):
+            connector = "degraded"
+            RECONNECT_BACKOFF_INITIAL = 0.0
+            RECONNECT_BACKOFF_MAX = 0.0
+
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
+                nonlocal attempts
+                attempts += 1
+                if attempts <= self.RECONNECT_FAILURE_THRESHOLD:
+                    raise RuntimeError(f"failure {attempts}")
+                fourth_attempt_started.set()
+                # Simulate a reconnect paused before per-connection state is installed.
+                await asyncio.Event().wait()
+
+        c = _DegradedConnector(base_url="http://x", token="aios_runtime_x")
+        c._connections["conn_1"] = _ConnectionState(
+            connection_id="conn_1", external_account_id="acct_1"
+        )
+        c._fetch_runtime_secrets = AsyncMock(return_value={})  # type: ignore[method-assign]
+        c.emit_lifecycle = AsyncMock()  # type: ignore[method-assign]
+
+        task = asyncio.create_task(c._isolated_serve_connection("conn_1", {}))
+        await asyncio.wait_for(fourth_attempt_started.wait(), timeout=1)
+        state = c._connections["conn_1"]
+        assert state.serve_restart_count == c.RECONNECT_FAILURE_THRESHOLD
+        assert state.serve_status == "restarting"
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
     async def test_pops_state_on_cancel(self) -> None:
         class _Connector(HttpConnector):
             connector = "withstate"

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -828,6 +828,39 @@ class TestLogging:
         assert len(failed) == 1
         assert failed[0]["reason"] == "connection_state_race"
 
+    async def test_dispatch_call_reports_down_after_repeated_serve_failures(
+        self, probe: _ProbeConnector
+    ) -> None:
+        probe._connections["conn_X"] = _ConnectionState(
+            connection_id="conn_X",
+            external_account_id="acct_X",
+            serve_status="restarting",
+            last_serve_error="RuntimeError: polling failed",
+            serve_restart_count=probe.RECONNECT_FAILURE_THRESHOLD,
+        )
+
+        with structlog.testing.capture_logs() as records:
+            await probe.dispatch_call(
+                {
+                    "connection_id": "conn_X",
+                    "tool_call_id": "call_down",
+                    "session_id": "sess_down",
+                    "name": "race",
+                    "arguments": "{}",
+                }
+            )
+
+        result = probe.results[0]
+        assert result.kwargs["is_error"] is True
+        assert json.loads(result.kwargs["content"]) == {
+            "error": "connector is down; operator intervention required",
+            "code": "connector_down",
+            "connection_id": "conn_X",
+            "reconnect_attempts": probe.RECONNECT_FAILURE_THRESHOLD,
+        }
+        failed = [r for r in records if r["event"] == "connector.tool_call.failed"]
+        assert failed[0]["reason"] == "connector_down"
+
     async def test_dispatch_call_keyerror_unrelated_to_connection_id_passes_through(
         self, probe: _ProbeConnector
     ) -> None:
@@ -1137,9 +1170,16 @@ class TestIsolatedServeConnection:
         )
         c._fetch_runtime_secrets = AsyncMock(return_value={})  # type: ignore[method-assign]
 
-        await c._isolated_serve_connection("conn_1", {})
+        with structlog.testing.capture_logs() as records:
+            await c._isolated_serve_connection("conn_1", {})
 
         assert attempts == 3
+        reconnects = [
+            record
+            for record in records
+            if record["event"] == "connector.connection.reconnect_attempt"
+        ]
+        assert [record["attempt"] for record in reconnects] == [1, 2]
         state = c._connections["conn_1"]
         assert state.serve_status == "serving"
         assert state.serve_restart_count == 2


### PR DESCRIPTION
Automated dev-pipeline build for issue #2180.