### PR TITLE
Boot gate does not assert the DB is at the code's alembic head — code can serve ahead of its schema

### DIFF
--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -51,6 +51,7 @@ from aios.jobs.app import app as procrastinate_app
 from aios.logging import configure_logging, get_logger
 from aios.retirements.boot_gate import (
     RetirementsNotAdmissible,
+    assert_at_head,
     assert_retirements_admissible,
 )
 from aios.sandbox.volumes import attachments_root, memory_stores_root, uploads_root
@@ -73,6 +74,7 @@ async def _await_retirements_admissible(pool: Any, log: Any) -> None:
     logged_wait = False
     while True:
         try:
+            await assert_at_head(pool)
             await assert_retirements_admissible(pool)
             return
         except RetirementsNotAdmissible as exc:

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -66,6 +66,7 @@ from aios.logging import configure_logging, get_logger
 from aios.mcp.pool import McpSessionPool
 from aios.retirements.boot_gate import (
     RetirementsNotAdmissible,
+    assert_at_head,
     assert_retirements_admissible,
 )
 from aios.sandbox.backends import select_sandbox_backend
@@ -253,6 +254,7 @@ async def _await_retirements_admissible(
     logged_wait = False
     while not latch.is_set():
         try:
+            await assert_at_head(pool)
             await assert_retirements_admissible(pool)
             return
         except RetirementsNotAdmissible as exc:

--- a/src/aios/retirements/boot_gate.py
+++ b/src/aios/retirements/boot_gate.py
@@ -8,14 +8,15 @@ eumemic-ops audit FAILS the build if it is configured pre-deploy) — and ONTO t
 code itself, at startup, *before* readiness flips green.
 
 :func:`assert_retirements_admissible` is called from BOTH the api and the worker
-startup path, gating readiness. For every contracted descriptor (one whose
-``contract_rev`` is set, i.e. whose data migration has been written) it proves:
+startup path, gating readiness. The startup paths first call :func:`assert_at_head`, proving that the live
+``alembic_version`` is at least the migration head required by this image. A DB
+behind the image FAILS admission; a DB ahead remains admissible for rollback.
+They then call :func:`assert_retirements_admissible`, which proves for every
+contracted descriptor (one whose ``contract_rev`` is set):
 
-1. **alembic head**: the live ``alembic_version`` is ``>= contract_rev``. If the
-   DB is behind — the post-deploy migrate has not run yet, OR a restore pointed
-   new code at an old DB — the proof FAILS. This is the startup alembic-head
-   assertion that did not exist before (the only prior startup version check was
-   the unrelated wf-version drift check at ``workflows/service.py``).
+1. **contract revision reached**: the live ``alembic_version`` is
+   ``>= contract_rev``. If the DB is behind the retirement's rewrite migration,
+   the proof FAILS.
 2. **live residue == 0**: once the rev is satisfied, the per-surface residue
    aggregate ``SUM over descriptor.surfaces of count(rows WHERE predicate(token))``
    must be zero. If any surface still carries a retired token the proof FAILS and
@@ -42,7 +43,9 @@ from __future__ import annotations
 from typing import Any
 
 import asyncpg
+from alembic.script import ScriptDirectory
 
+from aios.db.migrations import alembic_config
 from aios.logging import get_logger
 from aios.retirements import Retirement
 from aios.retirements.registry import REGISTRY
@@ -60,6 +63,10 @@ class RetirementsNotAdmissible(RuntimeError):
     loop tick. The distinct subclasses exist only to make the *reason* legible
     in logs and tests; callers should catch the base class.
     """
+
+
+class DatabaseNotAtHead(RetirementsNotAdmissible):
+    """The database is behind the migration head required by this image."""
 
 
 class DatabaseBehindContract(RetirementsNotAdmissible):
@@ -120,6 +127,38 @@ async def _current_alembic_version(conn: asyncpg.Connection[Any]) -> str | None:
         return None
     version: str | None = await conn.fetchval("SELECT version_num FROM alembic_version LIMIT 1")
     return version
+
+
+def _code_alembic_head() -> str:
+    """Return the migration head required by this application image."""
+
+    head = ScriptDirectory.from_config(alembic_config()).get_current_head()
+    if head is None:
+        raise RuntimeError("application image has no Alembic head")
+    return head
+
+
+async def assert_at_head(pool: asyncpg.Pool[Any]) -> None:
+    """Refuse boot when the database is behind this image's migration head.
+
+    A database ahead of this image is admitted to preserve rollback during an
+    expand-then-contract rolling deploy. Database access failures fail closed.
+    """
+
+    head = _code_alembic_head()
+    try:
+        async with pool.acquire() as conn:
+            version = await _current_alembic_version(conn)
+    except (asyncpg.PostgresError, OSError, ConnectionError, TimeoutError) as exc:
+        log.warning("boot_gate.db_unavailable", error=str(exc))
+        raise DatabaseUnavailable(f"cannot assert database migration head: {exc}") from exc
+
+    if version is None or version < head:
+        log.info("boot_gate.database_behind_head", alembic_version=version, code_head=head)
+        raise DatabaseNotAtHead(
+            f"DB at alembic_version={version!r} is behind code head={head!r}; "
+            "refusing readiness until migrations complete"
+        )
 
 
 async def assert_retirements_admissible(pool: asyncpg.Pool[Any]) -> None:

--- a/tests/unit/test_boot_admission_gate.py
+++ b/tests/unit/test_boot_admission_gate.py
@@ -25,9 +25,11 @@ import structlog
 from aios.retirements import Retirement, Surface, boot_gate
 from aios.retirements.boot_gate import (
     DatabaseBehindContract,
+    DatabaseNotAtHead,
     DatabaseUnavailable,
     LiveResidueDetected,
     RetirementsNotAdmissible,
+    assert_at_head,
     assert_retirements_admissible,
 )
 
@@ -137,6 +139,32 @@ def patch_registry(monkeypatch: pytest.MonkeyPatch) -> Any:
         monkeypatch.setattr(boot_gate, "REGISTRY", registry)
 
     return _set
+
+
+@pytest.mark.parametrize("version", ["0169", "0170"])
+async def test_at_or_ahead_of_code_head_is_admitted(
+    monkeypatch: pytest.MonkeyPatch, version: str
+) -> None:
+    """The current head and a forward-migrated DB both admit rolling deploys."""
+    monkeypatch.setattr(boot_gate, "_code_alembic_head", lambda: "0169")
+    await assert_at_head(_FakePool(_FakeConn(version=version)))
+
+
+async def test_db_behind_code_head_refuses_even_past_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DB past retirement contracts still refuses when behind this image."""
+    monkeypatch.setattr(boot_gate, "_code_alembic_head", lambda: "0169")
+    with pytest.raises(DatabaseNotAtHead) as exc:
+        await assert_at_head(_FakePool(_FakeConn(version="0166")))
+    assert isinstance(exc.value, RetirementsNotAdmissible)
+
+
+async def test_at_head_fails_closed_on_db_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(boot_gate, "_code_alembic_head", lambda: "0169")
+    pool = _FakePool(acquire_error=ConnectionError("no route to db"))
+    with pytest.raises(DatabaseUnavailable):
+        await assert_at_head(pool)
 
 
 async def test_behind_db_refuses_readiness(patch_registry: Any) -> None:

--- a/tests/unit/test_ready_route.py
+++ b/tests/unit/test_ready_route.py
@@ -199,7 +199,8 @@ def test_ready_503_when_boot_gate_not_admitted() -> None:
     """Before the boot-admission gate (#1575) flips green, ``/ready`` is 503.
 
     Even with a perfectly healthy DB, an un-admitted process (the boot gate is
-    still looping on a behind / residue-bearing DB) must report unready — that
+    still looping on a DB behind the code head / contract or carrying residue)
+    must report unready — that
     is what keeps the NEW container out of rotation while the OLD healthy one
     serves under a rolling deploy. The DB is never even queried.
     """


### PR DESCRIPTION
Automated dev-pipeline build for issue #2183.